### PR TITLE
RSDK-2518 - Sort headers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,6 +10,7 @@ DerivePointerAlignment: false
 IndentWidth: 4
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
+SortIncludes: false
 SpaceBeforeAssignmentOperators: true
 Standard: Cpp11
 UseTab: Never

--- a/src/common/proto_type.cpp
+++ b/src/common/proto_type.cpp
@@ -1,13 +1,15 @@
-#include <google/protobuf/struct.pb.h>
+#include <common/proto_type.hpp>
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
 
 #include <boost/blank.hpp>
 #include <boost/variant/get.hpp>
 #include <boost/variant/variant.hpp>
-#include <common/proto_type.hpp>
+#include <google/protobuf/struct.pb.h>
+
 #include <config/resource.hpp>
-#include <memory>
-#include <unordered_map>
-#include <vector>
 
 using google::protobuf::Struct;
 using google::protobuf::Value;

--- a/src/common/proto_type.hpp
+++ b/src/common/proto_type.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <google/protobuf/struct.pb.h>
+#include <unordered_map>
 
 #include <boost/variant/variant.hpp>
-#include <unordered_map>
+#include <google/protobuf/struct.pb.h>
 
 class ProtoType {
    public:

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -1,15 +1,18 @@
-#include <common/v1/common.pb.h>
+#include <common/utils.hpp>
+
+#include <tuple>
+#include <unordered_map>
+#include <vector>
 
 #include <boost/blank.hpp>
 #include <boost/optional/optional.hpp>
 #include <boost/variant/get.hpp>
 #include <boost/variant/variant.hpp>
-#include <common/utils.hpp>
+
+#include <common/v1/common.pb.h>
+
 #include <components/component_base.hpp>
 #include <registry/registry.hpp>
-#include <tuple>
-#include <unordered_map>
-#include <vector>
 
 using viam::common::v1::ResourceName;
 

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
-#include <common/v1/common.pb.h>
+#include <unordered_map>
 
 #include <boost/optional/optional.hpp>
 #include <boost/variant/get.hpp>
 #include <boost/variant/variant.hpp>
+
+#include <common/v1/common.pb.h>
+
 #include <common/proto_type.hpp>
 #include <components/component_base.hpp>
-#include <unordered_map>
 
 using viam::common::v1::ResourceName;
 const std::string COMPONENT = "component";

--- a/src/components/camera/camera.cpp
+++ b/src/components/camera/camera.cpp
@@ -1,9 +1,11 @@
-#include <component/camera/v1/camera.grpc.pb.h>
-#include <component/camera/v1/camera.pb.h>
+#include <components/camera/camera.hpp>
+
 #include <google/protobuf/descriptor.h>
 
+#include <component/camera/v1/camera.grpc.pb.h>
+#include <component/camera/v1/camera.pb.h>
+
 #include <common/utils.hpp>
-#include <components/camera/camera.hpp>
 #include <components/camera/client.hpp>
 #include <components/camera/server.hpp>
 #include <registry/registry.hpp>

--- a/src/components/camera/camera.hpp
+++ b/src/components/camera/camera.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <component/camera/v1/camera.pb.h>
-
 #include <bitset>
-#include <common/utils.hpp>
-#include <config/resource.hpp>
-#include <registry/registry.hpp>
 #include <string>
 #include <vector>
 
-#include "common/proto_type.hpp"
-#include "subtype/subtype.hpp"
+#include <component/camera/v1/camera.pb.h>
+
+#include <common/proto_type.hpp>
+#include <common/utils.hpp>
+#include <config/resource.hpp>
+#include <registry/registry.hpp>
+#include <subtype/subtype.hpp>
 
 class CameraSubtype : public ResourceSubtype {
    public:

--- a/src/components/camera/client.cpp
+++ b/src/components/camera/client.cpp
@@ -1,13 +1,15 @@
-#include <algorithm>
-#include <common/utils.hpp>
-#include <components/camera/camera.hpp>
 #include <components/camera/client.hpp>
-#include <config/resource.hpp>
+
+#include <algorithm>
 #include <string>
 #include <utility>
 
-#include "common/v1/common.pb.h"
-#include "component/camera/v1/camera.grpc.pb.h"
+#include <common/v1/common.pb.h>
+#include <component/camera/v1/camera.grpc.pb.h>
+
+#include <common/utils.hpp>
+#include <components/camera/camera.hpp>
+#include <config/resource.hpp>
 
 std::string normalize_mime_type(const std::string& str) {
     std::string mime_type = str;

--- a/src/components/camera/client.hpp
+++ b/src/components/camera/client.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <component/camera/v1/camera.grpc.pb.h>
 #include <grpcpp/channel.h>
+
+#include <component/camera/v1/camera.grpc.pb.h>
 
 #include <components/camera/camera.hpp>
 #include <components/camera/server.hpp>

--- a/src/components/camera/server.cpp
+++ b/src/components/camera/server.cpp
@@ -1,8 +1,9 @@
+#include <components/camera/server.hpp>
+
 #include <gen/google/api/http.pb.h>
 
 #include <common/utils.hpp>
 #include <components/camera/camera.hpp>
-#include <components/camera/server.hpp>
 #include <config/resource.hpp>
 #include <rpc/server.hpp>
 

--- a/src/components/camera/server.cpp
+++ b/src/components/camera/server.cpp
@@ -1,7 +1,5 @@
 #include <components/camera/server.hpp>
 
-#include <gen/google/api/http.pb.h>
-
 #include <common/utils.hpp>
 #include <components/camera/camera.hpp>
 #include <config/resource.hpp>

--- a/src/components/camera/server.hpp
+++ b/src/components/camera/server.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <gen/google/api/http.pb.h>
-
 #include <common/v1/common.pb.h>
 #include <component/camera/v1/camera.grpc.pb.h>
 

--- a/src/components/camera/server.hpp
+++ b/src/components/camera/server.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <gen/google/api/http.pb.h>
+
 #include <common/v1/common.pb.h>
 #include <component/camera/v1/camera.grpc.pb.h>
-#include <gen/google/api/http.pb.h>
 
 #include <resource/resource_server_base.hpp>
 #include <subtype/subtype.hpp>

--- a/src/components/component_base.cpp
+++ b/src/components/component_base.cpp
@@ -1,10 +1,13 @@
-#include <common/v1/common.pb.h>
+#include <components/component_base.hpp>
+
+#include <string>
+
 #include <google/protobuf/struct.pb.h>
 
+#include <common/v1/common.pb.h>
+
 #include <common/utils.hpp>
-#include <components/component_base.hpp>
 #include <resource/resource_base.hpp>
-#include <string>
 
 using viam::common::v1::ResourceName;
 

--- a/src/components/component_base.hpp
+++ b/src/components/component_base.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
-#include <common/v1/common.pb.h>
+#include <string>
+
 #include <google/protobuf/struct.pb.h>
+
+#include <common/v1/common.pb.h>
 
 #include <components/component_type.hpp>
 #include <resource/resource_base.hpp>
-#include <string>
+
 class ComponentBase : public ResourceBase {
    public:
     ComponentType type;

--- a/src/components/generic/client.cpp
+++ b/src/components/generic/client.cpp
@@ -1,10 +1,12 @@
-#include <common/proto_type.hpp>
 #include <components/generic/client.hpp>
-#include <config/resource.hpp>
+
 #include <utility>
 
-#include "common/v1/common.pb.h"
-#include "component/generic/v1/generic.grpc.pb.h"
+#include <common/v1/common.pb.h>
+#include <component/generic/v1/generic.grpc.pb.h>
+
+#include <common/proto_type.hpp>
+#include <config/resource.hpp>
 
 AttributeMap GenericClient::do_command(AttributeMap command) {
     viam::common::v1::DoCommandRequest req;

--- a/src/components/generic/client.hpp
+++ b/src/components/generic/client.hpp
@@ -1,5 +1,6 @@
-#include <component/generic/v1/generic.grpc.pb.h>
 #include <grpcpp/channel.h>
+
+#include <component/generic/v1/generic.grpc.pb.h>
 
 #include <components/generic/generic.hpp>
 

--- a/src/components/generic/client.hpp
+++ b/src/components/generic/client.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <grpcpp/channel.h>
 
 #include <component/generic/v1/generic.grpc.pb.h>

--- a/src/components/generic/generic.cpp
+++ b/src/components/generic/generic.cpp
@@ -1,14 +1,16 @@
-#include <component/generic/v1/generic.grpc.pb.h>
-#include <component/generic/v1/generic.pb.h>
+#include <components/generic/generic.hpp>
+
+#include <stdexcept>
+
 #include <google/protobuf/descriptor.h>
+
+#include <component/generic/v1/generic.grpc.pb.h>
 
 #include <common/utils.hpp>
 #include <components/generic/client.hpp>
-#include <components/generic/generic.hpp>
 #include <components/generic/server.hpp>
 #include <registry/registry.hpp>
 #include <resource/resource.hpp>
-#include <stdexcept>
 
 std::shared_ptr<ResourceServerBase> GenericSubtype::create_resource_server(
     std::shared_ptr<SubtypeService> svc) {

--- a/src/components/generic/generic.hpp
+++ b/src/components/generic/generic.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
+#include <google/protobuf/descriptor.h>
+
+#include <common/proto_type.hpp>
 #include <common/utils.hpp>
 #include <config/resource.hpp>
 #include <registry/registry.hpp>
-
-#include "common/proto_type.hpp"
-#include "subtype/subtype.hpp"
+#include <subtype/subtype.hpp>
 
 // TODO(RSDK-1742): one class per header
 class GenericSubtype : public ResourceSubtype {

--- a/src/components/generic/server.cpp
+++ b/src/components/generic/server.cpp
@@ -1,5 +1,6 @@
-#include <components/generic/generic.hpp>
 #include <components/generic/server.hpp>
+
+#include <components/generic/generic.hpp>
 #include <rpc/server.hpp>
 
 ::grpc::Status GenericServer::DoCommand(::grpc::ServerContext* context,

--- a/src/config/resource.cpp
+++ b/src/config/resource.cpp
@@ -1,15 +1,18 @@
+#include <config/resource.hpp>
+
+#include <numeric>
+#include <string>
+#include <unordered_map>
+
+#include <boost/algorithm/string.hpp>
+
 #include <app/v1/robot.pb.h>
 #include <robot/v1/robot.pb.h>
 
-#include <boost/algorithm/string.hpp>
 #include <common/proto_type.hpp>
 #include <common/utils.hpp>
-#include <config/resource.hpp>
-#include <numeric>
 #include <referenceframe/frame.hpp>
 #include <resource/resource.hpp>
-#include <string>
-#include <unordered_map>
 
 Name Resource::resource_name() {
     try {

--- a/src/config/resource.hpp
+++ b/src/config/resource.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
+#include <string>
+#include <unordered_map>
+
 #include <app/v1/robot.pb.h>
 #include <robot/v1/robot.pb.h>
 
 #include <common/proto_type.hpp>
 #include <referenceframe/frame.hpp>
 #include <resource/resource.hpp>
-#include <string>
-#include <unordered_map>
 
 typedef std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> AttributeMap;
 

--- a/src/module/handler_map.cpp
+++ b/src/module/handler_map.cpp
@@ -1,13 +1,14 @@
+#include <module/handler_map.hpp>
+
 #include <memory>
 
-#include "google/protobuf/descriptor.h"
-#define BOOST_LOG_DYN_LINK 1
+#include <boost/log/trivial.hpp>
+#include <google/protobuf/descriptor.h>
+
 #include <common/v1/common.pb.h>
 #include <module/v1/module.pb.h>
 #include <robot/v1/robot.pb.h>
 
-#include <boost/log/trivial.hpp>
-#include <module/handler_map.hpp>
 #include <resource/resource.hpp>
 
 viam::module::v1::HandlerMap HandlerMap_::to_proto() {

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -1,12 +1,11 @@
-#include <grpcpp/channel.h>
-#include <grpcpp/security/credentials.h>
-
-#include "subtype/subtype.hpp"
-#define BOOST_LOG_DYN_LINK 1
-#include <grpcpp/create_channel.h>
+#include <module/module.hpp>
 
 #include <boost/log/trivial.hpp>
-#include <module/module.hpp>
+#include <grpcpp/channel.h>
+#include <grpcpp/create_channel.h>
+#include <grpcpp/security/credentials.h>
+
+#include <subtype/subtype.hpp>
 
 Module::Module(std::string addr) : addr(addr){};
 

--- a/src/module/service.cpp
+++ b/src/module/service.cpp
@@ -1,40 +1,40 @@
-#include <grpcpp/server.h>
+#include <module/service.hpp>
 
 #include <csignal>
 #include <iostream>
-
-#include "google/protobuf/descriptor.h"
-#define BOOST_LOG_DYN_LINK 1
-#include <app/v1/robot.pb.h>
-#include <grpcpp/channel.h>
-#include <grpcpp/create_channel.h>
-#include <grpcpp/grpcpp.h>
-#include <grpcpp/security/credentials.h>
-#include <grpcpp/security/server_credentials.h>
-#include <grpcpp/server_builder.h>
-#include <grpcpp/server_context.h>
-#include <grpcpp/support/status.h>
-#include <module/v1/module.grpc.pb.h>
-#include <module/v1/module.pb.h>
+#include <memory>
+#include <string>
 #include <sys/socket.h>
 #include <sys/stat.h>
 
 #include <boost/log/trivial.hpp>
 #include <boost/none.hpp>
+#include <google/protobuf/descriptor.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/create_channel.h>
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/security/credentials.h>
+#include <grpcpp/security/server_credentials.h>
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
+#include <grpcpp/server_context.h>
+#include <grpcpp/support/status.h>
+
+#include <app/v1/robot.pb.h>
+#include <module/v1/module.grpc.pb.h>
+#include <module/v1/module.pb.h>
+
 #include <common/utils.hpp>
 #include <components/component_base.hpp>
 #include <components/service_base.hpp>
 #include <config/resource.hpp>
-#include <memory>
 #include <module/handler_map.hpp>
-#include <module/service.hpp>
 #include <registry/registry.hpp>
 #include <resource/resource.hpp>
 #include <resource/resource_base.hpp>
 #include <robot/client.hpp>
 #include <robot/service.hpp>
 #include <rpc/server.hpp>
-#include <string>
 #include <subtype/subtype.hpp>
 
 namespace {

--- a/src/module/service.hpp
+++ b/src/module/service.hpp
@@ -7,8 +7,6 @@
 #include <module/module.hpp>
 #include <resource/resource_base.hpp>
 
-#include "module/v1/module.pb.h"
-
 class ModuleService_ : public ComponentServiceBase,
                        public viam::module::v1::ModuleService::Service {
    public:

--- a/src/referenceframe/frame.cpp
+++ b/src/referenceframe/frame.cpp
@@ -1,11 +1,13 @@
+#include <referenceframe/frame.hpp>
+
+#include <string>
+
 #include <app/v1/robot.pb.h>
 #include <common/v1/common.pb.h>
 
-#include <referenceframe/frame.hpp>
 #include <spatialmath/geometry.hpp>
 #include <spatialmath/orientation.hpp>
 #include <spatialmath/orientation_types.hpp>
-#include <string>
 
 viam::app::v1::Frame LinkConfig::to_proto() {
     viam::app::v1::Frame frame;

--- a/src/referenceframe/frame.hpp
+++ b/src/referenceframe/frame.hpp
@@ -1,9 +1,11 @@
 #pragma once
+
+#include <string>
+
 #include <app/v1/robot.pb.h>
 
 #include <spatialmath/geometry.hpp>
 #include <spatialmath/orientation.hpp>
-#include <string>
 
 class LinkConfig {
    public:

--- a/src/registry/registry.cpp
+++ b/src/registry/registry.cpp
@@ -1,20 +1,23 @@
+#include <registry/registry.hpp>
+
+#include <exception>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <boost/log/trivial.hpp>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/struct.pb.h>
 #include <grpcpp/channel.h>
+
 #include <robot/v1/robot.pb.h>
 
-#include <boost/log/trivial.hpp>
 #include <components/component_base.hpp>
 #include <components/generic/generic.hpp>
 #include <components/service_base.hpp>
-#include <exception>
-#include <memory>
-#include <registry/registry.hpp>
 #include <resource/resource.hpp>
 #include <resource/resource_base.hpp>
 #include <services/service_base.hpp>
-#include <string>
-#include <unordered_map>
 
 using viam::robot::v1::Status;
 

--- a/src/registry/registry.hpp
+++ b/src/registry/registry.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <string>
+
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/message.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/impl/service_type.h>
 #include <grpcpp/server.h>
+
 #include <robot/v1/robot.pb.h>
 
 #include <config/resource.hpp>
@@ -12,7 +15,6 @@
 #include <resource/resource_base.hpp>
 #include <resource/resource_server_base.hpp>
 #include <resource/resource_type.hpp>
-#include <string>
 #include <subtype/subtype.hpp>
 
 // TODO(RSDK-1742): instead of std::functions, consider making these functions

--- a/src/resource/resource.cpp
+++ b/src/resource/resource.cpp
@@ -1,13 +1,16 @@
-#include <common/v1/common.pb.h>
-#include <google/protobuf/descriptor.h>
-
-#include <boost/algorithm/string.hpp>
-#include <common/utils.hpp>
-#include <components/component_base.hpp>
-#include <regex>
 #include <resource/resource.hpp>
+
+#include <regex>
 #include <sstream>
 #include <string>
+
+#include <boost/algorithm/string.hpp>
+#include <google/protobuf/descriptor.h>
+
+#include <common/v1/common.pb.h>
+
+#include <common/utils.hpp>
+#include <components/component_base.hpp>
 
 const std::regex NAME_REGEX("^([\\w-]+:[\\w-]+:(?:[\\w-]+))\\/?([\\w-]+:(?:[\\w-]+:)*)?(.+)?$");
 

--- a/src/resource/resource.hpp
+++ b/src/resource/resource.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <google/protobuf/descriptor.h>
-
 #include <string>
 
-#include "common/v1/common.pb.h"
+#include <google/protobuf/descriptor.h>
+
+#include <common/v1/common.pb.h>
 
 class Type {
    public:

--- a/src/resource/resource_base.cpp
+++ b/src/resource/resource_base.cpp
@@ -1,9 +1,11 @@
+#include <resource/resource_base.hpp>
+
+#include <unordered_map>
+
 #include <grpcpp/support/status.h>
 
 #include <common/proto_type.hpp>
 #include <resource/resource.hpp>
-#include <resource/resource_base.hpp>
-#include <unordered_map>
 
 grpc::StatusCode ResourceBase::stop(std::unordered_map<std::string, ProtoType*> extra) {
     return stop();

--- a/src/resource/resource_base.hpp
+++ b/src/resource/resource_base.hpp
@@ -1,13 +1,14 @@
 #pragma once
+
+#include <unordered_map>
+
 #include <grpcpp/impl/service_type.h>
 #include <grpcpp/support/status.h>
 
 #include <common/proto_type.hpp>
 #include <config/resource.hpp>
-#include <functional>
 #include <resource/resource.hpp>
 #include <resource/resource_type.hpp>
-#include <unordered_map>
 
 class ResourceBase;
 using Dependencies = std::unordered_map<Name, std::shared_ptr<ResourceBase>>;

--- a/src/resource/resource_manager.cpp
+++ b/src/resource/resource_manager.cpp
@@ -1,10 +1,12 @@
-#include <components/component_base.hpp>
 #include <resource/resource_manager.hpp>
-#include <services/service_base.hpp>
+
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include <components/component_base.hpp>
+#include <services/service_base.hpp>
 
 ResourceManager::ResourceManager() {}
 std::unordered_map<std::string, std::shared_ptr<ResourceBase>> ResourceManager::resources;
@@ -30,7 +32,7 @@ void ResourceManager::register_resource(std::shared_ptr<ResourceBase> resource) 
 std::shared_ptr<ResourceBase> ResourceManager::get_resource(std::string name,
                                                             ResourceType of_type) {
     if (resources.find(name) == resources.end()) {
-        throw "Resource name " + name + " doesn't exist!";
+        throw std::runtime_error("Resource name " + name + " doesn't exist!");
     }
 
     std::shared_ptr<ResourceBase> resource = resources.at(name);
@@ -42,7 +44,7 @@ std::shared_ptr<ResourceBase> ResourceManager::get_resource(std::string name,
     if (of_type == base) {
         return resource;
     }
-    throw "Resource name " + name +
-        " was found, but it has the wrong type! Expected type: " + of_type.type +
-        ". Actual type: " + resource->type.type;
+    throw std::runtime_error("Resource name " + name +
+                             " was found, but it has the wrong type! Expected type: " +
+                             of_type.type + ". Actual type: " + resource->type.type);
 }

--- a/src/resource/resource_manager.hpp
+++ b/src/resource/resource_manager.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <resource/resource_base.hpp>
-#include <resource/resource_type.hpp>
 #include <string>
 #include <unordered_map>
+
+#include <resource/resource_base.hpp>
+#include <resource/resource_type.hpp>
 
 class ResourceManager {
    public:

--- a/src/resource/resource_server_base.cpp
+++ b/src/resource/resource_server_base.cpp
@@ -1,5 +1,1 @@
 #include <resource/resource_server_base.hpp>
-
-void ResourceServerBase::register_server() {
-    throw "cannot register the abstract Resource Server base";
-}

--- a/src/resource/resource_server_base.hpp
+++ b/src/resource/resource_server_base.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <subtype/subtype.hpp>
+
 class ResourceServerBase {
    public:
-    virtual void register_server();
+    virtual void register_server() = 0;
 
    private:
     std::shared_ptr<SubtypeService> sub_svc;

--- a/src/resource/resource_type.hpp
+++ b/src/resource/resource_type.hpp
@@ -6,7 +6,5 @@ class ResourceType {
    public:
     std::string type;
     friend bool operator==(const ResourceType& lhs, const ResourceType& rhs);
-    ResourceType(std::string type) {
-        type = type;
-    }
+    ResourceType(std::string type) : type(std::move(type)){};
 };

--- a/src/robot/client.cpp
+++ b/src/robot/client.cpp
@@ -1,36 +1,37 @@
+#include <robot/client.hpp>
+
 #include <algorithm>
-
-#include "resource/resource_base.hpp"
-#define BOOST_LOG_DYN_LINK 1
-#include <common/v1/common.pb.h>
-#include <grpcpp/channel.h>
-#include <grpcpp/client_context.h>
-#include <grpcpp/create_channel.h>
-#include <grpcpp/grpcpp.h>
-#include <grpcpp/support/status.h>
-#include <robot/v1/robot.grpc.pb.h>
-#include <robot/v1/robot.pb.h>
-#include <unistd.h>
-
-#include <boost/log/trivial.hpp>
 #include <chrono>
-#include <common/proto_type.hpp>
-#include <common/utils.hpp>
-#include <components/service_base.hpp>
 #include <cstddef>
 #include <iostream>
 #include <memory>
 #include <mutex>
 #include <ostream>
-#include <registry/registry.hpp>
-#include <resource/resource_manager.hpp>
-#include <robot/client.hpp>
-#include <rpc/dial.hpp>
 #include <set>
 #include <string>
 #include <thread>
 #include <tuple>
+#include <unistd.h>
 #include <vector>
+
+#include <boost/log/trivial.hpp>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/create_channel.h>
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/support/status.h>
+
+#include <common/v1/common.pb.h>
+#include <robot/v1/robot.grpc.pb.h>
+#include <robot/v1/robot.pb.h>
+
+#include <common/proto_type.hpp>
+#include <common/utils.hpp>
+#include <components/service_base.hpp>
+#include <registry/registry.hpp>
+#include <resource/resource_base.hpp>
+#include <resource/resource_manager.hpp>
+#include <rpc/dial.hpp>
 
 using google::protobuf::RepeatedPtrField;
 using grpc::ClientContext;

--- a/src/robot/client.hpp
+++ b/src/robot/client.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
-#include <common/v1/common.pb.h>
+#include <string>
+#include <thread>
+
 #include <grpcpp/channel.h>
+
+#include <common/v1/common.pb.h>
 #include <robot/v1/robot.grpc.pb.h>
 #include <robot/v1/robot.pb.h>
 
@@ -9,8 +13,6 @@
 #include <registry/registry.hpp>
 #include <resource/resource_manager.hpp>
 #include <rpc/dial.hpp>
-#include <string>
-#include <thread>
 
 using grpc::Channel;
 using viam::common::v1::ResourceName;

--- a/src/robot/service.cpp
+++ b/src/robot/service.cpp
@@ -1,21 +1,24 @@
-#include <common/v1/common.pb.h>
+#include <robot/service.hpp>
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
 #include <google/protobuf/struct.pb.h>
 #include <grpcpp/support/status.h>
+
+#include <common/v1/common.pb.h>
 #include <robot/v1/robot.grpc.pb.h>
 #include <robot/v1/robot.pb.h>
 
 #include <common/utils.hpp>
 #include <components/component_base.hpp>
-#include <memory>
-#include <mutex>
 #include <registry/registry.hpp>
 #include <resource/resource.hpp>
 #include <robot/client.hpp>
-#include <robot/service.hpp>
 #include <services/service_base.hpp>
-#include <string>
-#include <thread>
-#include <unordered_map>
 
 using google::protobuf::RepeatedPtrField;
 using viam::common::v1::ResourceName;

--- a/src/robot/service.hpp
+++ b/src/robot/service.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
-#include <common/v1/common.pb.h>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
 #include <google/protobuf/struct.pb.h>
 #include <grpcpp/support/status.h>
+
+#include <common/v1/common.pb.h>
 #include <robot/v1/robot.grpc.pb.h>
 #include <robot/v1/robot.pb.h>
 
@@ -11,9 +16,6 @@
 #include <components/service_base.hpp>
 #include <resource/resource.hpp>
 #include <robot/client.hpp>
-#include <string>
-#include <thread>
-#include <unordered_map>
 
 using google::protobuf::RepeatedPtrField;
 using viam::common::v1::ResourceName;

--- a/src/rpc/dial.cpp
+++ b/src/rpc/dial.cpp
@@ -1,15 +1,16 @@
+#include <rpc/dial.hpp>
+
+#include <istream>
+#include <string>
+
+#include <boost/none.hpp>
+#include <boost/optional.hpp>
 #include <grpcpp/channel.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
 
-#include <boost/none.hpp>
-#include <boost/optional.hpp>
-#include <istream>
-#include <rpc/dial.hpp>
-#include <string>
-
-#include "robot/v1/robot.grpc.pb.h"
-#include "robot/v1/robot.pb.h"
+#include <robot/v1/robot.grpc.pb.h>
+#include <robot/v1/robot.pb.h>
 
 extern "C" void* init_rust_runtime();
 extern "C" int free_rust_runtime(void* ptr);

--- a/src/rpc/dial.hpp
+++ b/src/rpc/dial.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <grpcpp/channel.h>
-
-#include <boost/optional.hpp>
 #include <memory>
 #include <string>
+
+#include <boost/optional.hpp>
+#include <grpcpp/channel.h>
+
 // TODO(RSDK-1742): make use of namespaces throughout repo
 namespace Viam {
 namespace SDK {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -1,7 +1,7 @@
+#include <rpc/server.hpp>
+
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/security/server_credentials.h>
-
-#include <rpc/server.hpp>
 
 void Server::register_service(grpc::Service* service) {
     if (server != nullptr) {

--- a/src/rpc/server.hpp
+++ b/src/rpc/server.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <grpcpp/impl/service_type.h>
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server_builder.h>

--- a/src/services/service_base.cpp
+++ b/src/services/service_base.cpp
@@ -1,9 +1,11 @@
+#include <services/service_base.hpp>
+
+#include <string>
+
 #include <common/v1/common.pb.h>
 
 #include <common/utils.hpp>
 #include <resource/resource_base.hpp>
-#include <services/service_base.hpp>
-#include <string>
 
 ResourceName ServiceBase::get_resource_name(std::string name_) {
     // TODO (RSDK-1631): test, confirm whether we need to split on

--- a/src/services/service_base.hpp
+++ b/src/services/service_base.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <string>
+
 #include <common/v1/common.pb.h>
 
 #include <resource/resource_base.hpp>
-#include <string>
-
-#include "services/service_type.hpp"
+#include <services/service_type.hpp>
 
 class ServiceBase : public ResourceBase {
    public:

--- a/src/spatialmath/geometry.cpp
+++ b/src/spatialmath/geometry.cpp
@@ -1,9 +1,11 @@
-#include <common/v1/common.pb.h>
-
 #include <spatialmath/geometry.hpp>
-#include <spatialmath/orientation.hpp>
+
 #include <string>
 #include <tuple>
+
+#include <common/v1/common.pb.h>
+
+#include <spatialmath/orientation.hpp>
 
 viam::common::v1::Sphere GeometryConfig::sphere_proto() {
     viam::common::v1::Sphere sphere;

--- a/src/spatialmath/geometry.hpp
+++ b/src/spatialmath/geometry.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <string>
+#include <tuple>
+
 #include <common/v1/common.pb.h>
 
 #include <spatialmath/orientation.hpp>
-#include <string>
-#include <tuple>
 
 enum GeometryType {
     box,

--- a/src/spatialmath/orientation.cpp
+++ b/src/spatialmath/orientation.cpp
@@ -1,11 +1,14 @@
-#include <app/v1/robot.pb.h>
+#include <spatialmath/orientation.hpp>
+
+#include <string>
+#include <vector>
 
 #include <boost/variant/get.hpp>
 #include <boost/variant/variant.hpp>
-#include <spatialmath/orientation.hpp>
+
+#include <app/v1/robot.pb.h>
+
 #include <spatialmath/orientation_types.hpp>
-#include <string>
-#include <vector>
 
 namespace SDK = Viam::SDK;
 namespace proto = viam::app::v1;

--- a/src/spatialmath/orientation.hpp
+++ b/src/spatialmath/orientation.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
-#include <app/v1/robot.pb.h>
-
-#include <boost/variant/variant.hpp>
-#include <spatialmath/orientation_types.hpp>
 #include <string>
 #include <vector>
+
+#include <boost/variant/variant.hpp>
+
+#include <app/v1/robot.pb.h>
+
+#include <spatialmath/orientation_types.hpp>
 
 typedef boost::variant<Viam::SDK::axis_angles,
                        Viam::SDK::euler_angles,

--- a/src/spatialmath/orientation_types.cpp
+++ b/src/spatialmath/orientation_types.cpp
@@ -1,6 +1,6 @@
-#include <app/v1/robot.pb.h>
-
 #include <spatialmath/orientation_types.hpp>
+
+#include <app/v1/robot.pb.h>
 
 viam::app::v1::Translation Viam::SDK::translation::to_proto() {
     viam::app::v1::Translation t;

--- a/src/spatialmath/orientation_types.hpp
+++ b/src/spatialmath/orientation_types.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <app/v1/robot.pb.h>
+
 namespace Viam {
 namespace SDK {
 

--- a/src/subtype/subtype.cpp
+++ b/src/subtype/subtype.cpp
@@ -1,24 +1,24 @@
-#include <grpcpp/impl/service_type.h>
-#include <grpcpp/support/status.h>
+#include <subtype/subtype.hpp>
 
 #include <exception>
 #include <memory>
-
-#include "component/generic/v1/generic.grpc.pb.h"
-#include "registry/registry.hpp"
-#define BOOST_LOG_DYN_LINK 1
-#include <boost/algorithm/string.hpp>
-#include <boost/log/trivial.hpp>
-#include <boost/optional/optional.hpp>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-#include "resource/resource.hpp"
-#include "resource/resource_base.hpp"
-#include "rpc/server.hpp"
-#include "services/service_base.hpp"
-#include "subtype/subtype.hpp"
+#include <boost/algorithm/string.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/optional/optional.hpp>
+#include <grpcpp/impl/service_type.h>
+#include <grpcpp/support/status.h>
+
+#include <component/generic/v1/generic.grpc.pb.h>
+
+#include <registry/registry.hpp>
+#include <resource/resource.hpp>
+#include <resource/resource_base.hpp>
+#include <rpc/server.hpp>
+#include <services/service_base.hpp>
 
 std::shared_ptr<ResourceBase> SubtypeService::resource(std::string name) {
     lock.lock();

--- a/src/subtype/subtype.hpp
+++ b/src/subtype/subtype.hpp
@@ -1,14 +1,16 @@
 #pragma once
 
-#include <component/generic/v1/generic.grpc.pb.h>
-#include <grpcpp/impl/service_type.h>
-
-#include <boost/optional/optional.hpp>
 #include <memory>
-#include <resource/resource.hpp>
-#include <resource/resource_base.hpp>
 #include <string>
 #include <unordered_map>
+
+#include <boost/optional/optional.hpp>
+#include <grpcpp/impl/service_type.h>
+
+#include <component/generic/v1/generic.grpc.pb.h>
+
+#include <resource/resource.hpp>
+#include <resource/resource_base.hpp>
 
 class SubtypeService : public grpc::Service {
    public:

--- a/src/tests/mocks/camera_mocks.cpp
+++ b/src/tests/mocks/camera_mocks.cpp
@@ -1,10 +1,11 @@
+#include <tests/mocks/camera_mocks.hpp>
+
 #include <common/v1/common.pb.h>
 #include <component/camera/v1/camera.grpc.pb.h>
 #include <component/camera/v1/camera.pb.h>
 
 #include <components/camera/camera.hpp>
 #include <components/camera/server.hpp>
-#include <tests/mocks/camera_mocks.hpp>
 #include <tests/test_utils.hpp>
 
 AttributeMap MockCamera::do_command(AttributeMap command) {

--- a/src/tests/mocks/generic_mocks.cpp
+++ b/src/tests/mocks/generic_mocks.cpp
@@ -1,3 +1,5 @@
+#include <tests/mocks/generic_mocks.hpp>
+
 #include <common/v1/common.pb.h>
 #include <component/camera/v1/camera.grpc.pb.h>
 #include <component/camera/v1/camera.pb.h>
@@ -5,7 +7,6 @@
 #include <components/generic/client.hpp>
 #include <components/generic/generic.hpp>
 #include <components/generic/server.hpp>
-#include <tests/mocks/generic_mocks.hpp>
 #include <tests/test_utils.hpp>
 
 std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>>

--- a/src/tests/mocks/generic_mocks.hpp
+++ b/src/tests/mocks/generic_mocks.hpp
@@ -5,6 +5,7 @@
 #include <component/camera/v1/camera.pb.h>
 
 #include <components/generic/generic.hpp>
+#include <components/generic/client.hpp>
 #include <components/generic/server.hpp>
 
 class MockGeneric : public Generic {

--- a/src/tests/test_camera.cpp
+++ b/src/tests/test_camera.cpp
@@ -1,19 +1,22 @@
 #define BOOST_TEST_MODULE test module test_camera
+
+#include <typeinfo>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <boost/test/included/unit_test.hpp>
+
 #include <common/v1/common.pb.h>
 #include <component/camera/v1/camera.grpc.pb.h>
 #include <component/camera/v1/camera.pb.h>
 
-#include <boost/test/included/unit_test.hpp>
 #include <common/proto_type.hpp>
 #include <components/camera/camera.hpp>
 #include <components/camera/client.hpp>
 #include <components/camera/server.hpp>
 #include <tests/mocks/camera_mocks.hpp>
 #include <tests/test_utils.hpp>
-#include <typeinfo>
-#include <unordered_map>
-#include <utility>
-#include <vector>
 
 BOOST_AUTO_TEST_SUITE(test_camera)
 

--- a/src/tests/test_generic_component.cpp
+++ b/src/tests/test_generic_component.cpp
@@ -1,16 +1,19 @@
 #define BOOST_TEST_MODULE test module test_generic_component
-#include <common/v1/common.pb.h>
+
+#include <typeinfo>
+#include <unordered_map>
+#include <utility>
 
 #include <boost/test/included/unit_test.hpp>
+
+#include <common/v1/common.pb.h>
+
 #include <components/generic/client.hpp>
 #include <components/generic/generic.hpp>
 #include <components/generic/server.hpp>
 #include <config/resource.hpp>
 #include <tests/mocks/generic_mocks.hpp>
 #include <tests/test_utils.hpp>
-#include <typeinfo>
-#include <unordered_map>
-#include <utility>
 
 BOOST_AUTO_TEST_SUITE(generic_suite)
 

--- a/src/tests/test_robot.cpp
+++ b/src/tests/test_robot.cpp
@@ -1,6 +1,6 @@
-#include <common/v1/common.pb.h>
-#include <component/arm/v1/arm.grpc.pb.h>
-#include <component/arm/v1/arm.pb.h>
+#include <memory>
+#include <utility>
+
 #include <google/protobuf/struct.pb.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
@@ -12,13 +12,15 @@
 #include <grpcpp/server_context.h>
 #include <grpcpp/support/server_callback.h>
 #include <grpcpp/support/stub_options.h>
+
+#include <common/v1/common.pb.h>
+#include <component/arm/v1/arm.grpc.pb.h>
+#include <component/arm/v1/arm.pb.h>
 #include <robot/v1/robot.grpc.pb.h>
 #include <robot/v1/robot.pb.h>
 
 #include <common/utils.hpp>
-#include <memory>
 #include <robot/service.hpp>
-#include <utility>
 
 using google::protobuf::RepeatedPtrField;
 using viam::common::v1::PoseInFrame;

--- a/src/tests/test_types.cpp
+++ b/src/tests/test_types.cpp
@@ -1,9 +1,12 @@
 #define BOOST_TEST_MODULE test module test_types
+
+#include <unordered_map>
+
 #include <boost/test/included/unit_test.hpp>
+
 #include <common/proto_type.hpp>
 #include <config/resource.hpp>
 #include <tests/test_utils.hpp>
-#include <unordered_map>
 
 BOOST_AUTO_TEST_SUITE(test_prototype)
 

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -1,6 +1,9 @@
+#include <tests/test_utils.hpp>
+
+#include <unordered_map>
+
 #include <common/proto_type.hpp>
 #include <config/resource.hpp>
-#include <unordered_map>
 
 AttributeMap fake_map() {
     std::shared_ptr<ProtoType> proto_ptr =

--- a/src/tests/test_utils.hpp
+++ b/src/tests/test_utils.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <common/proto_type.hpp>
-#include <config/resource.hpp>
 #include <unordered_map>
+
+#include <config/resource.hpp>
 
 AttributeMap fake_map();


### PR DESCRIPTION
#### Major changes: ####
Sets up a sorting scheme for includes in C++ SDK. Headers should always be sorted according to the following scheme, alphabetically within a grouping and with line breaks separating.

1.     (implementation file only) the associated header
2.     Includes from std library (unordered_map, functional, string, etc.)
3.     Third parties includes (boost, google protobuf, etc.)
4.     Viam autogen files (anything from src/gen/ that was developed in-house)
5.     non-autogen includes from the CPP SDK

#### Minor changes: ####
Remove some unused headers
Remove unnecessary `BOOST_LOG` macro
add `#pragma once` in a couple places where it was missing