### PR TITLE
RSDK-2566 - refactor `from_robot`

### DIFF
--- a/examples/dial/example_dial.cpp
+++ b/examples/dial/example_dial.cpp
@@ -62,7 +62,7 @@ int main() {
     }
 
     // ensure we can create clients to the robot
-    std::shared_ptr<GenericClient> gc = typed_resource_from_robot<GenericClient>(robot, "generic1");
+    std::shared_ptr<GenericClient> gc = robot->resource_by_name<GenericClient>("generic1");
     std::cout << "got generic client named " << gc->name() << std::endl;
 
     robot->close();

--- a/examples/dial/example_dial.cpp
+++ b/examples/dial/example_dial.cpp
@@ -62,7 +62,7 @@ int main() {
     }
 
     // ensure we can create clients to the robot
-    std::shared_ptr<GenericClient> gc = robot->resource_by_name<GenericClient>("generic1");
+    auto gc = robot->resource_by_name<GenericClient>("generic1");
     std::cout << "got generic client named " << gc->name() << std::endl;
 
     robot->close();

--- a/src/components/camera/camera.cpp
+++ b/src/components/camera/camera.cpp
@@ -18,7 +18,7 @@ std::shared_ptr<ResourceServerBase> CameraSubtype::create_resource_server(
 
 std::shared_ptr<ResourceBase> CameraSubtype::create_rpc_client(
     std::string name, std::shared_ptr<grpc::Channel> chan) {
-    return std::make_shared<CameraClient>(std::move(name), chan);
+    return std::make_shared<CameraClient>(std::move(name), std::move(chan));
 };
 
 std::shared_ptr<ResourceSubtype> Camera::resource_subtype() {

--- a/src/components/camera/camera.hpp
+++ b/src/components/camera/camera.hpp
@@ -73,7 +73,7 @@ class Camera : public ComponentBase {
     virtual properties get_properties() = 0;
 
    protected:
-    Camera(std::string name) : ComponentBase(std::move(name)){};
+    explicit Camera(std::string name) : ComponentBase(std::move(name)){};
 };
 
 bool operator==(const Camera::raw_image& lhs, const Camera::raw_image& rhs);

--- a/src/components/camera/camera.hpp
+++ b/src/components/camera/camera.hpp
@@ -71,6 +71,9 @@ class Camera : public ComponentBase {
     virtual raw_image get_image(std::string mime_type) = 0;
     virtual point_cloud get_point_cloud(std::string mime_type) = 0;
     virtual properties get_properties() = 0;
+
+   protected:
+    Camera(std::string name) : ComponentBase(std::move(name)){};
 };
 
 bool operator==(const Camera::raw_image& lhs, const Camera::raw_image& rhs);

--- a/src/components/camera/client.cpp
+++ b/src/components/camera/client.cpp
@@ -31,7 +31,7 @@ AttributeMap CameraClient::do_command(AttributeMap command) {
 
     google::protobuf::Struct proto_command = map_to_struct(command);
     *req.mutable_command() = proto_command;
-    *req.mutable_name() = this->name_;
+    *req.mutable_name() = this->name();
     stub_->DoCommand(&ctx, req, &resp);
     return struct_to_map(resp.result());
 };
@@ -44,7 +44,7 @@ Camera::raw_image CameraClient::get_image(std::string mime_type) {
     normalize_mime_type(mime_type);
 
     *req.mutable_mime_type() = mime_type;
-    *req.mutable_name() = this->name_;
+    *req.mutable_name() = this->name();
 
     stub_->GetImage(&ctx, req, &resp);
     return from_proto(resp);
@@ -55,7 +55,7 @@ Camera::point_cloud CameraClient::get_point_cloud(std::string mime_type) {
     viam::component::camera::v1::GetPointCloudResponse resp;
     grpc::ClientContext ctx;
 
-    *req.mutable_name() = this->name_;
+    *req.mutable_name() = this->name();
     *req.mutable_mime_type() = mime_type;
 
     stub_->GetPointCloud(&ctx, req, &resp);
@@ -67,17 +67,8 @@ Camera::properties CameraClient::get_properties() {
     viam::component::camera::v1::GetPropertiesResponse resp;
     grpc::ClientContext ctx;
 
-    *req.mutable_name() = this->name_;
+    *req.mutable_name() = this->name();
 
     stub_->GetProperties(&ctx, req, &resp);
     return from_proto(resp);
-};
-
-CameraClient::CameraClient(std::string name, std::shared_ptr<grpc::Channel> channel_)
-    : channel_(channel_), stub_(viam::component::camera::v1::CameraService::NewStub(channel_)) {
-    name_ = std::move(name);
-};
-
-CameraClient::CameraClient(std::string name) : channel_(nullptr), stub_(nullptr) {
-    name_ = std::move(name);
 };

--- a/src/components/camera/client.hpp
+++ b/src/components/camera/client.hpp
@@ -15,15 +15,17 @@ class CameraClient : public Camera {
     raw_image get_image(std::string mime_type) override;
     point_cloud get_point_cloud(std::string mime_type) override;
     properties get_properties() override;
-    CameraClient(std::string name, std::shared_ptr<grpc::Channel> channel_);
+    CameraClient(std::string name, std::shared_ptr<grpc::Channel> channel)
+        : Camera(std::move(name)),
+          stub_(viam::component::camera::v1::CameraService::NewStub(channel)),
+          channel_(std::move(channel)){};
 
    protected:
-    CameraClient(std::string name);
-    std::unique_ptr<viam::component::camera::v1::CameraService::StubInterface> stub_;
+    CameraClient(std::string name,
+                 std::unique_ptr<viam::component::camera::v1::CameraService::StubInterface> stub)
+        : Camera(std::move(name)), stub_(std::move(stub)), channel_(nullptr){};
 
    private:
+    std::unique_ptr<viam::component::camera::v1::CameraService::StubInterface> stub_;
     std::shared_ptr<grpc::Channel> channel_;
 };
-
-template std::shared_ptr<CameraClient> typed_resource_from_robot(const std::shared_ptr<RobotClient>,
-                                                                 const std::string&);

--- a/src/components/camera/client.hpp
+++ b/src/components/camera/client.hpp
@@ -23,7 +23,7 @@ class CameraClient : public Camera {
    protected:
     CameraClient(std::string name,
                  std::unique_ptr<viam::component::camera::v1::CameraService::StubInterface> stub)
-        : Camera(std::move(name)), stub_(std::move(stub)), channel_(nullptr){};
+        : Camera(std::move(name)), stub_(std::move(stub)){};
 
    private:
     std::unique_ptr<viam::component::camera::v1::CameraService::StubInterface> stub_;

--- a/src/components/camera/client.hpp
+++ b/src/components/camera/client.hpp
@@ -21,6 +21,9 @@ class CameraClient : public Camera {
           channel_(std::move(channel)){};
 
    protected:
+    // This constructor leaves the `channel_` as a nullptr. This is useful for testing
+    // purposes, but renders it unusable for production use. Care should be taken to
+    // avoid use of this constructor outside of tests.
     CameraClient(std::string name,
                  std::unique_ptr<viam::component::camera::v1::CameraService::StubInterface> stub)
         : Camera(std::move(name)), stub_(std::move(stub)){};

--- a/src/components/component_base.hpp
+++ b/src/components/component_base.hpp
@@ -13,4 +13,7 @@ class ComponentBase : public ResourceBase {
     virtual ResourceType type() override;
     viam::common::v1::ResourceName get_resource_name(std::string name);
     ComponentBase() : ResourceBase("component"){};
+
+   protected:
+    explicit ComponentBase(std::string name) : ResourceBase(std::move(name)){};
 };

--- a/src/components/generic/client.cpp
+++ b/src/components/generic/client.cpp
@@ -16,16 +16,8 @@ AttributeMap GenericClient::do_command(AttributeMap command) {
 
     google::protobuf::Struct proto_command = map_to_struct(command);
     *req.mutable_command() = proto_command;
-    *req.mutable_name() = name_;
+    *req.mutable_name() = this->name();
     stub_->DoCommand(&ctx, req, &resp);
     return struct_to_map(resp.result());
 };
 
-GenericClient::GenericClient(std::string name, std::shared_ptr<grpc::Channel> channel_)
-    : channel_(channel_), stub_(viam::component::generic::v1::GenericService::NewStub(channel_)) {
-    name_ = std::move(name);
-}
-
-GenericClient::GenericClient(std::string name) : channel_(nullptr), stub_(nullptr) {
-    name_ = std::move(name);
-};

--- a/src/components/generic/client.cpp
+++ b/src/components/generic/client.cpp
@@ -20,4 +20,3 @@ AttributeMap GenericClient::do_command(AttributeMap command) {
     stub_->DoCommand(&ctx, req, &resp);
     return struct_to_map(resp.result());
 };
-

--- a/src/components/generic/client.hpp
+++ b/src/components/generic/client.hpp
@@ -10,15 +10,18 @@
 class GenericClient : public Generic {
    public:
     AttributeMap do_command(AttributeMap command) override;
-    GenericClient(std::string name, std::shared_ptr<grpc::Channel> channel_);
+    GenericClient(std::string name, std::shared_ptr<grpc::Channel> channel)
+        : Generic(std::move(name)),
+          stub_(viam::component::generic::v1::GenericService::NewStub(channel)),
+          channel_(std::move(channel)){};
 
    protected:
-    GenericClient(std::string name);
-    std::unique_ptr<viam::component::generic::v1::GenericService::StubInterface> stub_;
+    GenericClient(std::string name,
+                  std::unique_ptr<viam::component::generic::v1::GenericService::StubInterface> stub)
+        : Generic(std::move(name)), stub_(std::move(stub)), channel_(nullptr){};
 
    private:
+    std::unique_ptr<viam::component::generic::v1::GenericService::StubInterface> stub_;
     std::shared_ptr<grpc::Channel> channel_;
 };
 
-template std::shared_ptr<GenericClient> typed_resource_from_robot(
-    const std::shared_ptr<RobotClient>, const std::string&);

--- a/src/components/generic/client.hpp
+++ b/src/components/generic/client.hpp
@@ -24,4 +24,3 @@ class GenericClient : public Generic {
     std::unique_ptr<viam::component::generic::v1::GenericService::StubInterface> stub_;
     std::shared_ptr<grpc::Channel> channel_;
 };
-

--- a/src/components/generic/client.hpp
+++ b/src/components/generic/client.hpp
@@ -16,6 +16,9 @@ class GenericClient : public Generic {
           channel_(std::move(channel)){};
 
    protected:
+    // This constructor leaves the `channel_` as a nullptr. This is useful for testing
+    // purposes, but renders it unusable for production use. Care should be taken to
+    // avoid use of this constructor outside of tests.
     GenericClient(std::string name,
                   std::unique_ptr<viam::component::generic::v1::GenericService::StubInterface> stub)
         : Generic(std::move(name)), stub_(std::move(stub)){};

--- a/src/components/generic/client.hpp
+++ b/src/components/generic/client.hpp
@@ -18,7 +18,7 @@ class GenericClient : public Generic {
    protected:
     GenericClient(std::string name,
                   std::unique_ptr<viam::component::generic::v1::GenericService::StubInterface> stub)
-        : Generic(std::move(name)), stub_(std::move(stub)), channel_(nullptr){};
+        : Generic(std::move(name)), stub_(std::move(stub)){};
 
    private:
     std::unique_ptr<viam::component::generic::v1::GenericService::StubInterface> stub_;

--- a/src/components/generic/generic.cpp
+++ b/src/components/generic/generic.cpp
@@ -19,7 +19,7 @@ std::shared_ptr<ResourceServerBase> GenericSubtype::create_resource_server(
 
 std::shared_ptr<ResourceBase> GenericSubtype::create_rpc_client(
     std::string name, std::shared_ptr<grpc::Channel> chan) {
-    return std::make_shared<GenericClient>(std::move(name), chan);
+    return std::make_shared<GenericClient>(std::move(name), std::move(chan));
 };
 
 std::shared_ptr<ResourceSubtype> Generic::resource_subtype() {

--- a/src/components/generic/generic.hpp
+++ b/src/components/generic/generic.hpp
@@ -24,4 +24,7 @@ class Generic : public ComponentBase {
     static std::shared_ptr<ResourceSubtype> resource_subtype();
     static Subtype subtype();
     virtual AttributeMap do_command(AttributeMap command) = 0;
+
+   protected:
+    explicit Generic(std::string name) : ComponentBase(std::move(name)){};
 };

--- a/src/resource/resource_base.hpp
+++ b/src/resource/resource_base.hpp
@@ -22,6 +22,6 @@ class ResourceBase {
     virtual std::string name();
     virtual ResourceType type();
 
-   protected:
+   private:
     std::string name_;
 };

--- a/src/resource/resource_base.hpp
+++ b/src/resource/resource_base.hpp
@@ -14,7 +14,7 @@ class ResourceBase;
 using Dependencies = std::unordered_map<Name, std::shared_ptr<ResourceBase>>;
 class ResourceBase {
    public:
-    ResourceBase(std::string name) : name_(std::move(name)){};
+    explicit ResourceBase(std::string name) : name_(std::move(name)){};
     static Subtype subtype();
     virtual grpc::StatusCode stop(std::unordered_map<std::string, ProtoType*> extra);
     virtual grpc::StatusCode stop();

--- a/src/robot/client.cpp
+++ b/src/robot/client.cpp
@@ -346,8 +346,8 @@ std::vector<Discovery> RobotClient::discover_components(std::vector<DiscoveryQue
     return components;
 }
 
-std::shared_ptr<ResourceBase> RobotClient::resource_by_name(ResourceName name, ResourceType type) {
-    return resource_manager.get_resource(name.name(), type);
+std::shared_ptr<ResourceBase> RobotClient::resource_by_name(const ResourceName& name) {
+    return resource_manager.get_resource(name.name(), name.type());
 }
 
 void RobotClient::stop_all() {

--- a/src/robot/client.hpp
+++ b/src/robot/client.hpp
@@ -70,7 +70,7 @@ class RobotClient {
     /// cast to the desired type.
     std::shared_ptr<ResourceBase> resource_by_name(const ResourceName& name);
     template <typename T>
-    std::shared_ptr<T> resource_by_name(const std::string name) {
+    std::shared_ptr<T> resource_by_name(std::string name) {
         ResourceName r;
         Subtype subtype = T::subtype();
         *r.mutable_namespace_() = subtype.type_namespace();

--- a/src/robot/client.hpp
+++ b/src/robot/client.hpp
@@ -63,14 +63,26 @@ class RobotClient {
     /// Raises:
     /// 	Throws an error if the requested resource doesn't exist or is of the wrong type.
     ///
-    /// This function should not be called directly expect in specific cases. The
-    /// function `typed_resource_from_robot<T>(robot, name)` is the preferred method for obtaining
-    /// resources.
+    /// This method should not be called directly except in specific cases. The
+    /// type-annotated `resource_by_name<T>(name)` overload is the preferred method
+    /// for obtaining resources.
     ///
     /// Because the return type here is a `ResourceBase`, the user will need to manually
     /// cast to the desired type.
     std::shared_ptr<ResourceBase> resource_by_name(ResourceName name,
                                                    ResourceType type = {"resource"});
+    template <typename T>
+    std::shared_ptr<T> resource_by_name(const std::string& name) {
+        ResourceName r;
+        Subtype subtype = T::subtype();
+        *r.mutable_namespace_() = subtype.type_namespace();
+        *r.mutable_type() = subtype.resource_type();
+        *r.mutable_subtype() = subtype.resource_subtype();
+        *r.mutable_name() = std::move(name);
+
+        auto resource = this->resource_by_name(std::move(r), subtype.resource_type());
+        return std::dynamic_pointer_cast<T>(resource);
+    }
     std::vector<FrameSystemConfig> get_frame_system_config(
         std::vector<Transform> additional_transforms = std::vector<Transform>());
     std::vector<viam::robot::v1::Operation> get_operations();
@@ -106,25 +118,3 @@ class RobotClient {
     void refresh_every();
 };
 
-template <typename T>
-std::shared_ptr<T> typed_resource_from_robot(const std::shared_ptr<RobotClient> client,
-                                             const std::string& name) {
-    std::string resource_type;
-    if (std::is_base_of<ComponentBase, T>()) {
-        resource_type = COMPONENT;
-    } else if (std::is_base_of<ServiceBase, T>()) {
-        resource_type = SERVICE;
-    } else {
-        throw std::runtime_error("attempted to get unknown resource type from robot");
-    }
-
-    ResourceName r;
-    Subtype subtype = T::subtype();
-    *r.mutable_namespace_() = subtype.type_namespace();
-    *r.mutable_type() = subtype.resource_type();
-    *r.mutable_subtype() = subtype.resource_subtype();
-    *r.mutable_name() = std::move(name);
-
-    auto resource = client->resource_by_name(std::move(r), subtype.resource_type());
-    return std::dynamic_pointer_cast<T>(resource);
-}

--- a/src/robot/client.hpp
+++ b/src/robot/client.hpp
@@ -117,4 +117,3 @@ class RobotClient {
     ResourceManager resource_manager;
     void refresh_every();
 };
-

--- a/src/robot/client.hpp
+++ b/src/robot/client.hpp
@@ -58,7 +58,6 @@ class RobotClient {
     ///
     /// Args:
     /// 	name: the name of the resource
-    /// 	type: the resource type (defaults to a generic `ResourceBase`)
     ///
     /// Raises:
     /// 	Throws an error if the requested resource doesn't exist or is of the wrong type.
@@ -69,10 +68,9 @@ class RobotClient {
     ///
     /// Because the return type here is a `ResourceBase`, the user will need to manually
     /// cast to the desired type.
-    std::shared_ptr<ResourceBase> resource_by_name(ResourceName name,
-                                                   ResourceType type = {"resource"});
+    std::shared_ptr<ResourceBase> resource_by_name(const ResourceName& name);
     template <typename T>
-    std::shared_ptr<T> resource_by_name(const std::string& name) {
+    std::shared_ptr<T> resource_by_name(const std::string name) {
         ResourceName r;
         Subtype subtype = T::subtype();
         *r.mutable_namespace_() = subtype.type_namespace();
@@ -80,7 +78,7 @@ class RobotClient {
         *r.mutable_subtype() = subtype.resource_subtype();
         *r.mutable_name() = std::move(name);
 
-        auto resource = this->resource_by_name(std::move(r), subtype.resource_type());
+        auto resource = this->resource_by_name(std::move(r));
         return std::dynamic_pointer_cast<T>(resource);
     }
     std::vector<FrameSystemConfig> get_frame_system_config(

--- a/src/services/service_base.hpp
+++ b/src/services/service_base.hpp
@@ -13,5 +13,5 @@ class ServiceBase : public ResourceBase {
     ServiceBase();
 
    protected:
-    ServiceBase(std::string name) : ResourceBase(std::move(name)){};
+    explicit ServiceBase(std::string name) : ResourceBase(std::move(name)){};
 };

--- a/src/services/service_base.hpp
+++ b/src/services/service_base.hpp
@@ -9,6 +9,9 @@
 class ServiceBase : public ResourceBase {
    public:
     virtual viam::common::v1::ResourceName get_resource_name(std::string name);
-    virtual ResourceType type() override;
+    ResourceType type() override;
     ServiceBase();
+
+   protected:
+    ServiceBase(std::string name) : ResourceBase(std::move(name)){};
 };

--- a/src/tests/mocks/camera_mocks.cpp
+++ b/src/tests/mocks/camera_mocks.cpp
@@ -111,4 +111,3 @@ MockCameraStub::MockCameraStub() : server(std::make_shared<CameraServer>()) {
     grpc::ServerContext* ctx;
     return server->DoCommand(ctx, &request, response);
 }
-

--- a/src/tests/mocks/camera_mocks.cpp
+++ b/src/tests/mocks/camera_mocks.cpp
@@ -63,7 +63,7 @@ Camera::properties fake_properties() {
 }
 
 std::shared_ptr<MockCamera> MockCamera::get_mock_camera() {
-    auto camera = std::make_shared<MockCamera>();
+    auto camera = std::make_shared<MockCamera>("camera");
 
     camera->image = fake_raw_image();
     camera->pc = fake_point_cloud();
@@ -112,7 +112,3 @@ MockCameraStub::MockCameraStub() : server(std::make_shared<CameraServer>()) {
     return server->DoCommand(ctx, &request, response);
 }
 
-MockCameraClient::MockCameraClient(std::string name) : CameraClient(name) {
-    stub_ = std::make_unique<MockCameraStub>();
-    name_ = name;
-}

--- a/src/tests/mocks/camera_mocks.hpp
+++ b/src/tests/mocks/camera_mocks.hpp
@@ -15,6 +15,7 @@ class MockCamera : public Camera {
     point_cloud get_point_cloud(std::string mime_type) override;
     properties get_properties() override;
     static std::shared_ptr<MockCamera> get_mock_camera();
+    MockCamera(std::string name) : Camera(std::move(name)){};
 
    private:
     Camera::intrinsic_parameters intrinsic_parameters;
@@ -127,5 +128,6 @@ class MockCameraStub : public viam::component::camera::v1::CameraService::StubIn
 
 class MockCameraClient : public CameraClient {
    public:
-    MockCameraClient(std::string name);
+    MockCameraClient(std::string name)
+        : CameraClient(std::move(name), std::make_unique<MockCameraStub>()){};
 };

--- a/src/tests/mocks/generic_mocks.cpp
+++ b/src/tests/mocks/generic_mocks.cpp
@@ -16,7 +16,7 @@ MockGeneric::do_command(
 }
 
 std::shared_ptr<MockGeneric> MockGeneric::get_mock_generic() {
-    auto generic = std::make_shared<MockGeneric>();
+    auto generic = std::make_shared<MockGeneric>("generic");
     generic->map = fake_map();
 
     return generic;
@@ -33,6 +33,3 @@ MockGenericStub::MockGenericStub() : server(std::make_shared<GenericServer>()) {
     return server->DoCommand(ctx, &request, response);
 }
 
-MockGenericClient::MockGenericClient(std::string name) : GenericClient(name) {
-    stub_ = std::make_unique<MockGenericStub>();
-}

--- a/src/tests/mocks/generic_mocks.cpp
+++ b/src/tests/mocks/generic_mocks.cpp
@@ -32,4 +32,3 @@ MockGenericStub::MockGenericStub() : server(std::make_shared<GenericServer>()) {
     grpc::ServerContext* ctx;
     return server->DoCommand(ctx, &request, response);
 }
-

--- a/src/tests/mocks/generic_mocks.hpp
+++ b/src/tests/mocks/generic_mocks.hpp
@@ -10,6 +10,7 @@
 
 class MockGeneric : public Generic {
    public:
+    MockGeneric(std::string name) : Generic(std::move(name)){};
     std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> do_command(
         std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> command)
         override;
@@ -46,5 +47,6 @@ class MockGenericStub : public viam::component::generic::v1::GenericService::Stu
 
 class MockGenericClient : public GenericClient {
    public:
-    MockGenericClient(std::string name);
+    MockGenericClient(std::string name)
+        : GenericClient(std::move(name), std::make_unique<MockGenericStub>()){};
 };


### PR DESCRIPTION
#### Major changes ####
- Move `typed_resource_from_robot` into `RobotClient` as overload of `resource_by_name`
- Stop requiring explicit `template` language in class headers

#### Minor changes ####
- move data members of wrappers to `private`, make constructors `protected`