### PR TITLE
RSDK-1920 Fix non-graceful shutdown of modules

### DIFF
--- a/examples/modules/example_module.cpp
+++ b/examples/modules/example_module.cpp
@@ -112,16 +112,15 @@ int main(int argc, char** argv) {
     my_mod->add_model_from_registry(server, generic, m);
     my_mod->start(server);
 
-    std::thread signal_wait_thread([&server, &sigset]() {
+    std::thread server_thread([&server, &sigset]() {
+        server->start();
         int sig = 0;
         auto result = sigwait(&sigset, &sig);
         server->shutdown();
     });
 
-    server->start();
     server->wait();
-
-    signal_wait_thread.join();
+    server_thread.join();
 
     return 0;
 };

--- a/examples/modules/example_module.cpp
+++ b/examples/modules/example_module.cpp
@@ -107,19 +107,19 @@ int main(int argc, char** argv) {
     // The `ModuleService_` must outlive the Server, so the declaration order
     // here matters.
     auto my_mod = std::make_shared<ModuleService_>(argv[1]);
-    Server server;
+    auto server = std::make_shared<Server>();
 
-    my_mod->add_model_from_registry(&server, generic, m);
-    my_mod->start(&server);
+    my_mod->add_model_from_registry(server, generic, m);
+    my_mod->start(server);
 
     std::thread signal_wait_thread([&server, &sigset]() {
         int sig = 0;
         auto result = sigwait(&sigset, &sig);
-        server.shutdown();
+        server->shutdown();
     });
 
-    server.start();
-    server.wait();
+    server->start();
+    server->wait();
 
     signal_wait_thread.join();
 

--- a/examples/modules/example_module.cpp
+++ b/examples/modules/example_module.cpp
@@ -73,7 +73,8 @@ int main(int argc, char** argv) {
 
     // C++ modules must handle SIGINT and SIGTERM. Make sure to create a sigset
     // for SIGINT and SIGTERM that can be later awaited in a thread that cleanly
-    // shuts down your module.
+    // shuts down your module. pthread_sigmask should be called near the start
+    // of main so that later threads inherit the mask.
     sigset_t sigset;
     sigemptyset(&sigset);
     sigaddset(&sigset, SIGINT);

--- a/examples/modules/example_module.cpp
+++ b/examples/modules/example_module.cpp
@@ -3,7 +3,6 @@
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/server_context.h>
 #include <robot/v1/robot.pb.h>
-#include <signal.h>
 
 #include <components/component_base.hpp>
 #include <components/generic/generic.hpp>
@@ -30,7 +29,6 @@ class MyModule : public GenericService::Service, public ComponentBase {
         std::cout << "config in reconfigure: " << cfg.name << std::endl;
     }
 
-    void signal_handler(int signum);
     std::string name;
     static int which;
     int inner_which;
@@ -67,21 +65,10 @@ class MyModule : public GenericService::Service, public ComponentBase {
 int MyModule::which = 0;
 std::shared_ptr<ModuleService_> my_mod;
 
-void signal_handler(int signum) {
-    my_mod->close();
-}
-
 int main(int argc, char** argv) {
     if (argc != 2) {
         throw "need socket path as command line argument";
     }
-
-    // TODO(RSDK-1920) This is still causing non-graceful shutdown. Figure out why, and fix.
-    struct sigaction sig_handler;
-    sig_handler.sa_handler = signal_handler;
-    sigaction(SIGTERM, &sig_handler, nullptr);
-    sigemptyset(&sig_handler.sa_mask);
-    sig_handler.sa_flags = 0;
 
     Subtype generic = Generic::subtype();
     my_mod = std::make_shared<ModuleService_>(argv[1]);

--- a/src/components/camera/server.cpp
+++ b/src/components/camera/server.cpp
@@ -125,7 +125,7 @@
     return ::grpc::Status();
 }
 
-void CameraServer::register_server(Server* server) {
+void CameraServer::register_server(std::shared_ptr<Server> server) {
     viam::component::camera::v1::CameraService::Service* camera =
         static_cast<viam::component::camera::v1::CameraService::Service*>(this);
     server->register_service(camera);

--- a/src/components/camera/server.cpp
+++ b/src/components/camera/server.cpp
@@ -125,10 +125,10 @@
     return ::grpc::Status();
 }
 
-void CameraServer::register_server() {
+void CameraServer::register_server(Server* server) {
     viam::component::camera::v1::CameraService::Service* camera =
         static_cast<viam::component::camera::v1::CameraService::Service*>(this);
-    Server::register_service(camera);
+    server->register_service(camera);
 }
 
 std::shared_ptr<SubtypeService> CameraServer::get_sub_svc() {

--- a/src/components/camera/server.hpp
+++ b/src/components/camera/server.hpp
@@ -27,7 +27,7 @@ class CameraServer : public ResourceServerBase,
         const ::viam::component::camera::v1::GetPropertiesRequest* request,
         ::viam::component::camera::v1::GetPropertiesResponse* response) override;
 
-    void register_server() override;
+    void register_server(Server* server) override;
 
     std::shared_ptr<SubtypeService> get_sub_svc();
 

--- a/src/components/camera/server.hpp
+++ b/src/components/camera/server.hpp
@@ -27,7 +27,7 @@ class CameraServer : public ResourceServerBase,
         const ::viam::component::camera::v1::GetPropertiesRequest* request,
         ::viam::component::camera::v1::GetPropertiesResponse* response) override;
 
-    void register_server(Server* server) override;
+    void register_server(std::shared_ptr<Server> server) override;
 
     std::shared_ptr<SubtypeService> get_sub_svc();
 

--- a/src/components/generic/server.cpp
+++ b/src/components/generic/server.cpp
@@ -24,7 +24,7 @@
     return ::grpc::Status();
 }
 
-void GenericServer::register_server(Server* server) {
+void GenericServer::register_server(std::shared_ptr<Server> server) {
     viam::component::generic::v1::GenericService::Service* generic =
         static_cast<viam::component::generic::v1::GenericService::Service*>(this);
     try {

--- a/src/components/generic/server.cpp
+++ b/src/components/generic/server.cpp
@@ -24,11 +24,11 @@
     return ::grpc::Status();
 }
 
-void GenericServer::register_server() {
+void GenericServer::register_server(Server* server) {
     viam::component::generic::v1::GenericService::Service* generic =
         static_cast<viam::component::generic::v1::GenericService::Service*>(this);
     try {
-        Server::register_service(generic);
+        server->register_service(generic);
     } catch (std::exception& exc) {
         throw exc;
     }

--- a/src/components/generic/server.hpp
+++ b/src/components/generic/server.hpp
@@ -13,7 +13,7 @@ class GenericServer : public ResourceServerBase,
                              const ::viam::common::v1::DoCommandRequest* request,
                              ::viam::common::v1::DoCommandResponse* response) override;
 
-    void register_server(Server* server) override;
+    void register_server(std::shared_ptr<Server> server) override;
     std::shared_ptr<SubtypeService> get_sub_svc();
 
     GenericServer() : sub_svc(std::make_shared<SubtypeService>()){};

--- a/src/components/generic/server.hpp
+++ b/src/components/generic/server.hpp
@@ -13,7 +13,7 @@ class GenericServer : public ResourceServerBase,
                              const ::viam::common::v1::DoCommandRequest* request,
                              ::viam::common::v1::DoCommandResponse* response) override;
 
-    void register_server() override;
+    void register_server(Server* server) override;
     std::shared_ptr<SubtypeService> get_sub_svc();
 
     GenericServer() : sub_svc(std::make_shared<SubtypeService>()){};

--- a/src/module/service.cpp
+++ b/src/module/service.cpp
@@ -199,7 +199,7 @@ ModuleService_::ModuleService_(std::string addr) {
     module = std::make_shared<Module>(addr);
 }
 
-void ModuleService_::signal_handler(int signum) {
+void ModuleService_::signal_handler(int) {
     exit(0);
 }
 

--- a/src/module/service.cpp
+++ b/src/module/service.cpp
@@ -198,7 +198,7 @@ ModuleService_::ModuleService_(std::string addr) {
     module = std::make_shared<Module>(addr);
 }
 
-void ModuleService_::start(Server* server) {
+void ModuleService_::start(std::shared_ptr<Server> server) {
     module->lock.lock();
     mode_t old_mask = umask(0077);
     int sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -230,7 +230,7 @@ void ModuleService_::close() {
     }
 }
 
-void ModuleService_::add_api_from_registry(Server* server, Subtype api) {
+void ModuleService_::add_api_from_registry(std::shared_ptr<Server> server, Subtype api) {
     if (module->services.find(api) != module->services.end()) {
         return;
     }
@@ -245,7 +245,9 @@ void ModuleService_::add_api_from_registry(Server* server, Subtype api) {
     module->lock.unlock();
 }
 
-void ModuleService_::add_model_from_registry(Server* server, Subtype api, Model model) {
+void ModuleService_::add_model_from_registry(std::shared_ptr<Server> server,
+                                             Subtype api,
+                                             Model model) {
     if (module->services.find(api) == module->services.end()) {
         add_api_from_registry(server, api);
     }

--- a/src/module/service.cpp
+++ b/src/module/service.cpp
@@ -3,7 +3,6 @@
 #include <csignal>
 #include <iostream>
 #include <memory>
-#include <signal.h>
 #include <string>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -199,10 +198,6 @@ ModuleService_::ModuleService_(std::string addr) {
     module = std::make_shared<Module>(addr);
 }
 
-void ModuleService_::signal_handler(int) {
-    exit(0);
-}
-
 void ModuleService_::start() {
     module->lock.lock();
     mode_t old_mask = umask(0077);
@@ -214,11 +209,6 @@ void ModuleService_::start() {
     Server::register_service(this);
     std::string address = "unix://" + module->addr;
     Server::add_listening_port(address);
-
-    // Call exit(0) on SIGTERM or SIGINT so module can cleanly shutdown with its
-    // destructor.
-    signal(SIGINT, signal_handler);
-    signal(SIGTERM, signal_handler);
 
     module->lock.unlock();
     module->set_ready();

--- a/src/module/service.hpp
+++ b/src/module/service.hpp
@@ -44,5 +44,4 @@ class ModuleService_ : public ComponentServiceBase,
    private:
     std::shared_ptr<RobotClient> parent;
     std::string parent_addr;
-    static void signal_handler(int);
 };

--- a/src/module/service.hpp
+++ b/src/module/service.hpp
@@ -6,15 +6,17 @@
 #include <components/service_base.hpp>
 #include <module/module.hpp>
 #include <resource/resource_base.hpp>
+#include <rpc/server.hpp>
 
 class ModuleService_ : public ComponentServiceBase,
                        public viam::module::v1::ModuleService::Service {
    public:
-    void start();
+    void start(Server* server);
     void close();
     std::shared_ptr<ResourceBase> get_parent_resource(Name name);
-    void add_api_from_registry(Subtype api);
-    void add_model_from_registry(Subtype api, Model model);
+    
+    void add_api_from_registry(Server* server, Subtype api);
+    void add_model_from_registry(Server* server, Subtype api, Model model);
     ::grpc::Status AddResource(::grpc::ServerContext* context,
                                const ::viam::module::v1::AddResourceRequest* request,
                                ::viam::module::v1::AddResourceResponse* response) override;

--- a/src/module/service.hpp
+++ b/src/module/service.hpp
@@ -44,5 +44,5 @@ class ModuleService_ : public ComponentServiceBase,
    private:
     std::shared_ptr<RobotClient> parent;
     std::string parent_addr;
-    static void signal_handler(int signum);
+    static void signal_handler(int);
 };

--- a/src/module/service.hpp
+++ b/src/module/service.hpp
@@ -14,7 +14,7 @@ class ModuleService_ : public ComponentServiceBase,
     void start(Server* server);
     void close();
     std::shared_ptr<ResourceBase> get_parent_resource(Name name);
-    
+
     void add_api_from_registry(Server* server, Subtype api);
     void add_model_from_registry(Server* server, Subtype api, Model model);
     ::grpc::Status AddResource(::grpc::ServerContext* context,

--- a/src/module/service.hpp
+++ b/src/module/service.hpp
@@ -44,4 +44,5 @@ class ModuleService_ : public ComponentServiceBase,
    private:
     std::shared_ptr<RobotClient> parent;
     std::string parent_addr;
+    static void signal_handler(int signum);
 };

--- a/src/module/service.hpp
+++ b/src/module/service.hpp
@@ -11,12 +11,12 @@
 class ModuleService_ : public ComponentServiceBase,
                        public viam::module::v1::ModuleService::Service {
    public:
-    void start(Server* server);
+    void start(std::shared_ptr<Server> server);
     void close();
     std::shared_ptr<ResourceBase> get_parent_resource(Name name);
 
-    void add_api_from_registry(Server* server, Subtype api);
-    void add_model_from_registry(Server* server, Subtype api, Model model);
+    void add_api_from_registry(std::shared_ptr<Server> server, Subtype api);
+    void add_model_from_registry(std::shared_ptr<Server> server, Subtype api, Model model);
     ::grpc::Status AddResource(::grpc::ServerContext* context,
                                const ::viam::module::v1::AddResourceRequest* request,
                                ::viam::module::v1::AddResourceResponse* response) override;

--- a/src/resource/resource_server_base.hpp
+++ b/src/resource/resource_server_base.hpp
@@ -5,7 +5,7 @@
 
 class ResourceServerBase {
    public:
-    virtual void register_server(Server* server) = 0;
+    virtual void register_server(std::shared_ptr<Server> server) = 0;
 
    private:
     std::shared_ptr<SubtypeService> sub_svc;

--- a/src/resource/resource_server_base.hpp
+++ b/src/resource/resource_server_base.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <subtype/subtype.hpp>
 #include <rpc/server.hpp>
+#include <subtype/subtype.hpp>
 
 class ResourceServerBase {
    public:

--- a/src/resource/resource_server_base.hpp
+++ b/src/resource/resource_server_base.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <subtype/subtype.hpp>
+#include <rpc/server.hpp>
 
 class ResourceServerBase {
    public:
-    virtual void register_server() = 0;
+    virtual void register_server(Server* server) = 0;
 
    private:
     std::shared_ptr<SubtypeService> sub_svc;

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -3,8 +3,7 @@
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/security/server_credentials.h>
 
-Server::Server() : builder_(std::make_unique<grpc::ServerBuilder>()) {
-}
+Server::Server() : builder_(std::make_unique<grpc::ServerBuilder>()) {}
 
 Server::~Server() {
     shutdown();
@@ -30,7 +29,6 @@ void Server::start() {
 
 void Server::add_listening_port(std::string address,
                                 std::shared_ptr<grpc::ServerCredentials> creds) {
-
     if (!builder_) {
         throw "Cannot add a listening port after server has started";
     }

--- a/src/rpc/server.hpp
+++ b/src/rpc/server.hpp
@@ -7,7 +7,6 @@
 /// A grpc server
 class Server {
    public:
-
     Server();
     ~Server();
 

--- a/src/rpc/server.hpp
+++ b/src/rpc/server.hpp
@@ -7,9 +7,13 @@
 /// A grpc server
 class Server {
    public:
+
+    Server();
+    ~Server();
+
     /// Starts the grpc server. This can only be called once, and will throw on
     /// repeated calls.
-    static void start();
+    void start();
 
     // TODO: make `register_service` take one of our types as an arg rather than a
     // grpc service type, and convert under the hood
@@ -22,7 +26,7 @@ class Server {
     /// 	Must be called before starting the server; new services cannot be
     /// registered after 	the server starts. Attempting to do so will throw an
     /// error
-    static void register_service(grpc::Service* service);
+    void register_service(grpc::Service* service);
 
     /// Adds a listening port to the server.
     /// Args:
@@ -34,13 +38,13 @@ class Server {
     ///		Must be called before starting the server. Attempting to call
     /// after
     /// the server has 		started will throw an error
-    static void add_listening_port(std::string address,
-                                   std::shared_ptr<grpc::ServerCredentials> creds = nullptr);
+    void add_listening_port(std::string address,
+                            std::shared_ptr<grpc::ServerCredentials> creds = nullptr);
 
-    static void wait();
-    static void shutdown();
+    void wait();
+    void shutdown();
 
    private:
-    static std::unique_ptr<grpc::ServerBuilder> builder;
-    static std::unique_ptr<grpc::Server> server;
+    std::unique_ptr<grpc::ServerBuilder> builder_;
+    std::unique_ptr<grpc::Server> server_;
 };


### PR DESCRIPTION
[RSDK-1920](https://viam.atlassian.net/browse/RSDK-1920)

Spawns thread in example module to shutdown server when `SIGTERM` or `SIGINT` is received. Refactors `Server` to be wrapped by various services instead of being global.

This change allows the RDK to remove and reconfigure C++ modules.

[RSDK-1920]: https://viam.atlassian.net/browse/RSDK-1920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ