### PR TITLE
Fix uninitialized pointer in dial.cpp

### DIFF
--- a/src/rpc/dial.cpp
+++ b/src/rpc/dial.cpp
@@ -36,7 +36,7 @@ ViamChannel::ViamChannel(std::shared_ptr<grpc::Channel> channel, const char* pat
 ViamChannel ViamChannel::dial(const char* uri, boost::optional<DialOptions> options) {
     void* ptr = init_rust_runtime();
     DialOptions opts = options.get_value_or(DialOptions());
-    const char* payload;
+    const char* payload = nullptr;
 
     if (opts.credentials) {
         payload = opts.credentials->payload.c_str();


### PR DESCRIPTION
Without this fix, the pointer is initialized to a random value and is not nullptr. This causes problems in the rust code that checks if it is null.

To replicate: 
- edit example_dial to not pass a payload. The rust code will return a very non-helpful error. 