### PR TITLE
Build with shared libraries by default

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -296,13 +296,6 @@ similar on the link line.
 
 ## Limitations, Known Issues, and Troubleshooting
 
-### Limitation: Shared Library Builds Not Yet Supported
-
-Support for building with `BUILD_SHARED_LIBS=ON` is not yet
-integrated, but is a top priority. For now, the generated `viamcpp`
-library is static.
-
-
 ### Build Issue: Missing Build Dependency Edge when Using `VIAMDPPSDK_USE_DYNAMIC_PROTOS`
 
 Sometimes when running `ninja all` or `ninja install` in a project
@@ -341,18 +334,18 @@ ninja all    # OK!
 
 ### Runtime Issue: The `viam_rust_utils` Shared Library Not Found
 
-Without full support for `BUILD_SHARED_LIBS=ON`, the runtime and
-install name properties are not correctly configured. This can lead to
-a runtime error where the `viam_rust_utils` shared library is not
-found at program startup. If this happens, set `[DY]LD_LIBRARY_PATH`
-to point into the library directory of the installation when running
-commands that require it:
+For some platforms (mostly macOS) the runtime and install name
+properties are not correctly configured for the `viam_rust_utils`
+library. This can lead to a runtime error where the `viam_rust_utils`
+shared library is not found at program startup. If this happens, set
+`[DY]LD_LIBRARY_PATH` to point into the library directory of the
+installation when running commands that require it:
 
 ``` shell
 cmake ...
 ninja install
 ./build/install/bin/example_echo    # FAILS: libviam_rust_utils not found
-export LD_LIBRRAY_PATH=./build/install/lib
+export DYLD_LIBRRAY_PATH=./build/install/lib
 ./build/install/bin/example_echo    # OK!
 ```
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 
-# TODO: [required] libviam_rust_utils handling
-# TODO: [required] Runtime paths and make BUILD_SHARED_LIBS work
+# TODO: [required] fixup libviam_rust_utils install name after download
 # TODO: Sanitizer build configs
 # TODO: All warnings and warnings as errors
 # TODO: Runtime dependency sets?
@@ -43,6 +42,15 @@ project(viam-cpp-sdk
   HOMEPAGE_URL https://github.com/viamrobotics/viam-cpp-sdk
   LANGUAGES CXX
 )
+
+
+# Configure cmake-level options:
+#
+# - `BUILD_SHARED_LIBS`: Enabled by default so that we produce a
+# modern SDK, this option can be set to `OFF` to build a static
+# library. Note that this may result in non-functional examples.
+#
+option(BUILD_SHARED_LIBS "If enabled, build shared libraries" ON)
 
 
 # Configure project-global options:
@@ -109,11 +117,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 
-# Everything needs threads, and prefer -pthread if available
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
-
-
 # Produce a compilation database when generating for a build
 # system that is able to make one.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -126,10 +129,38 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 #
 # cmake ... -DCMAKE_INSTALL_PREFIX=$HOME/opt
 #
-include(GNUInstallDirs)
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "..." FORCE)
 endif()
+include(GNUInstallDirs)
+
+
+# Configure how the SDK will manage runtime paths. This is important
+# even for BUILD_SHARED_LIBS=OFF due to the always-shared
+# `libviam_rust_utils` shared library.
+set(CMAKE_BUILD_WITH_INSTALL_RPATH false)
+set(CMAKE_BUILD_RPATH_USE_ORIGIN true)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
+set(CMAKE_MACOSX_RPATH true)
+set(CMAKE_SKIP_BUILD_RPATH false)
+
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir)
+if("${isSystemDir}" STREQUAL "-1")
+  # TODO: Is there a way to do this with generator expressions?
+  file(RELATIVE_PATH BINTOPREFIXRELPATH ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR} ${CMAKE_INSTALL_PREFIX})
+  file(RELATIVE_PATH PREFIXTOLIBRELPATH ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+  if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(CMAKE_INSTALL_NAME_DIR "@rpath/${PREFIXTOLIBRELPATH}")
+    list(PREPEND CMAKE_INSTALL_RPATH "@loader_path/${BINTOPREFIXRELPATH}")
+  else()
+    list(PREPEND CMAKE_INSTALL_RPATH "$ORIGIN/${BINTOPREFIXRELPATH}/${PREFIXTOLIBRELPATH}")
+  endif()
+endif()
+
+
+# Everything needs threads, and prefer -pthread if available
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
 
 
 # See if the user provided a libviam_rust_utils in the root of the
@@ -190,7 +221,7 @@ set_property(TARGET viam_rust_utils PROPERTY IMPORTED_LOCATION ${viam_rust_utils
 
 install(
   IMPORTED_RUNTIME_ARTIFACTS viam_rust_utils
-  LIBRARY COMPONENT runtime
+  LIBRARY COMPONENT viam-cpp-sdk_runtime
 )
 
 
@@ -198,7 +229,7 @@ install(
 install(FILES
   LICENSE
   DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}
-  COMPONENT runtime
+  COMPONENT viam-cpp-sdk_runtime
 )
 
 
@@ -313,11 +344,35 @@ configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/config/cmake.in
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/viam-cpp-sdkConfigVersion.cmake"
   VERSION "${version}"
-  COMPATIBILITY AnyNewerVersion
+  COMPATIBILITY SameMajorVersion
 )
 
 install(FILES
   "${CMAKE_CURRENT_BINARY_DIR}/viam-cpp-sdkConfig.cmake"
   "${CMAKE_CURRENT_BINARY_DIR}/viam-cpp-sdkConfigVersion.cmake"
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/viam-cpp-sdk
+  COMPONENT viam-cpp-sdk_dev
+)
+
+
+# Define some custom targets to install different subsets of files.
+#
+# TODO: Can we programatically get the list of components?
+# TODO: The `all` dependency here is too broad. Can it be narrowed?
+add_custom_target(
+  install-runtime
+  COMMAND ${CMAKE_COMMAND} -DCOMPONENT=viam-cpp-sdk_runtime -P ${CMAKE_BINARY_DIR}/cmake_install.cmake
+  DEPENDS all
+)
+
+add_custom_target(
+  install-dev
+  COMMAND ${CMAKE_COMMAND} -DCOMPONENT=viam-cpp-sdk_dev -P ${CMAKE_BINARY_DIR}/cmake_install.cmake
+  DEPENDS all
+)
+
+add_custom_target(
+  install-examples
+  COMMAND ${CMAKE_COMMAND} -DCOMPONENT=viam-cpp-sdk_examples -P ${CMAKE_BINARY_DIR}/cmake_install.cmake
+  DEPENDS all
 )

--- a/examples/dial/CMakeLists.txt
+++ b/examples/dial/CMakeLists.txt
@@ -22,5 +22,5 @@ target_link_libraries(example_dial
 
 install(
   TARGETS example_dial
-  COMPONENT examples
+  COMPONENT viam-cpp-sdk_examples
 )

--- a/examples/echo/CMakeLists.txt
+++ b/examples/echo/CMakeLists.txt
@@ -58,5 +58,5 @@ target_link_libraries(example_echo
 
 install(
   TARGETS example_echo
-  COMPONENT examples
+  COMPONENT viam-cpp-sdk_examples
 )

--- a/examples/modules/example_module.cpp
+++ b/examples/modules/example_module.cpp
@@ -1,9 +1,7 @@
-#include <component/arm/v1/arm.grpc.pb.h>
 #include <component/generic/v1/generic.grpc.pb.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/server_context.h>
 #include <robot/v1/robot.pb.h>
-#include <service/slam/v1/slam.grpc.pb.h>
 #include <signal.h>
 
 #include <components/component_base.hpp>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,10 +107,10 @@ if (VIAMCPPSDK_USE_DYNAMIC_PROTOS)
     ${PROTO_GEN_DIR}/gen/google/api/httpbody.pb.h
     ${PROTO_GEN_DIR}/gen/google/api/http.pb.cc
     ${PROTO_GEN_DIR}/gen/google/api/http.pb.h
-	${PROTO_GEN_DIR}/gen/module/v1/module.grpc.pb.cc
-	${PROTO_GEN_DIR}/gen/module/v1/module.grpc.pb.h
-	${PROTO_GEN_DIR}/gen/module/v1/module.pb.cc
-	${PROTO_GEN_DIR}/gen/module/v1/module.pb.h
+    ${PROTO_GEN_DIR}/gen/module/v1/module.grpc.pb.cc
+    ${PROTO_GEN_DIR}/gen/module/v1/module.grpc.pb.h
+    ${PROTO_GEN_DIR}/gen/module/v1/module.pb.cc
+    ${PROTO_GEN_DIR}/gen/module/v1/module.pb.h
     ${PROTO_GEN_DIR}/gen/robot/v1/robot.grpc.pb.cc
     ${PROTO_GEN_DIR}/gen/robot/v1/robot.grpc.pb.h
     ${PROTO_GEN_DIR}/gen/robot/v1/robot.pb.cc
@@ -183,75 +183,75 @@ target_sources(viamcpp
     ${PROTO_GEN_DIR}/gen/common/v1/common.pb.cc
     ${PROTO_GEN_DIR}/gen/component/camera/v1/camera.grpc.pb.cc
     ${PROTO_GEN_DIR}/gen/component/camera/v1/camera.pb.cc
-	${PROTO_GEN_DIR}/gen/component/generic/v1/generic.grpc.pb.cc
-	${PROTO_GEN_DIR}/gen/component/generic/v1/generic.pb.cc
+    ${PROTO_GEN_DIR}/gen/component/generic/v1/generic.grpc.pb.cc
+    ${PROTO_GEN_DIR}/gen/component/generic/v1/generic.pb.cc
     ${PROTO_GEN_DIR}/gen/google/api/annotations.pb.cc
     ${PROTO_GEN_DIR}/gen/google/api/http.pb.cc
     ${PROTO_GEN_DIR}/gen/google/api/httpbody.pb.cc
-	${PROTO_GEN_DIR}/gen/module/v1/module.grpc.pb.cc
-	${PROTO_GEN_DIR}/gen/module/v1/module.pb.cc
+    ${PROTO_GEN_DIR}/gen/module/v1/module.grpc.pb.cc
+    ${PROTO_GEN_DIR}/gen/module/v1/module.pb.cc
     ${PROTO_GEN_DIR}/gen/robot/v1/robot.pb.cc
     ${PROTO_GEN_DIR}/gen/robot/v1/robot.grpc.pb.cc
     ${PROTO_GEN_DIR}/gen/tagger/v1/tagger.pb.cc
     ${PROTO_GEN_DIR}/gen/tagger/v1/tagger.grpc.pb.cc
-	# TODO(RSDK-1742): we have to put `registry` up top here because we need the
-	# registry types to be defined first, before anything tries to init them.
-	# this obviously isn't great. it breaks up stylistic ordering and is brittle
-	# when we need to add updates. we should refactor to make this unnecessary.
-	# consider making all necessary runtime values a single `context` that has to
-	# be initialized within main before anything else happens?
-	registry/registry.cpp
+    # TODO(RSDK-1742): we have to put `registry` up top here because we need the
+    # registry types to be defined first, before anything tries to init them.
+    # this obviously isn't great. it breaks up stylistic ordering and is brittle
+    # when we need to add updates. we should refactor to make this unnecessary.
+    # consider making all necessary runtime values a single `context` that has to
+    # be initialized within main before anything else happens?
+    registry/registry.cpp
     common/proto_type.cpp
     common/utils.cpp
     components/component_base.cpp
-	components/component_type.cpp
-	components/generic.cpp
-	config/resource.cpp
-	module/handler_map.cpp
-	module/module.cpp
-	module/service.cpp
-	referenceframe/frame.cpp
-	resource/resource.cpp
-	resource/resource_base.cpp
-	resource/resource_manager.cpp
-	resource/resource_type.cpp
+    components/component_type.cpp
+    components/generic.cpp
+    config/resource.cpp
+    module/handler_map.cpp
+    module/module.cpp
+    module/service.cpp
+    referenceframe/frame.cpp
+    resource/resource.cpp
+    resource/resource_base.cpp
+    resource/resource_manager.cpp
+    resource/resource_type.cpp
     robot/client.cpp
     rpc/dial.cpp
-	rpc/server.cpp
-	services/service_base.cpp
-	services/service_type.cpp
-	spatialmath/geometry.cpp
-	spatialmath/orientation_types.cpp
-	spatialmath/orientation.cpp
-	subtype/subtype.cpp
+    rpc/server.cpp
+    services/service_base.cpp
+    services/service_type.cpp
+    spatialmath/geometry.cpp
+    spatialmath/orientation_types.cpp
+    spatialmath/orientation.cpp
+    subtype/subtype.cpp
   PUBLIC FILE_SET viamcpp_public_includes TYPE HEADERS
     FILES
       common/proto_type.hpp
       common/utils.hpp
       components/component_base.hpp
-	  components/component_type.hpp
-	  components/generic.hpp
+      components/component_type.hpp
+      components/generic.hpp
       components/service_base.hpp
-	  config/resource.hpp
-	  module/handler_map.hpp
-	  module/module.hpp
-	  module/service.hpp
-	  referenceframe/frame.hpp
+      config/resource.hpp
+      module/handler_map.hpp
+      module/module.hpp
+      module/service.hpp
+      referenceframe/frame.hpp
       registry/registry.hpp
-	  resource/resource.hpp
+      resource/resource.hpp
       resource/resource_base.hpp
       resource/resource_manager.hpp
       resource/resource_type.hpp
       robot/client.hpp
       robot/service.hpp
       rpc/dial.hpp
-	  rpc/server.hpp
-	  services/service_base.hpp
-	  services/service_type.hpp
-	  spatialmath/geometry.hpp
-	  spatialmath/orientation_types.hpp
-	  spatialmath/orientation.hpp
-	  subtype/subtype.hpp
+      rpc/server.hpp
+      services/service_base.hpp
+      services/service_type.hpp
+      spatialmath/geometry.hpp
+      spatialmath/orientation_types.hpp
+      spatialmath/orientation.hpp
+      subtype/subtype.hpp
   PUBLIC FILE_SET viamcpp_public_pb_includes TYPE HEADERS
     BASE_DIRS
       ${PROTO_GEN_DIR}/gen
@@ -276,6 +276,12 @@ target_sources(viamcpp
       ${PROTO_GEN_DIR}/gen/tagger/v1/tagger.pb.h
 )
 
+set_target_properties(
+  viamcpp PROPERTIES
+  SOVERSION noabi
+  VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}
+)
+
 target_include_directories(viamcpp
   PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
@@ -292,14 +298,15 @@ target_include_directories(viamcpp
     "$<INSTALL_INTERFACE:${VIAMCPPSDK_PROTOBUF_INCLUDE_DIRS}>"
 )
 
-# This shouldn't be necessary, but we need it so that the installation
-# path of the C++ SDK is added to the link line of consumers to that
-# `-lviam_rust_utils` can be meaningfully resolved.
-#
-# TODO: Remove this when we can import `viam_rust_utils` as a real
-# imported target with its own properties.
 target_link_directories(viamcpp
-  INTERFACE
+  PUBLIC
+    # This shouldn't be necessary, but we need it so that the
+    # installation path of the C++ SDK is added to the link line of
+    # consumers to that `-lviam_rust_utils` can be meaningfully
+    # resolved.
+    #
+    # TODO: Remove this when we can import `viam_rust_utils` as a real
+    # imported target with its own properties.
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}>"
 
@@ -327,9 +334,12 @@ target_link_libraries(viamcpp
 install(
   TARGETS viamcpp
   EXPORT LibTargets
-  LIBRARY COMPONENT runtime
-  FILE_SET viamcpp_public_includes COMPONENT dev
-  FILE_SET viamcpp_public_pb_includes COMPONENT dev
+  RUNTIME COMPONENT viam-cpp-sdk_runtime
+  LIBRARY COMPONENT viam-cpp-sdk_runtime
+      NAMELINK_COMPONENT viam-cpp-sdk_dev
+  ARCHIVE COMPONENT viam-cpp-sdk_dev
+  FILE_SET viamcpp_public_includes COMPONENT viam-cpp-sdk_dev
+  FILE_SET viamcpp_public_pb_includes COMPONENT viam-cpp-sdk_dev
 )
 
 install(
@@ -337,6 +347,7 @@ install(
   FILE viam-cpp-sdkLibTargets.cmake
   NAMESPACE viam-cpp-sdk::
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/viam-cpp-sdk
+  COMPONENT viam-cpp-sdk_dev
 )
 
 
@@ -358,5 +369,5 @@ configure_file(
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/config/viam-cpp-sdk-libviamcpp.pc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-  COMPONENT dev
+  COMPONENT viam-cpp-sdk_dev
 )

--- a/src/robot/client.hpp
+++ b/src/robot/client.hpp
@@ -10,6 +10,7 @@
 #include <resource/resource_manager.hpp>
 #include <rpc/dial.hpp>
 #include <string>
+#include <thread>
 
 using grpc::Channel;
 using viam::common::v1::ResourceName;


### PR DESCRIPTION
@stuqdog - No rush on this. It flips the default to building shared libraries and adds some other SDK-ification stuff. The only remaining wrinkle that I'm aware of is that `viam-rust-utils.dylib` has an incorrect install name per https://viam.atlassian.net/browse/RSDK-1996. That only affects macOS builds.