### PR TITLE
RSDK-2352 - setup UB sanitizer, add -Wall and -Werror flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,9 @@ option(BUILD_SHARED_LIBS "If enabled, build shared libraries" ON)
 option(VIAMCPPSDK_ENFORCE_COMPILER_MINIMA "Control whether we validate the selected compiler against known minima" ON)
 option(VIAMCPPSDK_OFFLINE_PROTO_GENERATION "Use local tools for proto generation" OFF)
 option(VIAMCPPSDK_USE_DYNAMIC_PROTOS "Regenerate protos as part of building (network access may be required)" OFF)
+option(VIAMCPPSDK_USE_WALL_WERROR "Build with -Wall and -Werror flags" ON)
+# N.b.: `VIAMCPPSDK_SANITIZED_BUILD` may cause runtime failures if gRPC is not also built with sanitizers.
+option(VIAMCPPSDK_SANITIZED_BUILD "Build with address and UB sanitizers (less performant)" OFF)
 
 
 # Enforce known toolchains and toolchain minima unless asked not to.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,13 +57,15 @@ option(BUILD_SHARED_LIBS "If enabled, build shared libraries" ON)
 #
 # - `VIAMCPPSDK_ENFORCE_COMPILER_MINIMA`: The user can elect to
 # disable enforcement of compiler minima (at their peril).
-#
-#
-# # - `VIAMCPPSDK_LOCAL_PROTO_GENERATION`: Do not use buf.builds remote
+option(VIAMCPPSDK_ENFORCE_COMPILER_MINIMA "Control whether we validate the selected compiler against known minima" ON)
+
+
+# # - `VIAMCPPSDK_OFFLINE_PROTO_GENERATION`: Do not use buf.builds remote
 # definitions or services and use the local proto compiler plugins to
 # do generation.
-#
-#
+option(VIAMCPPSDK_OFFLINE_PROTO_GENERATION "Use local tools for proto generation" OFF)
+
+
 # - `VIAMCPPSDK_USE_DYNAMIC_PROTOS`: The user can select whether to
 # use the prebuilt proto files under the `gen` directory, or to
 # dynamically regenerate them as part of the build. In the latter
@@ -75,14 +77,18 @@ option(BUILD_SHARED_LIBS "If enabled, build shared libraries" ON)
 # cmake ... -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON
 # [make|ninja|...] update-static-protos
 # ```
-#
 # Remember to check-in the results after regenerating!
-#
-option(VIAMCPPSDK_ENFORCE_COMPILER_MINIMA "Control whether we validate the selected compiler against known minima" ON)
-option(VIAMCPPSDK_OFFLINE_PROTO_GENERATION "Use local tools for proto generation" OFF)
 option(VIAMCPPSDK_USE_DYNAMIC_PROTOS "Regenerate protos as part of building (network access may be required)" OFF)
+
+
+# # - `VIAMCPPSDK_USE_WALL_WERROR`: This causes the SDK's internal
+# code to compile with `-Wall` and `-Werror` flags.
 option(VIAMCPPSDK_USE_WALL_WERROR "Build with -Wall and -Werror flags" ON)
-# N.b.: `VIAMCPPSDK_SANITIZED_BUILD` may cause runtime failures if gRPC is not also built with sanitizers.
+
+
+# # - `VIAMCPPSDK_SANITIZED_BUILD`: This causes the SDK to build with
+# UBSan, helping in the detection of undefined behavior. Note that builds
+# with this flag will be less performant.
 option(VIAMCPPSDK_SANITIZED_BUILD "Build with address and UB sanitizers (less performant)" OFF)
 
 

--- a/etc/docker/tests/run_test.sh
+++ b/etc/docker/tests/run_test.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 mkdir build
 cd build
-cmake .. -G Ninja -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON -DVIAMCPPSDK_OFFLINE_PROTO_GENERATION=ON
+cmake .. -G Ninja -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON \
+		-DVIAMCPPSDK_OFFLINE_PROTO_GENERATION=ON \
+		-DVIAMCPPSDK_SANITIZED_BUILD=ON
 ninja all
 ninja install
 cd src/viam/sdk/tests

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -166,8 +166,8 @@ if (VIAMCPPSDK_USE_WALL_WERROR)
   target_compile_options(viamsdk PRIVATE -Wall -Werror)
 endif()
 if (VIAMCPPSDK_SANITIZED_BUILD)
-  target_link_options(viamsdk PRIVATE -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -fno-sanitize-recover)
-  target_compile_options(viamsdk PRIVATE -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -fno-sanitize-recover)
+  target_link_options(viamsdk PRIVATE -fsanitize=undefined -fno-omit-frame-pointer -fno-sanitize-recover)
+  target_compile_options(viamsdk PRIVATE -fsanitize=undefined -fno-omit-frame-pointer -fno-sanitize-recover)
 endif()
 
 

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -158,8 +158,6 @@ target_link_libraries(viamsdk
   PRIVATE Threads::Threads
 )
 
-# Build api as a system library so we Wall/Werror don't cause unsolvable compilation failures
-target_include_directories(viamapi SYSTEM INTERFACE)
 
 # Set compile and link options based on arguments
 if (VIAMCPPSDK_USE_WALL_WERROR)

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -158,6 +158,18 @@ target_link_libraries(viamsdk
   PRIVATE Threads::Threads
 )
 
+# Build api as a system library so we Wall/Werror don't cause unsolvable compilation failures
+target_include_directories(viamapi SYSTEM INTERFACE)
+
+# Set compile and link options based on arguments
+if (VIAMCPPSDK_USE_WALL_WERROR)
+  target_compile_options(viamsdk PRIVATE -Wall -Werror)
+endif()
+if (VIAMCPPSDK_SANITIZED_BUILD)
+  target_link_options(viamsdk PRIVATE -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -fno-sanitize-recover)
+  target_compile_options(viamsdk PRIVATE -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -fno-sanitize-recover)
+endif()
+
 
 install(
   TARGETS viamsdk

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -19,6 +19,17 @@ target_include_directories(viamsdk
     "$<BUILD_INTERFACE:$<TARGET_PROPERTY:viam-cpp-sdk::viamapi,INTERFACE_INCLUDE_DIRECTORIES>>"
 )
 
+
+# Set compile and link options based on arguments
+if (VIAMCPPSDK_USE_WALL_WERROR)
+  target_compile_options(viamsdk PRIVATE -Wall -Werror)
+endif()
+if (VIAMCPPSDK_SANITIZED_BUILD)
+  target_link_options(viamsdk PRIVATE -fsanitize=undefined -fno-omit-frame-pointer -fno-sanitize-recover)
+  target_compile_options(viamsdk PRIVATE -fsanitize=undefined -fno-omit-frame-pointer -fno-sanitize-recover)
+endif()
+
+
 target_sources(viamsdk
   PRIVATE
     # TODO(RSDK-1742): we have to put `registry` up top here because we need the
@@ -157,16 +168,6 @@ target_link_libraries(viamsdk
   PRIVATE viam_rust_utils
   PRIVATE Threads::Threads
 )
-
-
-# Set compile and link options based on arguments
-if (VIAMCPPSDK_USE_WALL_WERROR)
-  target_compile_options(viamsdk PRIVATE -Wall -Werror)
-endif()
-if (VIAMCPPSDK_SANITIZED_BUILD)
-  target_link_options(viamsdk PRIVATE -fsanitize=undefined -fno-omit-frame-pointer -fno-sanitize-recover)
-  target_compile_options(viamsdk PRIVATE -fsanitize=undefined -fno-omit-frame-pointer -fno-sanitize-recover)
-endif()
 
 
 install(

--- a/src/viam/sdk/common/proto_type.cpp
+++ b/src/viam/sdk/common/proto_type.cpp
@@ -47,7 +47,8 @@ ProtoType ProtoType::of_value(Value value) {
             return ProtoType(map);
         }
         case Value::KindCase::KIND_NOT_SET:
-        case Value::KindCase::kNullValue: {
+        case Value::KindCase::kNullValue:
+        default: {
             return ProtoType();
         }
     }
@@ -84,8 +85,7 @@ Value ProtoType::proto_value() {
     Value v;
     switch (proto_type.which()) {
         case 0: {
-            ::google::protobuf::NullValue value;
-            v.set_null_value(value);
+            v.set_null_value(::google::protobuf::NULL_VALUE);
             break;
         }
         case 1: {

--- a/src/viam/sdk/components/camera/camera.cpp
+++ b/src/viam/sdk/components/camera/camera.cpp
@@ -14,6 +14,8 @@
 namespace viam {
 namespace sdk {
 
+CameraSubtype::~CameraSubtype() = default;
+
 std::shared_ptr<ResourceServerBase> CameraSubtype::create_resource_server(
     std::shared_ptr<SubtypeService> svc) {
     return std::make_shared<CameraServer>(svc);

--- a/src/viam/sdk/components/camera/camera.cpp
+++ b/src/viam/sdk/components/camera/camera.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<ResourceSubtype> Camera::resource_subtype() {
     const google::protobuf::DescriptorPool* p = google::protobuf::DescriptorPool::generated_pool();
     const google::protobuf::ServiceDescriptor* sd =
         p->FindServiceByName(viam::component::camera::v1::CameraService::service_full_name());
-    if (sd == nullptr) {
+    if (!sd) {
         throw std::runtime_error("Unable to get service descriptor for the camera service");
     }
     return std::make_shared<CameraSubtype>(sd);

--- a/src/viam/sdk/components/camera/camera.hpp
+++ b/src/viam/sdk/components/camera/camera.hpp
@@ -25,6 +25,7 @@ namespace sdk {
 /// @ingroup Camera
 class CameraSubtype : public ResourceSubtype {
    public:
+    virtual ~CameraSubtype() = default;
     std::shared_ptr<ResourceServerBase> create_resource_server(
         std::shared_ptr<SubtypeService> svc) override;
     std::shared_ptr<ResourceBase> create_rpc_client(std::string name,

--- a/src/viam/sdk/components/camera/camera.hpp
+++ b/src/viam/sdk/components/camera/camera.hpp
@@ -25,7 +25,7 @@ namespace sdk {
 /// @ingroup Camera
 class CameraSubtype : public ResourceSubtype {
    public:
-    virtual ~CameraSubtype() = default;
+    virtual ~CameraSubtype();
     std::shared_ptr<ResourceServerBase> create_resource_server(
         std::shared_ptr<SubtypeService> svc) override;
     std::shared_ptr<ResourceBase> create_rpc_client(std::string name,

--- a/src/viam/sdk/components/camera/client.cpp
+++ b/src/viam/sdk/components/camera/client.cpp
@@ -16,6 +16,7 @@
 namespace viam {
 namespace sdk {
 
+CameraClient::~CameraClient() = default;
 std::string normalize_mime_type(const std::string& str) {
     std::string mime_type = str;
     if (str.size() >= Camera::lazy_suffix.size() &&

--- a/src/viam/sdk/components/camera/client.hpp
+++ b/src/viam/sdk/components/camera/client.hpp
@@ -20,6 +20,7 @@ namespace sdk {
 /// @ingroup Camera
 class CameraClient : public Camera {
    public:
+    virtual ~CameraClient() = default;
     AttributeMap do_command(AttributeMap command) override;
     raw_image get_image(std::string mime_type) override;
     point_cloud get_point_cloud(std::string mime_type) override;

--- a/src/viam/sdk/components/camera/client.hpp
+++ b/src/viam/sdk/components/camera/client.hpp
@@ -20,7 +20,7 @@ namespace sdk {
 /// @ingroup Camera
 class CameraClient : public Camera {
    public:
-    virtual ~CameraClient() = default;
+    virtual ~CameraClient();
     AttributeMap do_command(AttributeMap command) override;
     raw_image get_image(std::string mime_type) override;
     point_cloud get_point_cloud(std::string mime_type) override;

--- a/src/viam/sdk/components/camera/server.cpp
+++ b/src/viam/sdk/components/camera/server.cpp
@@ -11,13 +11,13 @@ namespace sdk {
 ::grpc::Status CameraServer::DoCommand(::grpc::ServerContext* context,
                                        const ::viam::common::v1::DoCommandRequest* request,
                                        ::viam::common::v1::DoCommandResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [DoCommand] without a request");
     };
 
     std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
-    if (rb == nullptr) {
+    if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
 
@@ -32,13 +32,13 @@ namespace sdk {
 ::grpc::Status CameraServer::GetImage(::grpc::ServerContext* context,
                                       const ::viam::component::camera::v1::GetImageRequest* request,
                                       ::viam::component::camera::v1::GetImageResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [GetImage] without a request");
     };
 
     std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
-    if (rb == nullptr) {
+    if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
 
@@ -58,13 +58,13 @@ namespace sdk {
     ::grpc::ServerContext* context,
     const ::viam::component::camera::v1::RenderFrameRequest* request,
     ::google::api::HttpBody* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [RenderFrame] without a request");
     };
 
     std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
-    if (rb == nullptr) {
+    if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
 
@@ -82,14 +82,14 @@ namespace sdk {
     ::grpc::ServerContext* context,
     const ::viam::component::camera::v1::GetPointCloudRequest* request,
     ::viam::component::camera::v1::GetPointCloudResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [GetPointCloud] without a request");
     };
 
     std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
 
-    if (rb == nullptr) {
+    if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
 
@@ -107,13 +107,13 @@ namespace sdk {
     ::grpc::ServerContext* context,
     const ::viam::component::camera::v1::GetPropertiesRequest* request,
     ::viam::component::camera::v1::GetPropertiesResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [GetProperties] without a request");
     };
 
     std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
-    if (rb == nullptr) {
+    if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
 
@@ -129,9 +129,7 @@ namespace sdk {
 }
 
 void CameraServer::register_server(std::shared_ptr<Server> server) {
-    viam::component::camera::v1::CameraService::Service* camera =
-        static_cast<viam::component::camera::v1::CameraService::Service*>(this);
-    server->register_service(camera);
+    server->register_service(this);
 }
 
 std::shared_ptr<SubtypeService> CameraServer::get_sub_svc() {

--- a/src/viam/sdk/components/generic/client.cpp
+++ b/src/viam/sdk/components/generic/client.cpp
@@ -12,6 +12,7 @@
 namespace viam {
 namespace sdk {
 
+GenericClient::~GenericClient() = default;
 AttributeMap GenericClient::do_command(AttributeMap command) {
     viam::common::v1::DoCommandRequest req;
     viam::common::v1::DoCommandResponse resp;

--- a/src/viam/sdk/components/generic/client.hpp
+++ b/src/viam/sdk/components/generic/client.hpp
@@ -18,7 +18,7 @@ namespace sdk {
 /// @ingroup Generic
 class GenericClient : public Generic {
    public:
-    virtual ~GenericClient() = default;
+    virtual ~GenericClient();
     AttributeMap do_command(AttributeMap command) override;
     GenericClient(std::string name, std::shared_ptr<grpc::Channel> channel)
         : Generic(std::move(name)),

--- a/src/viam/sdk/components/generic/client.hpp
+++ b/src/viam/sdk/components/generic/client.hpp
@@ -34,8 +34,8 @@ class GenericClient : public Generic {
         : Generic(std::move(name)), stub_(std::move(stub)){};
 
    private:
-    std::unique_ptr<viam::component::generic::v1::GenericService::StubInterface> stub_{};
-    std::shared_ptr<grpc::Channel> channel_{};
+    std::unique_ptr<viam::component::generic::v1::GenericService::StubInterface> stub_;
+    std::shared_ptr<grpc::Channel> channel_;
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/generic/client.hpp
+++ b/src/viam/sdk/components/generic/client.hpp
@@ -18,6 +18,7 @@ namespace sdk {
 /// @ingroup Generic
 class GenericClient : public Generic {
    public:
+    virtual ~GenericClient() = default;
     AttributeMap do_command(AttributeMap command) override;
     GenericClient(std::string name, std::shared_ptr<grpc::Channel> channel)
         : Generic(std::move(name)),
@@ -33,8 +34,8 @@ class GenericClient : public Generic {
         : Generic(std::move(name)), stub_(std::move(stub)){};
 
    private:
-    std::unique_ptr<viam::component::generic::v1::GenericService::StubInterface> stub_;
-    std::shared_ptr<grpc::Channel> channel_;
+    std::unique_ptr<viam::component::generic::v1::GenericService::StubInterface> stub_{};
+    std::shared_ptr<grpc::Channel> channel_{};
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/generic/generic.cpp
+++ b/src/viam/sdk/components/generic/generic.cpp
@@ -15,6 +15,8 @@
 namespace viam {
 namespace sdk {
 
+GenericSubtype::~GenericSubtype() = default;
+
 std::shared_ptr<ResourceServerBase> GenericSubtype::create_resource_server(
     std::shared_ptr<SubtypeService> svc) {
     return std::make_shared<GenericServer>(svc);

--- a/src/viam/sdk/components/generic/generic.cpp
+++ b/src/viam/sdk/components/generic/generic.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<ResourceSubtype> Generic::resource_subtype() {
     const google::protobuf::DescriptorPool* p = google::protobuf::DescriptorPool::generated_pool();
     const google::protobuf::ServiceDescriptor* sd =
         p->FindServiceByName(viam::component::generic::v1::GenericService::service_full_name());
-    if (sd == nullptr) {
+    if (!sd) {
         throw std::runtime_error("Unable to get service descriptor for the generic service");
     }
     return std::make_shared<GenericSubtype>(sd);

--- a/src/viam/sdk/components/generic/generic.hpp
+++ b/src/viam/sdk/components/generic/generic.hpp
@@ -22,7 +22,7 @@ namespace sdk {
 /// @ingroup Generic
 class GenericSubtype : public ResourceSubtype {
    public:
-    virtual ~GenericSubtype() = default;
+    virtual ~GenericSubtype();
     std::shared_ptr<ResourceServerBase> create_resource_server(
         std::shared_ptr<SubtypeService> svc) override;
     std::shared_ptr<ResourceBase> create_rpc_client(std::string name,

--- a/src/viam/sdk/components/generic/generic.hpp
+++ b/src/viam/sdk/components/generic/generic.hpp
@@ -22,6 +22,7 @@ namespace sdk {
 /// @ingroup Generic
 class GenericSubtype : public ResourceSubtype {
    public:
+    virtual ~GenericSubtype() = default;
     std::shared_ptr<ResourceServerBase> create_resource_server(
         std::shared_ptr<SubtypeService> svc) override;
     std::shared_ptr<ResourceBase> create_rpc_client(std::string name,

--- a/src/viam/sdk/components/generic/server.cpp
+++ b/src/viam/sdk/components/generic/server.cpp
@@ -9,13 +9,13 @@ namespace sdk {
 ::grpc::Status GenericServer::DoCommand(::grpc::ServerContext* context,
                                         const ::viam::common::v1::DoCommandRequest* request,
                                         ::viam::common::v1::DoCommandResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [DoCommand] without a request");
     };
 
     std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
-    if (rb == nullptr) {
+    if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
 
@@ -28,13 +28,7 @@ namespace sdk {
 }
 
 void GenericServer::register_server(std::shared_ptr<Server> server) {
-    viam::component::generic::v1::GenericService::Service* generic =
-        static_cast<viam::component::generic::v1::GenericService::Service*>(this);
-    try {
-        server->register_service(generic);
-    } catch (std::exception& exc) {
-        throw exc;
-    }
+    server->register_service(this);
 }
 
 std::shared_ptr<SubtypeService> GenericServer::get_sub_svc() {

--- a/src/viam/sdk/components/motor/client.cpp
+++ b/src/viam/sdk/components/motor/client.cpp
@@ -17,6 +17,8 @@
 namespace viam {
 namespace sdk {
 
+MotorClient::~MotorClient() = default;
+
 void MotorClient::set_power(double power_pct) {
     viam::component::motor::v1::SetPowerRequest request;
     viam::component::motor::v1::SetPowerResponse response;

--- a/src/viam/sdk/components/motor/client.hpp
+++ b/src/viam/sdk/components/motor/client.hpp
@@ -20,7 +20,7 @@ namespace sdk {
 /// @ingroup Motor
 class MotorClient : public Motor {
    public:
-    virtual ~MotorClient() = default;
+    virtual ~MotorClient();
     void set_power(double power_pct) override;
     void go_for(double rpm, double revolutions) override;
     void go_to(double rpm, double position_revolutions) override;

--- a/src/viam/sdk/components/motor/client.hpp
+++ b/src/viam/sdk/components/motor/client.hpp
@@ -20,6 +20,7 @@ namespace sdk {
 /// @ingroup Motor
 class MotorClient : public Motor {
    public:
+    virtual ~MotorClient() = default;
     void set_power(double power_pct) override;
     void go_for(double rpm, double revolutions) override;
     void go_to(double rpm, double position_revolutions) override;

--- a/src/viam/sdk/components/motor/motor.cpp
+++ b/src/viam/sdk/components/motor/motor.cpp
@@ -14,6 +14,7 @@
 namespace viam {
 namespace sdk {
 
+MotorSubtype::~MotorSubtype() = default;
 std::shared_ptr<ResourceServerBase> MotorSubtype::create_resource_server(
     std::shared_ptr<SubtypeService> svc) {
     return std::make_shared<MotorServer>(svc);

--- a/src/viam/sdk/components/motor/motor.hpp
+++ b/src/viam/sdk/components/motor/motor.hpp
@@ -23,6 +23,7 @@ namespace sdk {
 /// @ingroup Motor
 class MotorSubtype : public ResourceSubtype {
    public:
+    virtual ~MotorSubtype() = default;
     std::shared_ptr<ResourceServerBase> create_resource_server(
         std::shared_ptr<SubtypeService> svc) override;
     std::shared_ptr<ResourceBase> create_rpc_client(std::string name,

--- a/src/viam/sdk/components/motor/motor.hpp
+++ b/src/viam/sdk/components/motor/motor.hpp
@@ -23,7 +23,7 @@ namespace sdk {
 /// @ingroup Motor
 class MotorSubtype : public ResourceSubtype {
    public:
-    virtual ~MotorSubtype() = default;
+    virtual ~MotorSubtype();
     std::shared_ptr<ResourceServerBase> create_resource_server(
         std::shared_ptr<SubtypeService> svc) override;
     std::shared_ptr<ResourceBase> create_rpc_client(std::string name,

--- a/src/viam/sdk/config/resource.hpp
+++ b/src/viam/sdk/config/resource.hpp
@@ -24,12 +24,12 @@ class ResourceLevelServiceConfig {
 
 class Resource {
    public:
+    Subtype api;
+    LinkConfig frame;
+    Model model;
     std::string name;
     std::string namespace_;
     std::string type;
-    Subtype api;
-    Model model;
-    LinkConfig frame;
     std::vector<std::string> depends_on;
     std::vector<ResourceLevelServiceConfig> service_config;
     AttributeMap attributes;

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -54,7 +54,7 @@ Dependencies get_dependencies(ModuleService_* m,
 }  // namespace
    //
 std::shared_ptr<ResourceBase> ModuleService_::get_parent_resource(Name name) {
-    if (parent == nullptr) {
+    if (!parent) {
         parent = RobotClient::at_local_socket(parent_addr, {0, boost::none});
     }
 
@@ -72,7 +72,7 @@ std::shared_ptr<ResourceBase> ModuleService_::get_parent_resource(Name name) {
     std::shared_ptr<ResourceBase> res;
     Dependencies deps = get_dependencies(this, request->dependencies());
     std::shared_ptr<ModelRegistration> reg = Registry::lookup_resource(cfg.api, cfg.model);
-    if (reg != nullptr) {
+    if (reg) {
         res = reg->construct_resource(deps, cfg);
     };
     if (module->services.find(cfg.api) == module->services.end()) {
@@ -104,7 +104,7 @@ std::shared_ptr<ResourceBase> ModuleService_::get_parent_resource(Name name) {
 
     // see if our resource is reconfigurable. if it is, reconfigure
     std::shared_ptr<ResourceBase> res = sub_svc->resource(cfg.resource_name().name);
-    if (res == nullptr) {
+    if (!res) {
         return grpc::Status(
             grpc::UNKNOWN,
             "unable to reconfigure resource " + cfg.resource_name().name + " as it doesn't exist.");
@@ -123,7 +123,7 @@ std::shared_ptr<ResourceBase> ModuleService_::get_parent_resource(Name name) {
     }
 
     std::shared_ptr<ModelRegistration> reg = Registry::lookup_resource(cfg.name);
-    if (reg != nullptr) {
+    if (reg) {
         std::shared_ptr<ResourceBase> res = reg->construct_resource(deps, cfg);
         sub_svc->replace_one(cfg.resource_name(), res);
     }
@@ -139,7 +139,7 @@ std::shared_ptr<ResourceBase> ModuleService_::get_parent_resource(Name name) {
     Resource cfg = Resource::from_proto(proto);
 
     std::shared_ptr<ModelRegistration> reg = Registry::lookup_resource(cfg.api, cfg.model);
-    if (reg == nullptr) {
+    if (!reg) {
         return grpc::Status(grpc::UNKNOWN,
                             "unable to validate resource " + cfg.resource_name().name +
                                 " as it hasn't been registered.");
@@ -168,7 +168,7 @@ std::shared_ptr<ResourceBase> ModuleService_::get_parent_resource(Name name) {
     }
     std::shared_ptr<SubtypeService> svc = m->services.at(*name.to_subtype());
     std::shared_ptr<ResourceBase> res = svc->resource(name.name);
-    if (res == nullptr) {
+    if (!res) {
         return grpc::Status(
             grpc::UNKNOWN,
             "unable to remove resource " + name.to_string() + " as it doesn't exist.");
@@ -223,7 +223,7 @@ ModuleService_::~ModuleService_() {
 void ModuleService_::close() {
     BOOST_LOG_TRIVIAL(info) << "Shutting down gracefully.";
 
-    if (parent != nullptr) {
+    if (parent) {
         try {
             parent->close();
         } catch (std::exception& exc) {
@@ -256,8 +256,8 @@ void ModuleService_::add_model_from_registry(std::shared_ptr<Server> server,
 
     std::shared_ptr<ResourceSubtype> creator = Registry::lookup_subtype(api);
     std::string name;
-    const google::protobuf::ServiceDescriptor* sd;
-    if (creator != nullptr && creator->service_descriptor != nullptr) {
+    const google::protobuf::ServiceDescriptor* sd = nullptr;
+    if (creator && creator->service_descriptor) {
         name = creator->service_descriptor->full_name();
         sd = creator->service_descriptor;
     }

--- a/src/viam/sdk/registry/registry.cpp
+++ b/src/viam/sdk/registry/registry.cpp
@@ -77,31 +77,7 @@ Registry::registered_resources() {
 
 Status ModelRegistration::create_status(std::shared_ptr<ResourceBase> resource) {
     Status status;
-    ResourceName* name;
-    if (resource->type().to_string() == COMPONENT) {
-        try {
-            std::shared_ptr<ComponentBase> cb = std::dynamic_pointer_cast<ComponentBase>(resource);
-            ResourceName rn = cb->get_resource_name(resource->name());
-            name = &rn;
-        } catch (std::exception& exc) {
-            BOOST_LOG_TRIVIAL(debug)
-                << "Unable to get resource name from resource base " << resource->name();
-        }
-    } else if (resource->type().to_string() == SERVICE) {
-        try {
-            std::shared_ptr<ServiceBase> sb = std::dynamic_pointer_cast<ServiceBase>(resource);
-            ResourceName rn = sb->get_resource_name(resource->name());
-            name = &rn;
-        } catch (std::exception& exc) {
-            BOOST_LOG_TRIVIAL(debug)
-                << "Unable to get resource name from resource base " << resource->name();
-        };
-    } else {
-        throw "unable to create status; provided resource was of an unknown "
-          "type: " +
-        resource->type().to_string();
-    }
-    *status.mutable_name() = *name;
+    *status.mutable_name() = resource->get_resource_name(resource->name());
     *status.mutable_status() = google::protobuf::Struct();
     return status;
 }

--- a/src/viam/sdk/registry/registry.hpp
+++ b/src/viam/sdk/registry/registry.hpp
@@ -66,9 +66,9 @@ class ModelRegistration {
         Subtype subtype,
         Model model,
         std::function<std::shared_ptr<ResourceBase>(Dependencies, Resource)> constructor)
-        : subtype(std::move(subtype)),
+        : model(std::move(model)),
           resource_type(std::move(rt)),
-          model(std::move(model)),
+          subtype(std::move(subtype)),
           construct_resource(std::move(constructor)),
           validate(default_validator){};
     ModelRegistration(
@@ -77,14 +77,14 @@ class ModelRegistration {
         Model model,
         std::function<std::shared_ptr<ResourceBase>(Dependencies, Resource)> constructor,
         std::function<std::vector<std::string>(Resource)> validator)
-        : subtype(std::move(subtype)),
+        : model(std::move(model)),
           resource_type(std::move(rt)),
-          model(std::move(model)),
+          subtype(std::move(subtype)),
           construct_resource(std::move(constructor)),
           validate(std::move(validator)){};
-    Subtype subtype;
     Model model;
     ResourceType resource_type;
+    Subtype subtype;
 
     /// @brief Constructs a resource from a map of dependencies and a resource config.
     std::function<std::shared_ptr<ResourceBase>(Dependencies, Resource)> construct_resource;

--- a/src/viam/sdk/resource/resource.cpp
+++ b/src/viam/sdk/resource/resource.cpp
@@ -80,7 +80,7 @@ std::string Name::to_string() const {
 }
 
 std::string Name::short_name() const {
-    if (remote_name == "") {
+    if (remote_name != "") {
         return remote_name + ":" + name;
     }
     return name;
@@ -144,10 +144,12 @@ bool operator==(const Model& lhs, const Model& rhs) {
 RPCSubtype::RPCSubtype(Subtype subtype,
                        std::string proto_service_name,
                        const google::protobuf::ServiceDescriptor& descriptor)
-    : subtype(subtype), descriptor(&descriptor), proto_service_name(proto_service_name) {}
+    : descriptor(std::move(&descriptor)),
+      proto_service_name(std::move(proto_service_name)),
+      subtype(std::move(subtype)) {}
 
 RPCSubtype::RPCSubtype(Subtype subtype, const google::protobuf::ServiceDescriptor& descriptor)
-    : subtype(subtype), descriptor(&descriptor) {}
+    : descriptor(std::move(&descriptor)), subtype(std::move(subtype)) {}
 
 ModelFamily::ModelFamily(std::string namespace_, std::string family)
     : namespace_(namespace_), family(family) {}

--- a/src/viam/sdk/resource/resource.hpp
+++ b/src/viam/sdk/resource/resource.hpp
@@ -61,9 +61,9 @@ class Name : public Subtype {
 
 class RPCSubtype {
    public:
-    Subtype subtype;
-    std::string proto_service_name;
     const google::protobuf::ServiceDescriptor* descriptor;
+    std::string proto_service_name;
+    Subtype subtype;
 
     bool operator<(const RPCSubtype& rhs) const {
         return (subtype.to_string() + proto_service_name + descriptor->DebugString()) <

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -190,7 +190,7 @@ void RobotClient::refresh() {
     }
     bool is_equal = current_resources.size() == resource_names_.size();
     if (is_equal) {
-        for (long unsigned int i = 0; i < resource_names_.size(); ++i) {
+        for (size_t i = 0; i < resource_names_.size(); ++i) {
             if (!ResourceNameEqual::check_equal(resource_names_.at(i), current_resources.at(i))) {
                 is_equal = false;
                 break;

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -69,7 +69,8 @@ void RobotClient::close() {
         t->~thread();
     }
     stop_all();
-    viam_channel.close();
+    viam_channel->close();
+    viam_channel = nullptr;
 }
 
 bool is_error_response(grpc::Status response) {
@@ -160,7 +161,6 @@ void RobotClient::refresh() {
     ResourceManager new_resource_manager;
     RepeatedPtrField<ResourceName> resources = resp.resources();
 
-    const int num_resources = resources.size();
     std::vector<ResourceName> current_resources;
 
     for (auto& name : resources) {
@@ -177,8 +177,8 @@ void RobotClient::refresh() {
         // are being properly registered from name.subtype(), or update what we're
         // using for lookup
         std::shared_ptr<ResourceSubtype> rs =
-            Registry::lookup_subtype(Subtype({name.namespace_(), name.type(), name.subtype()}));
-        if (rs != nullptr) {
+            Registry::lookup_subtype({name.namespace_(), name.type(), name.subtype()});
+        if (rs) {
             try {
                 std::shared_ptr<ResourceBase> rpc_client =
                     rs->create_rpc_client(name.name(), channel);
@@ -191,7 +191,7 @@ void RobotClient::refresh() {
     }
     bool is_equal = current_resources.size() == resource_names_.size();
     if (is_equal) {
-        for (int i = 0; i < current_resources.size(); ++i) {
+        for (long unsigned int i = 0; i < resource_names_.size(); ++i) {
             if (!ResourceNameEqual::check_equal(resource_names_.at(i), current_resources.at(i))) {
                 is_equal = false;
                 break;
@@ -220,11 +220,11 @@ void RobotClient::refresh_every() {
     }
 };
 
-RobotClient::RobotClient(ViamChannel vc) : viam_channel(vc) {
-    should_close_channel = false;
-    stub_ = std::move(RobotService::NewStub(vc.channel));
-    channel = vc.channel;
-}
+RobotClient::RobotClient(std::shared_ptr<ViamChannel> vc)
+    : viam_channel(vc),
+      channel(vc->channel),
+      should_close_channel(false),
+      stub_(RobotService::NewStub(channel)) {}
 
 std::vector<ResourceName>* RobotClient::resource_names() {
     lock.lock();
@@ -233,7 +233,8 @@ std::vector<ResourceName>* RobotClient::resource_names() {
     return resources;
 }
 
-std::shared_ptr<RobotClient> RobotClient::with_channel(ViamChannel channel, Options options) {
+std::shared_ptr<RobotClient> RobotClient::with_channel(std::shared_ptr<ViamChannel> channel,
+                                                       Options options) {
     std::shared_ptr<RobotClient> robot = std::make_shared<RobotClient>(channel);
     robot->refresh_interval = options.refresh_interval;
     robot->should_refresh = (robot->refresh_interval > 0);
@@ -253,7 +254,7 @@ std::shared_ptr<RobotClient> RobotClient::with_channel(ViamChannel channel, Opti
 
 std::shared_ptr<RobotClient> RobotClient::at_address(std::string address, Options options) {
     const char* uri = address.c_str();
-    ViamChannel channel = ViamChannel::dial(uri, options.dial_options);
+    auto channel = ViamChannel::dial(uri, options.dial_options);
     std::shared_ptr<RobotClient> robot = RobotClient::with_channel(channel, options);
     robot->should_close_channel = true;
 
@@ -261,13 +262,13 @@ std::shared_ptr<RobotClient> RobotClient::at_address(std::string address, Option
 };
 
 std::shared_ptr<RobotClient> RobotClient::at_local_socket(std::string address, Options options) {
-    address = "unix://" + address;
-    const char* uri = address.c_str();
+    std::string addr = "unix://" + address;
+    const char* uri = addr.c_str();
     std::shared_ptr<grpc::Channel> channel =
         grpc::CreateChannel(uri, grpc::InsecureChannelCredentials());
     std::unique_ptr<viam::robot::v1::RobotService::Stub> st =
         viam::robot::v1::RobotService::NewStub(channel);
-    ViamChannel viam_channel = ViamChannel(channel, uri, nullptr);
+    auto viam_channel = std::make_shared<ViamChannel>(channel, address.c_str(), nullptr);
     std::shared_ptr<RobotClient> robot = RobotClient::with_channel(viam_channel, options);
     robot->should_close_channel = true;
 

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -70,7 +70,6 @@ void RobotClient::close() {
     }
     stop_all();
     viam_channel->close();
-    viam_channel = nullptr;
 }
 
 bool is_error_response(grpc::Status response) {

--- a/src/viam/sdk/robot/client.hpp
+++ b/src/viam/sdk/robot/client.hpp
@@ -64,10 +64,10 @@ class RobotClient {
     /// @param options Options for connecting and refreshing.
     /// Connects directly to a pre-existing channel. A robot created this way must be
     /// `close()`d manually.
-    static std::shared_ptr<RobotClient> with_channel(ViamChannel channel, Options options);
-    RobotClient(ViamChannel channel);
+    static std::shared_ptr<RobotClient> with_channel(std::shared_ptr<ViamChannel> channel,
+                                                     Options options);
+    RobotClient(std::shared_ptr<ViamChannel> channel);
     std::vector<ResourceName>* resource_names();
-    std::unique_ptr<RobotService::Stub> stub_;
 
     /// @brief Lookup and return a `shared_ptr` to a resource.
     /// @param name The `ResourceName` of the resource.
@@ -111,8 +111,8 @@ class RobotClient {
     /// @brief Get the status of the robot's components.
     /// @param components An optional list of the specific components for which status is desired.
     /// @return A list of statuses.
-    std::vector<Status> get_status(
-        std::vector<ResourceName> components = std::vector<ResourceName>());
+    std::vector<Status> get_status(std::vector<ResourceName> components = {});
+
     std::vector<viam::robot::v1::Discovery> discover_components(
         std::vector<viam::robot::v1::DiscoveryQuery> queries);
 
@@ -147,10 +147,10 @@ class RobotClient {
     std::vector<std::shared_ptr<std::thread>> threads_;
     std::atomic<bool> should_refresh;
     unsigned int refresh_interval;
-    // (RSDK-919): make use of should_close_channel
-    bool should_close_channel;
+    std::shared_ptr<ViamChannel> viam_channel;
     std::shared_ptr<Channel> channel;
-    ViamChannel viam_channel;
+    bool should_close_channel;
+    std::unique_ptr<RobotService::Stub> stub_;
     std::mutex lock;
     std::vector<ResourceName> resource_names_;
     ResourceManager resource_manager;

--- a/src/viam/sdk/robot/service.cpp
+++ b/src/viam/sdk/robot/service.cpp
@@ -81,7 +81,7 @@ std::vector<Status> RobotService_::generate_status(RepeatedPtrField<ResourceName
 ::grpc::Status RobotService_::ResourceNames(::grpc::ServerContext* context,
                                             const viam::robot::v1::ResourceNamesRequest* request,
                                             viam::robot::v1::ResourceNamesResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [ResourceNames] without a request");
     };
@@ -96,7 +96,7 @@ std::vector<Status> RobotService_::generate_status(RepeatedPtrField<ResourceName
 ::grpc::Status RobotService_::GetStatus(::grpc::ServerContext* context,
                                         const ::viam::robot::v1::GetStatusRequest* request,
                                         ::viam::robot::v1::GetStatusResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [GetStatus] without a request");
     };
@@ -116,14 +116,13 @@ void RobotService_::stream_status(
     int interval) {
     while (true) {
         std::vector<Status> statuses = generate_status(request->resource_names());
-        viam::robot::v1::StreamStatusResponse* response;
-        RepeatedPtrField<Status>* response_status = response->mutable_status();
+        viam::robot::v1::StreamStatusResponse response;
+        RepeatedPtrField<Status>* response_status = response.mutable_status();
         for (Status status : statuses) {
             *response_status->Add() = status;
         }
 
-        const viam::robot::v1::StreamStatusResponse* resp = response;
-        writer->Write(*resp);
+        writer->Write(response);
         std::this_thread::sleep_for(std::chrono::seconds(interval));
     }
 }

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -31,7 +31,8 @@ void ViamChannel::close() {
 ViamChannel::ViamChannel(std::shared_ptr<grpc::Channel> channel, const char* path, void* runtime)
     : channel(channel), path(path), closed(false), rust_runtime(runtime) {}
 
-ViamChannel ViamChannel::dial(const char* uri, boost::optional<DialOptions> options) {
+std::shared_ptr<ViamChannel> ViamChannel::dial(const char* uri,
+                                               boost::optional<DialOptions> options) {
     void* ptr = init_rust_runtime();
     DialOptions opts = options.get_value_or(DialOptions());
     const char* payload = nullptr;
@@ -53,9 +54,7 @@ ViamChannel ViamChannel::dial(const char* uri, boost::optional<DialOptions> opti
         grpc::CreateChannel(address, grpc::InsecureChannelCredentials());
     std::unique_ptr<viam::robot::v1::RobotService::Stub> st =
         viam::robot::v1::RobotService::NewStub(channel);
-    const char* path = address.c_str();
-    ViamChannel viam_channel = ViamChannel(channel, path, ptr);
-    return viam_channel;
+    return std::make_shared<ViamChannel>(channel, socket_path, ptr);
 };
 
 Credentials::Credentials(std::string payload_) {

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -15,7 +15,7 @@ class ViamChannel {
     std::shared_ptr<grpc::Channel> channel;
     void close();
     ViamChannel(std::shared_ptr<grpc::Channel> channel, const char* path, void* runtime);
-    static ViamChannel dial(const char* uri, boost::optional<DialOptions> options);
+    static std::shared_ptr<ViamChannel> dial(const char* uri, boost::optional<DialOptions> options);
 
    private:
     const char* path;

--- a/src/viam/sdk/rpc/server.cpp
+++ b/src/viam/sdk/rpc/server.cpp
@@ -26,7 +26,7 @@ void Server::start() {
     }
 
     grpc::reflection::InitProtoReflectionServerBuilderPlugin();
-    server_ = std::move(builder_->BuildAndStart());
+    server_ = builder_->BuildAndStart();
     builder_ = nullptr;
 }
 

--- a/src/viam/sdk/spatialmath/geometry.cpp
+++ b/src/viam/sdk/spatialmath/geometry.cpp
@@ -31,9 +31,9 @@ viam::common::v1::Pose GeometryConfig::pose_proto() {
     pose.set_x(x);
     pose.set_y(y);
     pose.set_z(z);
-    pose.set_o_x(0);
-    pose.set_o_y(0);
-    pose.set_o_z(1);
+    pose.set_o_x(o_x);
+    pose.set_o_y(o_y);
+    pose.set_o_z(o_z);
     pose.set_theta(0);
     return pose;
 }
@@ -84,7 +84,8 @@ viam::common::v1::Geometry GeometryConfig::to_proto() {
 
             return geometry_;
         }
-        case unknown: {
+        case unknown:
+        default: {
             if (x == 0 && y == 0 && z == 0) {
                 *geometry_.mutable_box() = box_proto();
             } else {

--- a/src/viam/sdk/spatialmath/orientation.cpp
+++ b/src/viam/sdk/spatialmath/orientation.cpp
@@ -76,8 +76,11 @@ OrientationConfig OrientationConfig::from_proto(proto::Orientation proto) {
             quat.x = 0;
             quat.y = 0;
             quat.z = 0;
+            cfg.orientation_ = quat;
+            break;
         }
-        case proto::Orientation::TypeCase::TYPE_NOT_SET: {
+        case proto::Orientation::TypeCase::TYPE_NOT_SET:
+        default: {
             throw "orientation type not known";
         }
     }
@@ -135,6 +138,9 @@ proto::Orientation OrientationConfig::to_proto() {
             quat.set_z(q.z);
             orientation.set_allocated_quaternion(&quat);
             return orientation;
+        }
+        default: {
+            throw std::runtime_error("orientation type not known");
         }
     }
 }

--- a/src/viam/sdk/spatialmath/orientation.cpp
+++ b/src/viam/sdk/spatialmath/orientation.cpp
@@ -142,9 +142,6 @@ proto::Orientation OrientationConfig::to_proto() {
         default: {
             throw std::runtime_error("orientation type not known");
         }
-        default: {
-            throw std::runtime_error("orientation type not known");
-        }
     }
 }
 

--- a/src/viam/sdk/tests/mocks/camera_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.cpp
@@ -74,6 +74,8 @@ std::shared_ptr<MockCamera> MockCamera::get_mock_camera() {
     camera->image = fake_raw_image();
     camera->pc = fake_point_cloud();
     camera->camera_properties = fake_properties();
+    camera->intrinsic_parameters = fake_intrinsic_parameters();
+    camera->distortion_parameters = fake_distortion_parameters();
     camera->map = fake_map();
 
     return camera;
@@ -87,35 +89,35 @@ MockCameraStub::MockCameraStub() : server(std::make_shared<CameraServer>()) {
     ::grpc::ClientContext* context,
     const ::viam::component::camera::v1::GetImageRequest& request,
     ::viam::component::camera::v1::GetImageResponse* response) {
-    grpc::ServerContext* ctx;
-    return server->GetImage(ctx, &request, response);
+    grpc::ServerContext ctx;
+    return server->GetImage(&ctx, &request, response);
 }
 ::grpc::Status MockCameraStub::RenderFrame(
     ::grpc::ClientContext* context,
     const ::viam::component::camera::v1::RenderFrameRequest& request,
     ::google::api::HttpBody* response) {
-    grpc::ServerContext* ctx;
-    return server->RenderFrame(ctx, &request, response);
+    grpc::ServerContext ctx;
+    return server->RenderFrame(&ctx, &request, response);
 }
 ::grpc::Status MockCameraStub::GetPointCloud(
     ::grpc::ClientContext* context,
     const ::viam::component::camera::v1::GetPointCloudRequest& request,
     ::viam::component::camera::v1::GetPointCloudResponse* response) {
-    grpc::ServerContext* ctx;
-    return server->GetPointCloud(ctx, &request, response);
+    grpc::ServerContext ctx;
+    return server->GetPointCloud(&ctx, &request, response);
 }
 ::grpc::Status MockCameraStub::GetProperties(
     ::grpc::ClientContext* context,
     const ::viam::component::camera::v1::GetPropertiesRequest& request,
     ::viam::component::camera::v1::GetPropertiesResponse* response) {
-    grpc::ServerContext* ctx;
-    return server->GetProperties(ctx, &request, response);
+    grpc::ServerContext ctx;
+    return server->GetProperties(&ctx, &request, response);
 }
 ::grpc::Status MockCameraStub::DoCommand(::grpc::ClientContext* context,
                                          const ::viam::common::v1::DoCommandRequest& request,
                                          ::viam::common::v1::DoCommandResponse* response) {
-    grpc::ServerContext* ctx;
-    return server->DoCommand(ctx, &request, response);
+    grpc::ServerContext ctx;
+    return server->DoCommand(&ctx, &request, response);
 }
 
 }  // namespace camera

--- a/src/viam/sdk/tests/mocks/camera_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.cpp
@@ -14,6 +14,8 @@ namespace camera {
 
 using namespace viam::sdk;
 
+MockCamera::~MockCamera() = default;
+
 AttributeMap MockCamera::do_command(AttributeMap command) {
     return map;
 }

--- a/src/viam/sdk/tests/mocks/camera_mocks.hpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.hpp
@@ -16,6 +16,7 @@ using namespace viam::sdk;
 
 class MockCamera : public Camera {
    public:
+    virtual ~MockCamera() = default;
     AttributeMap do_command(AttributeMap command) override;
     raw_image get_image(std::string mime_type) override;
     point_cloud get_point_cloud(std::string mime_type) override;

--- a/src/viam/sdk/tests/mocks/camera_mocks.hpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.hpp
@@ -16,7 +16,7 @@ using namespace viam::sdk;
 
 class MockCamera : public Camera {
    public:
-    virtual ~MockCamera() = default;
+    virtual ~MockCamera();
     AttributeMap do_command(AttributeMap command) override;
     raw_image get_image(std::string mime_type) override;
     point_cloud get_point_cloud(std::string mime_type) override;

--- a/src/viam/sdk/tests/mocks/generic_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/generic_mocks.cpp
@@ -35,8 +35,8 @@ MockGenericStub::MockGenericStub() : server(std::make_shared<GenericServer>()) {
 ::grpc::Status MockGenericStub::DoCommand(::grpc::ClientContext* context,
                                           const ::viam::common::v1::DoCommandRequest& request,
                                           ::viam::common::v1::DoCommandResponse* response) {
-    grpc::ServerContext* ctx;
-    return server->DoCommand(ctx, &request, response);
+    grpc::ServerContext ctx;
+    return server->DoCommand(&ctx, &request, response);
 }
 
 }  // namespace generic

--- a/src/viam/sdk/tests/mocks/generic_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/generic_mocks.cpp
@@ -15,6 +15,8 @@ namespace generic {
 
 using namespace viam::sdk;
 
+MockGeneric::~MockGeneric() = default;
+
 std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>>
 MockGeneric::do_command(
     std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> command) {

--- a/src/viam/sdk/tests/mocks/generic_mocks.hpp
+++ b/src/viam/sdk/tests/mocks/generic_mocks.hpp
@@ -16,6 +16,7 @@ using namespace viam::sdk;
 
 class MockGeneric : public Generic {
    public:
+    virtual ~MockGeneric() = default;
     MockGeneric(std::string name) : Generic(std::move(name)){};
     std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> do_command(
         std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> command)

--- a/src/viam/sdk/tests/mocks/generic_mocks.hpp
+++ b/src/viam/sdk/tests/mocks/generic_mocks.hpp
@@ -16,7 +16,7 @@ using namespace viam::sdk;
 
 class MockGeneric : public Generic {
    public:
-    virtual ~MockGeneric() = default;
+    virtual ~MockGeneric();
     MockGeneric(std::string name) : Generic(std::move(name)){};
     std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> do_command(
         std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> command)

--- a/src/viam/sdk/tests/mocks/mock_motor.cpp
+++ b/src/viam/sdk/tests/mocks/mock_motor.cpp
@@ -16,6 +16,8 @@ namespace motor {
 
 using namespace viam::sdk;
 
+MockMotor::~MockMotor() = default;
+
 void MockMotor::set_power(double power_pct) {
     power_status.is_on = power_pct != 0.0;
     power_status.power_pct = power_pct;

--- a/src/viam/sdk/tests/mocks/mock_motor.hpp
+++ b/src/viam/sdk/tests/mocks/mock_motor.hpp
@@ -16,7 +16,7 @@ using viam::sdk::Motor;
 
 class MockMotor : public Motor {
    public:
-    virtual ~MockMotor() = default;
+    virtual ~MockMotor();
     void set_power(double power_pct) override;
     void go_for(double rpm, double revolutions) override;
     void go_to(double rpm, double position_revolutions) override;

--- a/src/viam/sdk/tests/mocks/mock_motor.hpp
+++ b/src/viam/sdk/tests/mocks/mock_motor.hpp
@@ -16,6 +16,7 @@ using viam::sdk::Motor;
 
 class MockMotor : public Motor {
    public:
+    virtual ~MockMotor() = default;
     void set_power(double power_pct) override;
     void go_for(double rpm, double revolutions) override;
     void go_to(double rpm, double position_revolutions) override;

--- a/src/viam/sdk/tests/test_camera.cpp
+++ b/src/viam/sdk/tests/test_camera.cpp
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(test_camera_client)
 
-MockCameraClient client = MockCameraClient("camera");
+MockCameraClient client("camera");
 
 BOOST_AUTO_TEST_CASE(test_image_client) {
     Camera::raw_image image = client.get_image("JPEG");

--- a/src/viam/sdk/tests/test_generic_component.cpp
+++ b/src/viam/sdk/tests/test_generic_component.cpp
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(test_do_service) {
 }
 
 BOOST_AUTO_TEST_CASE(test_do_client) {
-    MockGenericClient client = MockGenericClient("generic");
+    MockGenericClient client("generic");
 
     AttributeMap command = fake_map();
     AttributeMap expected_map = fake_map();

--- a/src/viam/sdk/tests/test_types.cpp
+++ b/src/viam/sdk/tests/test_types.cpp
@@ -26,8 +26,7 @@ BOOST_AUTO_TEST_CASE(test_prototype_equality) {
 
     BOOST_CHECK(type1 == type2);
 
-    std::shared_ptr<ProtoType> proto_ptr =
-        std::make_shared<ProtoType>(std::move(std::string("not hello")));
+    auto proto_ptr = std::make_shared<ProtoType>(std::move(std::string("not hello")));
     AttributeMap unequal_map =
         std::make_shared<std::unordered_map<std::string, std::shared_ptr<ProtoType>>>();
     unequal_map->insert({{std::string("test"), proto_ptr}});

--- a/src/viam/sdk/tests/test_utils.cpp
+++ b/src/viam/sdk/tests/test_utils.cpp
@@ -11,7 +11,7 @@ namespace sdktests {
 using namespace viam::sdk;
 
 AttributeMap fake_map() {
-    std::shared_ptr<ProtoType> proto_ptr = std::make_shared<ProtoType>(std::string("hello"));
+    auto proto_ptr = std::make_shared<ProtoType>(std::string("hello"));
     AttributeMap map =
         std::make_shared<std::unordered_map<std::string, std::shared_ptr<ProtoType>>>();
     map->insert({{std::string("test"), proto_ptr}});

--- a/src/viam/sdk/tests/test_utils.cpp
+++ b/src/viam/sdk/tests/test_utils.cpp
@@ -11,8 +11,7 @@ namespace sdktests {
 using namespace viam::sdk;
 
 AttributeMap fake_map() {
-    std::shared_ptr<ProtoType> proto_ptr =
-        std::make_shared<ProtoType>(std::move(std::string("hello")));
+    std::shared_ptr<ProtoType> proto_ptr = std::make_shared<ProtoType>(std::string("hello"));
     AttributeMap map =
         std::make_shared<std::unordered_map<std::string, std::shared_ptr<ProtoType>>>();
     map->insert({{std::string("test"), proto_ptr}});


### PR DESCRIPTION
## UPDATED DESCRIPTION
#### Major changes #### 

- Add flag for building with `-Wall` and `-Werror` (defaults to `on`)
- Add flag for building with UB sanitizer (defaults to `off`)

#### Minor changes ####

- Miscellaneous refactors to ensure successful building with `Wall/Werror` flags and no errors

#### Testing ####

- Builds successfully with flags passed
- Unit tests pass with instrumented build
- `dial` example runs successfully on mac with both ubsan and asan

#### Notes ####
- Currently we are not building with asan. This is because unit tests are failing with asan on linux. This is possibly due to `gRPC` not being similarly built with asan. We don't yet support doing this ourselves; this is a future goal however, see [here](https://viam.atlassian.net/browse/RSDK-2553).

## Deprecated description, left here for posterity's sake.

#### Major changes #### 

- Add flag for building with `-Wall` and `-Werror` (defaults to `on`)
- Add flag for building with address sanitizer and UB sanitizer (defaults to `off`)

#### Minor changes ####

- Miscellaneous refactors to ensure successful building with `Wall/Werror` flags and no errors

#### Testing ####

- Builds successfully with flags passed
- Unit tests pass with instrumented build

#### Notes ####
- Currently integration testing/production use with an instrumented build is expected to fail unless `gRPC` is similarly built with sanitizers. We don't yet support doing this ourselves; this is a future goal however, see [here](https://viam.atlassian.net/browse/RSDK-2553).