### PR TITLE
RSDK-796 Server and client wrapper (motor)

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,3 +15,4 @@
 add_subdirectory(dial)
 add_subdirectory(echo)
 add_subdirectory(modules)
+add_subdirectory(motor)

--- a/examples/motor/CMakeLists.txt
+++ b/examples/motor/CMakeLists.txt
@@ -12,10 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-enable_testing()
-include(viamcppsdk_utils)
-viamcppsdk_add_boost_test(test_generic_component.cpp)
-viamcppsdk_add_boost_test(test_motor.cpp)
-viamcppsdk_add_boost_test(test_camera.cpp)
-viamcppsdk_add_boost_test(test_types.cpp)
+add_executable(example_motor
+  example_motor.cpp
+)
 
+target_link_libraries(example_motor
+  viamcpp
+)
+
+install(
+  TARGETS example_motor
+  COMPONENT viam-cpp-sdk_examples
+)

--- a/examples/motor/example_motor.cpp
+++ b/examples/motor/example_motor.cpp
@@ -1,17 +1,3 @@
-#include <components/motor/client.hpp>
-#include <components/motor/motor.hpp>
-#include <components/motor/server.hpp>
-
-#include <common/v1/common.pb.h>
-#include <grpcpp/channel.h>
-#include <grpcpp/client_context.h>
-#include <grpcpp/grpcpp.h>
-#include <grpcpp/support/status.h>
-#include <robot/v1/robot.grpc.pb.h>
-#include <robot/v1/robot.pb.h>
-#include <unistd.h>
-
-#include <boost/optional.hpp>
 #include <chrono>
 #include <cstddef>
 #include <fstream>
@@ -23,14 +9,25 @@
 #include <thread>
 #include <vector>
 
-#include "robot/client.hpp"
-#include "robot/service.hpp"
-#include "rpc/dial.hpp"
+#include <boost/optional.hpp>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/support/status.h>
+#include <unistd.h>
+
+#include <common/v1/common.pb.h>
+#include <robot/v1/robot.grpc.pb.h>
+#include <robot/v1/robot.pb.h>
+
+#include <components/motor/client.hpp>
+#include <components/motor/motor.hpp>
+#include <components/motor/server.hpp>
+#include <robot/client.hpp>
+#include <robot/service.hpp>
+#include <rpc/dial.hpp>
 
 using namespace viam::cppsdk;
-using viam::cppsdk::Credentials;
-using viam::cppsdk::DialOptions;
-using viam::cppsdk::Options;
 using viam::robot::v1::Status;
 
 // TODO(RSDK-2751) Cleanup examples for components
@@ -42,8 +39,8 @@ int main() {
     std::string address = "localhost:8080";
     Options options = Options(0, opts);
     std::shared_ptr<RobotClient> robot = RobotClient::at_address(address, options);
-    std::cout << "Created robot" << std::endl;
     robot->refresh();
+    std::cout << "Created robot" << std::endl;
     std::vector<ResourceName>* resource_names = robot->resource_names();
 
     std::cout << "List resources of the robot" << std::endl;
@@ -55,20 +52,15 @@ int main() {
 
     std::cout << "Getting motor: " << motor_name << std::endl;
     std::shared_ptr<MotorClient> motor = robot->resource_by_name<MotorClient>(motor_name);
-    {
-        Motor::position pos = motor->get_position();
 
-        std::cout << "Motor position " << pos << std::endl;
-    }
+    Motor::position pos = motor->get_position();
+    std::cout << "Motor position " << pos << std::endl;
 
     std::cout << "Moving forward by 1/2 rotation" << std::endl;
     motor->go_for(1000, 0.5);
 
-    {
-        Motor::position pos = motor->get_position();
-
-        std::cout << "Motor position " << pos << std::endl;
-    }
+    pos = motor->get_position();
+    std::cout << "Motor position " << pos << std::endl;
 
     robot->close();
     return 0;

--- a/examples/motor/example_motor.cpp
+++ b/examples/motor/example_motor.cpp
@@ -1,0 +1,75 @@
+#include <components/motor/client.hpp>
+#include <components/motor/motor.hpp>
+#include <components/motor/server.hpp>
+
+#include <common/v1/common.pb.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/support/status.h>
+#include <robot/v1/robot.grpc.pb.h>
+#include <robot/v1/robot.pb.h>
+#include <unistd.h>
+
+#include <boost/optional.hpp>
+#include <chrono>
+#include <cstddef>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "robot/client.hpp"
+#include "robot/service.hpp"
+#include "rpc/dial.hpp"
+
+using viam::robot::v1::Status;
+using Viam::SDK::Credentials;
+using Viam::SDK::Options;
+
+int main() {
+    std::cout << "Started" << std::endl;
+
+    Viam::SDK::DialOptions dial_options = Viam::SDK::DialOptions();
+
+    dial_options.allow_insecure_downgrade = true;
+    boost::optional<Viam::SDK::DialOptions> opts(dial_options);
+
+    std::string address = "localhost:8080";
+    Options options = Options(0, opts);
+    std::shared_ptr<RobotClient> robot = RobotClient::at_address(address, options);
+    std::cout << "Created robot" << std::endl;
+    robot->refresh();
+    std::vector<ResourceName>* resource_names = robot->resource_names();
+
+    std::cout << "List resources of the robot" << std::endl;
+    for (ResourceName resource : *resource_names) {
+        std::cout << "Resource name: " << resource.name() << resource.type() << resource.subtype()
+                  << std::endl;
+    }
+    std::string motor_name = "motor1";
+
+    std::cout << "Getting motor: " << motor_name << std::endl;
+    std::shared_ptr<MotorClient> motor = robot->resource_by_name<MotorClient>(motor_name);
+    {
+        Motor::position pos = motor->get_position();
+
+        std::cout << "Motor position " << pos << std::endl;
+    }
+
+    std::cout << "Moving forward by 1/2 rotation" << std::endl;
+    motor->go_for(1000, 0.5);
+
+    {
+        Motor::position pos = motor->get_position();
+
+        std::cout << "Motor position " << pos << std::endl;
+    }
+
+    robot->close();
+    return 0;
+}

--- a/examples/motor/example_motor.cpp
+++ b/examples/motor/example_motor.cpp
@@ -27,17 +27,18 @@
 #include "robot/service.hpp"
 #include "rpc/dial.hpp"
 
+using namespace viam::cppsdk;
+using viam::cppsdk::Credentials;
+using viam::cppsdk::DialOptions;
+using viam::cppsdk::Options;
 using viam::robot::v1::Status;
-using Viam::SDK::Credentials;
-using Viam::SDK::Options;
 
 int main() {
     std::cout << "Started" << std::endl;
 
-    Viam::SDK::DialOptions dial_options = Viam::SDK::DialOptions();
-
+    DialOptions dial_options;
     dial_options.allow_insecure_downgrade = true;
-    boost::optional<Viam::SDK::DialOptions> opts(dial_options);
+    boost::optional<DialOptions> opts(dial_options);
 
     std::string address = "localhost:8080";
     Options options = Options(0, opts);
@@ -58,7 +59,7 @@ int main() {
     {
         Motor::position pos = motor->get_position();
 
-        std::cout << "Motor position " << pos << std::endl;
+        std::cout << "Motor position " << pos.position << std::endl;
     }
 
     std::cout << "Moving forward by 1/2 rotation" << std::endl;
@@ -67,7 +68,7 @@ int main() {
     {
         Motor::position pos = motor->get_position();
 
-        std::cout << "Motor position " << pos << std::endl;
+        std::cout << "Motor position " << pos.position << std::endl;
     }
 
     robot->close();

--- a/examples/motor/example_motor.cpp
+++ b/examples/motor/example_motor.cpp
@@ -33,9 +33,8 @@ using viam::cppsdk::DialOptions;
 using viam::cppsdk::Options;
 using viam::robot::v1::Status;
 
+// TODO(RSDK-2751) Cleanup examples for components
 int main() {
-    std::cout << "Started" << std::endl;
-
     DialOptions dial_options;
     dial_options.allow_insecure_downgrade = true;
     boost::optional<DialOptions> opts(dial_options);
@@ -59,7 +58,7 @@ int main() {
     {
         Motor::position pos = motor->get_position();
 
-        std::cout << "Motor position " << pos.position << std::endl;
+        std::cout << "Motor position " << pos << std::endl;
     }
 
     std::cout << "Moving forward by 1/2 rotation" << std::endl;
@@ -68,7 +67,7 @@ int main() {
     {
         Motor::position pos = motor->get_position();
 
-        std::cout << "Motor position " << pos.position << std::endl;
+        std::cout << "Motor position " << pos << std::endl;
     }
 
     robot->close();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,6 +93,10 @@ if (VIAMCPPSDK_USE_DYNAMIC_PROTOS)
     ${PROTO_GEN_DIR}/gen/common/v1/common.grpc.pb.h
     ${PROTO_GEN_DIR}/gen/common/v1/common.pb.cc
     ${PROTO_GEN_DIR}/gen/common/v1/common.pb.h
+    ${PROTO_GEN_DIR}/gen/component/motor/v1/motor.grpc.pb.cc
+    ${PROTO_GEN_DIR}/gen/component/motor/v1/motor.grpc.pb.h
+    ${PROTO_GEN_DIR}/gen/component/motor/v1/motor.pb.cc
+    ${PROTO_GEN_DIR}/gen/component/motor/v1/motor.pb.h
     ${PROTO_GEN_DIR}/gen/component/camera/v1/camera.grpc.pb.cc
     ${PROTO_GEN_DIR}/gen/component/camera/v1/camera.grpc.pb.h
     ${PROTO_GEN_DIR}/gen/component/camera/v1/camera.pb.cc
@@ -181,6 +185,8 @@ target_sources(viamcpp
     ${PROTO_GEN_DIR}/gen/app/v1/robot.pb.cc
     ${PROTO_GEN_DIR}/gen/common/v1/common.grpc.pb.cc
     ${PROTO_GEN_DIR}/gen/common/v1/common.pb.cc
+    ${PROTO_GEN_DIR}/gen/component/motor/v1/motor.grpc.pb.cc
+    ${PROTO_GEN_DIR}/gen/component/motor/v1/motor.pb.cc
     ${PROTO_GEN_DIR}/gen/component/camera/v1/camera.grpc.pb.cc
     ${PROTO_GEN_DIR}/gen/component/camera/v1/camera.pb.cc
     ${PROTO_GEN_DIR}/gen/component/generic/v1/generic.grpc.pb.cc
@@ -203,6 +209,9 @@ target_sources(viamcpp
     registry/registry.cpp
     common/proto_type.cpp
     common/utils.cpp
+    components/motor/motor.cpp
+    components/motor/client.cpp
+    components/motor/server.cpp
     components/camera/camera.cpp
     components/camera/client.cpp
     components/camera/server.cpp
@@ -230,12 +239,16 @@ target_sources(viamcpp
     spatialmath/orientation.cpp
     subtype/subtype.cpp
     tests/test_utils.cpp
+    tests/mocks/mock_motor.cpp
     tests/mocks/camera_mocks.cpp
     tests/mocks/generic_mocks.cpp
   PUBLIC FILE_SET viamcpp_public_includes TYPE HEADERS
     FILES
       common/proto_type.hpp
       common/utils.hpp
+      components/motor/motor.hpp
+      components/motor/client.hpp
+      components/motor/server.hpp
       components/camera/camera.hpp
       components/camera/client.hpp
       components/camera/server.hpp
@@ -265,6 +278,7 @@ target_sources(viamcpp
       spatialmath/orientation.hpp
       subtype/subtype.hpp
       tests/test_utils.hpp
+      tests/mocks/mock_motor.hpp
       tests/mocks/camera_mocks.hpp
       tests/mocks/generic_mocks.hpp
   PUBLIC FILE_SET viamcpp_public_pb_includes TYPE HEADERS
@@ -279,6 +293,8 @@ target_sources(viamcpp
       ${PROTO_GEN_DIR}/gen/google/api/http.pb.h
       ${PROTO_GEN_DIR}/gen/google/api/httpbody.pb.h
       ${PROTO_GEN_DIR}/gen/common/v1/common.pb.h
+      ${PROTO_GEN_DIR}/gen/component/motor/v1/motor.grpc.pb.h
+      ${PROTO_GEN_DIR}/gen/component/motor/v1/motor.pb.h
       ${PROTO_GEN_DIR}/gen/component/camera/v1/camera.grpc.pb.h
       ${PROTO_GEN_DIR}/gen/component/camera/v1/camera.pb.h
       ${PROTO_GEN_DIR}/gen/component/generic/v1/generic.grpc.pb.h

--- a/src/components/motor/client.cpp
+++ b/src/components/motor/client.cpp
@@ -113,7 +113,7 @@ Motor::power_status MotorClient::get_power_status() {
     return from_proto(response);
 }
 
-Motor::moving_status MotorClient::is_moving() {
+bool MotorClient::is_moving() {
     viam::component::motor::v1::IsMovingRequest request;
     viam::component::motor::v1::IsMovingResponse response;
 
@@ -122,7 +122,7 @@ Motor::moving_status MotorClient::is_moving() {
     *request.mutable_name() = this->name();
 
     stub_->IsMoving(&ctx, request, &response);
-    return from_proto(response);
+    return response.is_moving();
 }
 
 AttributeMap MotorClient::do_command(AttributeMap command) {

--- a/src/components/motor/client.cpp
+++ b/src/components/motor/client.cpp
@@ -13,9 +13,10 @@
 #include <config/resource.hpp>
 #include <robot/client.hpp>
 
+namespace viam {
+namespace cppsdk {
 
-
-void MotorClient::set_power(double power_pct){
+void MotorClient::set_power(double power_pct) {
     viam::component::motor::v1::SetPowerRequest request;
     viam::component::motor::v1::SetPowerResponse response;
 
@@ -25,10 +26,9 @@ void MotorClient::set_power(double power_pct){
     request.set_power_pct(power_pct);
 
     stub_->SetPower(&ctx, request, &response);
-    return from_proto(response);
 }
 
-void MotorClient::go_for(double rpm, double revolutions){
+void MotorClient::go_for(double rpm, double revolutions) {
     viam::component::motor::v1::GoForRequest request;
     viam::component::motor::v1::GoForResponse response;
 
@@ -39,10 +39,9 @@ void MotorClient::go_for(double rpm, double revolutions){
     request.set_revolutions(revolutions);
 
     stub_->GoFor(&ctx, request, &response);
-    return from_proto(response);
 }
 
-void MotorClient::go_to(double rpm, double position_revolutions){
+void MotorClient::go_to(double rpm, double position_revolutions) {
     viam::component::motor::v1::GoToRequest request;
     viam::component::motor::v1::GoToResponse response;
 
@@ -53,10 +52,9 @@ void MotorClient::go_to(double rpm, double position_revolutions){
     request.set_position_revolutions(position_revolutions);
 
     stub_->GoTo(&ctx, request, &response);
-    return from_proto(response);
 }
 
-void MotorClient::reset_zero_position(double offset){
+void MotorClient::reset_zero_position(double offset) {
     viam::component::motor::v1::ResetZeroPositionRequest request;
     viam::component::motor::v1::ResetZeroPositionResponse response;
 
@@ -66,10 +64,9 @@ void MotorClient::reset_zero_position(double offset){
     request.set_offset(offset);
 
     stub_->ResetZeroPosition(&ctx, request, &response);
-    return from_proto(response);
 }
 
-Motor::position MotorClient::get_position(){
+Motor::position MotorClient::get_position() {
     viam::component::motor::v1::GetPositionRequest request;
     viam::component::motor::v1::GetPositionResponse response;
 
@@ -81,7 +78,7 @@ Motor::position MotorClient::get_position(){
     return from_proto(response);
 }
 
-Motor::properties MotorClient::get_properties(){
+Motor::properties MotorClient::get_properties() {
     viam::component::motor::v1::GetPropertiesRequest request;
     viam::component::motor::v1::GetPropertiesResponse response;
 
@@ -93,7 +90,7 @@ Motor::properties MotorClient::get_properties(){
     return from_proto(response);
 }
 
-void MotorClient::stop(){
+void MotorClient::stop_motor() {
     viam::component::motor::v1::StopRequest request;
     viam::component::motor::v1::StopResponse response;
 
@@ -102,10 +99,9 @@ void MotorClient::stop(){
     *request.mutable_name() = this->name();
 
     stub_->Stop(&ctx, request, &response);
-    return from_proto(response);
 }
 
-Motor::power_status MotorClient::get_power_status(){
+Motor::power_status MotorClient::get_power_status() {
     viam::component::motor::v1::IsPoweredRequest request;
     viam::component::motor::v1::IsPoweredResponse response;
 
@@ -117,7 +113,7 @@ Motor::power_status MotorClient::get_power_status(){
     return from_proto(response);
 }
 
-Motor::moving_status MotorClient::is_moving(){
+Motor::moving_status MotorClient::is_moving() {
     viam::component::motor::v1::IsMovingRequest request;
     viam::component::motor::v1::IsMovingResponse response;
 
@@ -129,17 +125,19 @@ Motor::moving_status MotorClient::is_moving(){
     return from_proto(response);
 }
 
-AttributeMap MotorClient::do_command(ERROR TODO){
-    viam::component::motor::v1::common.v1.DoCommandRequest request;
-    viam::component::motor::v1::common.v1.DoCommandResponse response;
+AttributeMap MotorClient::do_command(AttributeMap command) {
+    viam::common::v1::DoCommandRequest request;
+    viam::common::v1::DoCommandResponse response;
 
     grpc::ClientContext ctx;
 
+    google::protobuf::Struct proto_command = map_to_struct(command);
+    *request.mutable_command() = proto_command;
     *request.mutable_name() = this->name();
-    request.set_TODO(TODO);
 
     stub_->DoCommand(&ctx, request, &response);
-    return from_proto(response);
+    return struct_to_map(response.result());
 }
 
-
+}  // namespace cppsdk
+}  // namespace viam

--- a/src/components/motor/client.cpp
+++ b/src/components/motor/client.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -25,7 +26,10 @@ void MotorClient::set_power(double power_pct) {
     *request.mutable_name() = this->name();
     request.set_power_pct(power_pct);
 
-    stub_->SetPower(&ctx, request, &response);
+    grpc::Status status = stub_->SetPower(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
 }
 
 void MotorClient::go_for(double rpm, double revolutions) {
@@ -38,7 +42,10 @@ void MotorClient::go_for(double rpm, double revolutions) {
     request.set_rpm(rpm);
     request.set_revolutions(revolutions);
 
-    stub_->GoFor(&ctx, request, &response);
+    grpc::Status status = stub_->GoFor(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
 }
 
 void MotorClient::go_to(double rpm, double position_revolutions) {
@@ -51,7 +58,10 @@ void MotorClient::go_to(double rpm, double position_revolutions) {
     request.set_rpm(rpm);
     request.set_position_revolutions(position_revolutions);
 
-    stub_->GoTo(&ctx, request, &response);
+    grpc::Status status = stub_->GoTo(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
 }
 
 void MotorClient::reset_zero_position(double offset) {
@@ -63,7 +73,10 @@ void MotorClient::reset_zero_position(double offset) {
     *request.mutable_name() = this->name();
     request.set_offset(offset);
 
-    stub_->ResetZeroPosition(&ctx, request, &response);
+    grpc::Status status = stub_->ResetZeroPosition(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
 }
 
 Motor::position MotorClient::get_position() {
@@ -74,7 +87,10 @@ Motor::position MotorClient::get_position() {
 
     *request.mutable_name() = this->name();
 
-    stub_->GetPosition(&ctx, request, &response);
+    grpc::Status status = stub_->GetPosition(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
     return from_proto(response);
 }
 
@@ -86,7 +102,10 @@ Motor::properties MotorClient::get_properties() {
 
     *request.mutable_name() = this->name();
 
-    stub_->GetProperties(&ctx, request, &response);
+    grpc::Status status = stub_->GetProperties(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
     return from_proto(response);
 }
 
@@ -98,7 +117,10 @@ void MotorClient::stop_motor() {
 
     *request.mutable_name() = this->name();
 
-    stub_->Stop(&ctx, request, &response);
+    grpc::Status status = stub_->Stop(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
 }
 
 Motor::power_status MotorClient::get_power_status() {
@@ -109,7 +131,10 @@ Motor::power_status MotorClient::get_power_status() {
 
     *request.mutable_name() = this->name();
 
-    stub_->IsPowered(&ctx, request, &response);
+    grpc::Status status = stub_->IsPowered(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
     return from_proto(response);
 }
 
@@ -121,7 +146,10 @@ bool MotorClient::is_moving() {
 
     *request.mutable_name() = this->name();
 
-    stub_->IsMoving(&ctx, request, &response);
+    grpc::Status status = stub_->IsMoving(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
     return response.is_moving();
 }
 
@@ -135,7 +163,10 @@ AttributeMap MotorClient::do_command(AttributeMap command) {
     *request.mutable_command() = proto_command;
     *request.mutable_name() = this->name();
 
-    stub_->DoCommand(&ctx, request, &response);
+    grpc::Status status = stub_->DoCommand(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
     return struct_to_map(response.result());
 }
 

--- a/src/components/motor/client.cpp
+++ b/src/components/motor/client.cpp
@@ -109,7 +109,7 @@ Motor::properties MotorClient::get_properties() {
     return from_proto(response);
 }
 
-void MotorClient::stop_motor() {
+grpc::StatusCode MotorClient::stop(AttributeMap extra) {
     viam::component::motor::v1::StopRequest request;
     viam::component::motor::v1::StopResponse response;
 
@@ -118,9 +118,7 @@ void MotorClient::stop_motor() {
     *request.mutable_name() = this->name();
 
     grpc::Status status = stub_->Stop(&ctx, request, &response);
-    if (!status.ok()) {
-        throw std::runtime_error(status.error_message());
-    }
+    return status.error_code();
 }
 
 Motor::power_status MotorClient::get_power_status() {

--- a/src/components/motor/client.cpp
+++ b/src/components/motor/client.cpp
@@ -1,0 +1,145 @@
+#include <components/motor/client.hpp>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <common/v1/common.pb.h>
+#include <component/motor/v1/motor.grpc.pb.h>
+
+#include <common/utils.hpp>
+#include <components/motor/motor.hpp>
+#include <config/resource.hpp>
+#include <robot/client.hpp>
+
+
+
+void MotorClient::set_power(double power_pct){
+    viam::component::motor::v1::SetPowerRequest request;
+    viam::component::motor::v1::SetPowerResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+    request.set_power_pct(power_pct);
+
+    stub_->SetPower(&ctx, request, &response);
+    return from_proto(response);
+}
+
+void MotorClient::go_for(double rpm, double revolutions){
+    viam::component::motor::v1::GoForRequest request;
+    viam::component::motor::v1::GoForResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+    request.set_rpm(rpm);
+    request.set_revolutions(revolutions);
+
+    stub_->GoFor(&ctx, request, &response);
+    return from_proto(response);
+}
+
+void MotorClient::go_to(double rpm, double position_revolutions){
+    viam::component::motor::v1::GoToRequest request;
+    viam::component::motor::v1::GoToResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+    request.set_rpm(rpm);
+    request.set_position_revolutions(position_revolutions);
+
+    stub_->GoTo(&ctx, request, &response);
+    return from_proto(response);
+}
+
+void MotorClient::reset_zero_position(double offset){
+    viam::component::motor::v1::ResetZeroPositionRequest request;
+    viam::component::motor::v1::ResetZeroPositionResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+    request.set_offset(offset);
+
+    stub_->ResetZeroPosition(&ctx, request, &response);
+    return from_proto(response);
+}
+
+Motor::position MotorClient::get_position(){
+    viam::component::motor::v1::GetPositionRequest request;
+    viam::component::motor::v1::GetPositionResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+
+    stub_->GetPosition(&ctx, request, &response);
+    return from_proto(response);
+}
+
+Motor::properties MotorClient::get_properties(){
+    viam::component::motor::v1::GetPropertiesRequest request;
+    viam::component::motor::v1::GetPropertiesResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+
+    stub_->GetProperties(&ctx, request, &response);
+    return from_proto(response);
+}
+
+void MotorClient::stop(){
+    viam::component::motor::v1::StopRequest request;
+    viam::component::motor::v1::StopResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+
+    stub_->Stop(&ctx, request, &response);
+    return from_proto(response);
+}
+
+Motor::power_status MotorClient::get_power_status(){
+    viam::component::motor::v1::IsPoweredRequest request;
+    viam::component::motor::v1::IsPoweredResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+
+    stub_->IsPowered(&ctx, request, &response);
+    return from_proto(response);
+}
+
+Motor::moving_status MotorClient::is_moving(){
+    viam::component::motor::v1::IsMovingRequest request;
+    viam::component::motor::v1::IsMovingResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+
+    stub_->IsMoving(&ctx, request, &response);
+    return from_proto(response);
+}
+
+AttributeMap MotorClient::do_command(ERROR TODO){
+    viam::component::motor::v1::common.v1.DoCommandRequest request;
+    viam::component::motor::v1::common.v1.DoCommandResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+    request.set_TODO(TODO);
+
+    stub_->DoCommand(&ctx, request, &response);
+    return from_proto(response);
+}
+
+

--- a/src/components/motor/client.hpp
+++ b/src/components/motor/client.hpp
@@ -35,14 +35,6 @@ class MotorClient : public Motor {
           stub_(viam::component::motor::v1::MotorService::NewStub(channel)),
           channel_(std::move(channel)){};
 
-   protected:
-    // This constructor leaves the `channel_` as a nullptr. This is useful for testing
-    // purposes, but renders it unusable for production use. Care should be taken to
-    // avoid use of this constructor outside of tests.
-    MotorClient(std::string name,
-                std::unique_ptr<viam::component::motor::v1::MotorService::StubInterface> stub)
-        : Motor(std::move(name)), stub_(std::move(stub)){};
-
    private:
     std::unique_ptr<viam::component::motor::v1::MotorService::StubInterface> stub_;
     std::shared_ptr<grpc::Channel> channel_;

--- a/src/components/motor/client.hpp
+++ b/src/components/motor/client.hpp
@@ -26,7 +26,7 @@ class MotorClient : public Motor {
     void reset_zero_position(double offset) override;
     position get_position() override;
     properties get_properties() override;
-    void stop_motor() override;
+    grpc::StatusCode stop(AttributeMap extra) override;
     power_status get_power_status() override;
     bool is_moving() override;
     AttributeMap do_command(AttributeMap command) override;

--- a/src/components/motor/client.hpp
+++ b/src/components/motor/client.hpp
@@ -1,0 +1,46 @@
+/// @file components/motor/client.hpp
+///
+/// @brief Implements a gRPC client for the `Motor` component.
+#pragma once
+
+#include <grpcpp/channel.h>
+
+#include <component/motor/v1/motor.grpc.pb.h>
+
+#include <components/motor/motor.hpp>
+#include <components/motor/server.hpp>
+#include <config/resource.hpp>
+#include <robot/client.hpp>
+
+/// @class MotorClient
+/// @brief gRPC client implementation of a `Motor` component.
+/// @ingroup Motor
+class MotorClient : public Motor {
+   public:
+   void set_power(double power_pct) override;
+   void go_for(double rpm, double revolutions) override;
+   void go_to(double rpm, double position_revolutions) override;
+   void reset_zero_position(double offset) override;
+   position get_position() override;
+   properties get_properties() override;
+   void stop() override;
+   power_status get_power_status() override;
+   moving_status is_moving() override;
+   AttributeMap do_command(ERROR TODO) override;
+    MotorClient(std::string name, std::shared_ptr<grpc::Channel> channel)
+        : Motor(std::move(name)),
+          stub_(viam::component::motor::v1::MotorService::NewStub(channel)),
+          channel_(std::move(channel)){};
+
+   protected:
+    // This constructor leaves the `channel_` as a nullptr. This is useful for testing
+    // purposes, but renders it unusable for production use. Care should be taken to
+    // avoid use of this constructor outside of tests.
+    MotorClient(std::string name,
+                 std::unique_ptr<viam::component::motor::v1::MotorService::StubInterface> stub)
+        : Motor(std::move(name)), stub_(std::move(stub)){};
+
+   private:
+    std::unique_ptr<viam::component::motor::v1::MotorService::StubInterface> stub_;
+    std::shared_ptr<grpc::Channel> channel_;
+};

--- a/src/components/motor/client.hpp
+++ b/src/components/motor/client.hpp
@@ -12,21 +12,24 @@
 #include <config/resource.hpp>
 #include <robot/client.hpp>
 
+namespace viam {
+namespace cppsdk {
+
 /// @class MotorClient
 /// @brief gRPC client implementation of a `Motor` component.
 /// @ingroup Motor
 class MotorClient : public Motor {
    public:
-   void set_power(double power_pct) override;
-   void go_for(double rpm, double revolutions) override;
-   void go_to(double rpm, double position_revolutions) override;
-   void reset_zero_position(double offset) override;
-   position get_position() override;
-   properties get_properties() override;
-   void stop() override;
-   power_status get_power_status() override;
-   moving_status is_moving() override;
-   AttributeMap do_command(ERROR TODO) override;
+    void set_power(double power_pct) override;
+    void go_for(double rpm, double revolutions) override;
+    void go_to(double rpm, double position_revolutions) override;
+    void reset_zero_position(double offset) override;
+    position get_position() override;
+    properties get_properties() override;
+    void stop_motor() override;
+    power_status get_power_status() override;
+    moving_status is_moving() override;
+    AttributeMap do_command(AttributeMap command) override;
     MotorClient(std::string name, std::shared_ptr<grpc::Channel> channel)
         : Motor(std::move(name)),
           stub_(viam::component::motor::v1::MotorService::NewStub(channel)),
@@ -37,10 +40,13 @@ class MotorClient : public Motor {
     // purposes, but renders it unusable for production use. Care should be taken to
     // avoid use of this constructor outside of tests.
     MotorClient(std::string name,
-                 std::unique_ptr<viam::component::motor::v1::MotorService::StubInterface> stub)
+                std::unique_ptr<viam::component::motor::v1::MotorService::StubInterface> stub)
         : Motor(std::move(name)), stub_(std::move(stub)){};
 
    private:
     std::unique_ptr<viam::component::motor::v1::MotorService::StubInterface> stub_;
     std::shared_ptr<grpc::Channel> channel_;
 };
+
+}  // namespace cppsdk
+}  // namespace viam

--- a/src/components/motor/client.hpp
+++ b/src/components/motor/client.hpp
@@ -28,7 +28,7 @@ class MotorClient : public Motor {
     properties get_properties() override;
     void stop_motor() override;
     power_status get_power_status() override;
-    moving_status is_moving() override;
+    bool is_moving() override;
     AttributeMap do_command(AttributeMap command) override;
     MotorClient(std::string name, std::shared_ptr<grpc::Channel> channel)
         : Motor(std::move(name)),

--- a/src/components/motor/motor.cpp
+++ b/src/components/motor/motor.cpp
@@ -11,13 +11,16 @@
 #include <registry/registry.hpp>
 #include <resource/resource.hpp>
 
+namespace viam {
+namespace cppsdk {
+
 std::shared_ptr<ResourceServerBase> MotorSubtype::create_resource_server(
     std::shared_ptr<SubtypeService> svc) {
     return std::make_shared<MotorServer>(svc);
 };
 
-std::shared_ptr<ResourceBase> MotorSubtype::create_rpc_client(
-    std::string name, std::shared_ptr<grpc::Channel> chan) {
+std::shared_ptr<ResourceBase> MotorSubtype::create_rpc_client(std::string name,
+                                                              std::shared_ptr<grpc::Channel> chan) {
     return std::make_shared<MotorClient>(std::move(name), std::move(chan));
 };
 
@@ -35,89 +38,73 @@ Subtype Motor::subtype() {
     return Subtype(RDK, COMPONENT, "motor");
 }
 
-
-Motor::position Motor::from_proto(viam::component::motor::v1::GetPositionResponse proto){
+Motor::position Motor::from_proto(viam::component::motor::v1::GetPositionResponse proto) {
     Motor::position position;
     position.position = proto.position();
     return position;
 }
 
-Motor::power_status Motor::from_proto(viam::component::motor::v1::IsPoweredResponse proto){
+Motor::power_status Motor::from_proto(viam::component::motor::v1::IsPoweredResponse proto) {
     Motor::power_status power_status;
     power_status.is_on = proto.is_on();
-    
+
     power_status.power_pct = proto.power_pct();
     return power_status;
 }
 
-Motor::properties Motor::from_proto(viam::component::motor::v1::GetPropertiesResponse proto){
+Motor::properties Motor::from_proto(viam::component::motor::v1::GetPropertiesResponse proto) {
     Motor::properties properties;
     properties.position_reporting = proto.position_reporting();
     return properties;
 }
 
-Motor::moving_status Motor::from_proto(viam::component::motor::v1::IsMovingResponse proto){
+Motor::moving_status Motor::from_proto(viam::component::motor::v1::IsMovingResponse proto) {
     Motor::moving_status moving_status;
     moving_status.is_moving = proto.is_moving();
     return moving_status;
 }
 
-
-
-
-viam::component::motor::v1::GetPositionResponse Motor::to_proto( position position) {
+viam::component::motor::v1::GetPositionResponse Motor::to_proto(position position) {
     viam::component::motor::v1::GetPositionResponse proto;
     proto.set_position(position.position);
-    return proto
+    return proto;
 }
 
-
-viam::component::motor::v1::IsPoweredResponse Motor::to_proto( power_status power_status) {
+viam::component::motor::v1::IsPoweredResponse Motor::to_proto(power_status power_status) {
     viam::component::motor::v1::IsPoweredResponse proto;
     proto.set_is_on(power_status.is_on);
-    
+
     proto.set_power_pct(power_status.power_pct);
-    return proto
+    return proto;
 }
 
-
-viam::component::motor::v1::GetPropertiesResponse Motor::to_proto( properties properties) {
+viam::component::motor::v1::GetPropertiesResponse Motor::to_proto(properties properties) {
     viam::component::motor::v1::GetPropertiesResponse proto;
     proto.set_position_reporting(properties.position_reporting);
-    return proto
+    return proto;
 }
 
-
-viam::component::motor::v1::IsMovingResponse Motor::to_proto( moving_status moving_status) {
+viam::component::motor::v1::IsMovingResponse Motor::to_proto(moving_status moving_status) {
     viam::component::motor::v1::IsMovingResponse proto;
     proto.set_is_moving(moving_status.is_moving);
-    return proto
+    return proto;
 }
 
-
-
 bool operator==(const Motor::position& lhs, const Motor::position& rhs) {
-    return (
-        lhs.position == rhs.position);
+    return (lhs.position == rhs.position);
 }
 
 bool operator==(const Motor::power_status& lhs, const Motor::power_status& rhs) {
-    return (
-        lhs.is_on == rhs.is_on && 
-        lhs.power_pct == rhs.power_pct);
+    return (lhs.is_on == rhs.is_on && lhs.power_pct == rhs.power_pct);
 }
 
 bool operator==(const Motor::properties& lhs, const Motor::properties& rhs) {
-    return (
-        lhs.position_reporting == rhs.position_reporting);
+    return (lhs.position_reporting == rhs.position_reporting);
 }
 
 bool operator==(const Motor::moving_status& lhs, const Motor::moving_status& rhs) {
-    return (
-        lhs.is_moving == rhs.is_moving);
+    return (lhs.is_moving == rhs.is_moving);
 }
-
-
 
 namespace {
 bool init() {
@@ -127,3 +114,6 @@ bool init() {
 
 bool inited = init();
 }  // namespace
+
+}  // namespace cppsdk
+}  // namespace viam

--- a/src/components/motor/motor.cpp
+++ b/src/components/motor/motor.cpp
@@ -1,0 +1,129 @@
+#include <components/motor/motor.hpp>
+
+#include <google/protobuf/descriptor.h>
+
+#include <component/motor/v1/motor.grpc.pb.h>
+#include <component/motor/v1/motor.pb.h>
+
+#include <common/utils.hpp>
+#include <components/motor/client.hpp>
+#include <components/motor/server.hpp>
+#include <registry/registry.hpp>
+#include <resource/resource.hpp>
+
+std::shared_ptr<ResourceServerBase> MotorSubtype::create_resource_server(
+    std::shared_ptr<SubtypeService> svc) {
+    return std::make_shared<MotorServer>(svc);
+};
+
+std::shared_ptr<ResourceBase> MotorSubtype::create_rpc_client(
+    std::string name, std::shared_ptr<grpc::Channel> chan) {
+    return std::make_shared<MotorClient>(std::move(name), std::move(chan));
+};
+
+std::shared_ptr<ResourceSubtype> Motor::resource_subtype() {
+    const google::protobuf::DescriptorPool* p = google::protobuf::DescriptorPool::generated_pool();
+    const google::protobuf::ServiceDescriptor* sd =
+        p->FindServiceByName(viam::component::motor::v1::MotorService::service_full_name());
+    if (sd == nullptr) {
+        throw std::runtime_error("Unable to get service descriptor for the motor service");
+    }
+    return std::make_shared<MotorSubtype>(sd);
+}
+
+Subtype Motor::subtype() {
+    return Subtype(RDK, COMPONENT, "motor");
+}
+
+
+Motor::position Motor::from_proto(viam::component::motor::v1::GetPositionResponse proto){
+    Motor::position position;
+    position.position = proto.position();
+    return position;
+}
+
+Motor::power_status Motor::from_proto(viam::component::motor::v1::IsPoweredResponse proto){
+    Motor::power_status power_status;
+    power_status.is_on = proto.is_on();
+    
+    power_status.power_pct = proto.power_pct();
+    return power_status;
+}
+
+Motor::properties Motor::from_proto(viam::component::motor::v1::GetPropertiesResponse proto){
+    Motor::properties properties;
+    properties.position_reporting = proto.position_reporting();
+    return properties;
+}
+
+Motor::moving_status Motor::from_proto(viam::component::motor::v1::IsMovingResponse proto){
+    Motor::moving_status moving_status;
+    moving_status.is_moving = proto.is_moving();
+    return moving_status;
+}
+
+
+
+
+viam::component::motor::v1::GetPositionResponse Motor::to_proto( position position) {
+    viam::component::motor::v1::GetPositionResponse proto;
+    proto.set_position(position.position);
+    return proto
+}
+
+
+viam::component::motor::v1::IsPoweredResponse Motor::to_proto( power_status power_status) {
+    viam::component::motor::v1::IsPoweredResponse proto;
+    proto.set_is_on(power_status.is_on);
+    
+    proto.set_power_pct(power_status.power_pct);
+    return proto
+}
+
+
+viam::component::motor::v1::GetPropertiesResponse Motor::to_proto( properties properties) {
+    viam::component::motor::v1::GetPropertiesResponse proto;
+    proto.set_position_reporting(properties.position_reporting);
+    return proto
+}
+
+
+viam::component::motor::v1::IsMovingResponse Motor::to_proto( moving_status moving_status) {
+    viam::component::motor::v1::IsMovingResponse proto;
+    proto.set_is_moving(moving_status.is_moving);
+    return proto
+}
+
+
+
+bool operator==(const Motor::position& lhs, const Motor::position& rhs) {
+    return (
+        lhs.position == rhs.position);
+}
+
+bool operator==(const Motor::power_status& lhs, const Motor::power_status& rhs) {
+    return (
+        lhs.is_on == rhs.is_on && 
+        lhs.power_pct == rhs.power_pct);
+}
+
+bool operator==(const Motor::properties& lhs, const Motor::properties& rhs) {
+    return (
+        lhs.position_reporting == rhs.position_reporting);
+}
+
+bool operator==(const Motor::moving_status& lhs, const Motor::moving_status& rhs) {
+    return (
+        lhs.is_moving == rhs.is_moving);
+}
+
+
+
+namespace {
+bool init() {
+    Registry::register_subtype(Motor::subtype(), Motor::resource_subtype());
+    return true;
+};
+
+bool inited = init();
+}  // namespace

--- a/src/components/motor/motor.cpp
+++ b/src/components/motor/motor.cpp
@@ -39,9 +39,7 @@ Subtype Motor::subtype() {
 }
 
 Motor::position Motor::from_proto(viam::component::motor::v1::GetPositionResponse proto) {
-    Motor::position position;
-    position.position = proto.position();
-    return position;
+    return proto.position();
 }
 
 Motor::power_status Motor::from_proto(viam::component::motor::v1::IsPoweredResponse proto) {
@@ -58,15 +56,9 @@ Motor::properties Motor::from_proto(viam::component::motor::v1::GetPropertiesRes
     return properties;
 }
 
-Motor::moving_status Motor::from_proto(viam::component::motor::v1::IsMovingResponse proto) {
-    Motor::moving_status moving_status;
-    moving_status.is_moving = proto.is_moving();
-    return moving_status;
-}
-
 viam::component::motor::v1::GetPositionResponse Motor::to_proto(position position) {
     viam::component::motor::v1::GetPositionResponse proto;
-    proto.set_position(position.position);
+    proto.set_position(position);
     return proto;
 }
 
@@ -84,26 +76,12 @@ viam::component::motor::v1::GetPropertiesResponse Motor::to_proto(properties pro
     return proto;
 }
 
-viam::component::motor::v1::IsMovingResponse Motor::to_proto(moving_status moving_status) {
-    viam::component::motor::v1::IsMovingResponse proto;
-    proto.set_is_moving(moving_status.is_moving);
-    return proto;
-}
-
-bool operator==(const Motor::position& lhs, const Motor::position& rhs) {
-    return (lhs.position == rhs.position);
-}
-
 bool operator==(const Motor::power_status& lhs, const Motor::power_status& rhs) {
     return (lhs.is_on == rhs.is_on && lhs.power_pct == rhs.power_pct);
 }
 
 bool operator==(const Motor::properties& lhs, const Motor::properties& rhs) {
     return (lhs.position_reporting == rhs.position_reporting);
-}
-
-bool operator==(const Motor::moving_status& lhs, const Motor::moving_status& rhs) {
-    return (lhs.is_moving == rhs.is_moving);
 }
 
 namespace {

--- a/src/components/motor/motor.hpp
+++ b/src/components/motor/motor.hpp
@@ -11,19 +11,22 @@
 #include <string>
 #include <subtype/subtype.hpp>
 
+namespace viam {
+namespace cppsdk {
+
 /// @defgroup Motor Classes related to the `Motor` component.
 
 /// @class MotorSubtype
 /// @brief Defines a `ResourceSubtype` for the `Motor` component.
 /// @ingroup Motor
 class MotorSubtype : public ResourceSubtype {
-public:
-  std::shared_ptr<ResourceServerBase> create_resource_server(
-      std::shared_ptr<SubtypeService> svc) override;
-  std::shared_ptr<ResourceBase> create_rpc_client(
-      std::string name, std::shared_ptr<grpc::Channel> chan) override;
-  MotorSubtype(const google::protobuf::ServiceDescriptor *service_descriptor)
-      : ResourceSubtype(service_descriptor){};
+   public:
+    std::shared_ptr<ResourceServerBase> create_resource_server(
+        std::shared_ptr<SubtypeService> svc) override;
+    std::shared_ptr<ResourceBase> create_rpc_client(std::string name,
+                                                    std::shared_ptr<grpc::Channel> chan) override;
+    MotorSubtype(const google::protobuf::ServiceDescriptor* service_descriptor)
+        : ResourceSubtype(service_descriptor){};
 };
 
 /// @class Motor motor.hpp "components/motor/motor.hpp"
@@ -33,114 +36,123 @@ public:
 /// This acts as an abstract base class to be inherited from by any drivers representing
 /// specific motor implementations. This class cannot be used on its own.
 class Motor : public ComponentBase {
-public:
-  
-  /// @struct position
-  /// @brief TODO.
-  struct position {
+   public:
+    /// @struct position
+    /// @brief TODO.
+    struct position {
         /// Current position of the motor relative to its home
         double position;
-  };
-  
-  /// @struct power_status
-  /// @brief TODO.
-  struct power_status {
+    };
+
+    /// @struct power_status
+    /// @brief TODO.
+    struct power_status {
         /// Returns true if the motor is on
         bool is_on;
-        /// Returns power percent (from 0 to 1, or from -1 to 1 for motors that support negative power), based on the last command sent to motor. If the last command was a stop command, this value will be 0.
+        /// Returns power percent (from 0 to 1, or from -1 to 1 for motors that support negative
+        /// power), based on the last command sent to motor. If the last command was a stop command,
+        /// this value will be 0.
         double power_pct;
-  };
-  
-  /// @struct properties
-  /// @brief TODO.
-  struct properties {
+    };
+
+    /// @struct properties
+    /// @brief TODO.
+    struct properties {
         /// Returns true if the motor supports reporting its position
         bool position_reporting;
-  };
-  
-  /// @struct moving_status
-  /// @brief TODO.
-  struct moving_status {
-        ///
+    };
+
+    /// @struct moving_status
+    /// @brief TODO.
+    struct moving_status {
+        /// TODO
         bool is_moving;
-  };
-  
-  
+    };
 
-  // functions shared across all components
-  static std::shared_ptr<ResourceSubtype> resource_subtype();
-  static Subtype subtype();
+    // functions shared across all components
+    static std::shared_ptr<ResourceSubtype> resource_subtype();
+    static Subtype subtype();
 
-  
-  /// @brief creates an `position` struct from its proto representation.
-  static position from_proto(viam::component::motor::v1::GetPositionResponse proto);
-    
-  /// @brief creates an `power_status` struct from its proto representation.
-  static power_status from_proto(viam::component::motor::v1::IsPoweredResponse proto);
-    
-  /// @brief creates an `properties` struct from its proto representation.
-  static properties from_proto(viam::component::motor::v1::GetPropertiesResponse proto);
-    
-  /// @brief creates an `moving_status` struct from its proto representation.
-  static moving_status from_proto(viam::component::motor::v1::IsMovingResponse proto);
-    
+    /// @brief creates an `position` struct from its proto representation.
+    static position from_proto(viam::component::motor::v1::GetPositionResponse proto);
 
-  
-  /// @brief converts an `position` struct to its proto representation.
-  static viam::component::motor::v1::GetPositionResponse to_proto(position position);
-  
-  /// @brief converts an `power_status` struct to its proto representation.
-  static viam::component::motor::v1::IsPoweredResponse to_proto(power_status power_status);
-  
-  /// @brief converts an `properties` struct to its proto representation.
-  static viam::component::motor::v1::GetPropertiesResponse to_proto(properties properties);
-  
-  /// @brief converts an `moving_status` struct to its proto representation.
-  static viam::component::motor::v1::IsMovingResponse to_proto(moving_status moving_status);
-  
+    /// @brief creates an `power_status` struct from its proto representation.
+    static power_status from_proto(viam::component::motor::v1::IsPoweredResponse proto);
 
-  
-  ///  SetPower sets the percentage of the motor's total power that should be employed expressed a value between -1 and 1 where negative values indicate a backwards direction and positive values a forward direction
-  virtual void set_power(double power_pct) = 0;
-  
-  ///  GoFor instructs the motor to turn at a specified speed, which is expressed in RPM, for a specified number of rotations relative to its starting position This method will return an error if position reporting is not supported If revolutions is 0, this will run the motor at rpm indefinitely If revolutions != 0, this will block until the number of revolutions has been completed or another operation comes in.
-  virtual void go_for(double rpm, double revolutions) = 0;
-  
-  ///  GoTo requests the robot's motor to move to a specific position that is relative to its home position at a specified speed which is expressed in RPM This method will return an error if position reporting is not supported
-  virtual void go_to(double rpm, double position_revolutions) = 0;
-  
-  ///  ResetZeroPosition sets the current position of the motor as the new zero position This method will return an error if position reporting is not supported
-  virtual void reset_zero_position(double offset) = 0;
-  
-  ///  Position reports the position of the robot's motor relative to its zero position This method will return an error if position reporting is not supported
-  virtual position get_position() = 0;
-  
-  ///  GetProperties returns a message of booleans indicating which optional features the robot's motor supports
-  virtual properties get_properties() = 0;
-  
-  ///  Stop turns the robot's motor off
-  virtual void stop() = 0;
-  
-  ///  IsPowered returns true if the robot's motor is on
-  virtual power_status get_power_status() = 0;
-  
-  ///  IsMoving reports if a component is in motion
-  virtual moving_status is_moving() = 0;
-  
-  ///  DoCommand sends/receives arbitrary commands
-  virtual AttributeMap do_command(ERROR TODO) = 0;
-  
+    /// @brief creates an `properties` struct from its proto representation.
+    static properties from_proto(viam::component::motor::v1::GetPropertiesResponse proto);
 
-protected:
-  explicit Motor(std::string name) : ComponentBase(std::move(name)){};
+    /// @brief creates an `moving_status` struct from its proto representation.
+    static moving_status from_proto(viam::component::motor::v1::IsMovingResponse proto);
+
+    /// @brief converts an `position` struct to its proto representation.
+    static viam::component::motor::v1::GetPositionResponse to_proto(position position);
+
+    /// @brief converts an `power_status` struct to its proto representation.
+    static viam::component::motor::v1::IsPoweredResponse to_proto(power_status power_status);
+
+    /// @brief converts an `properties` struct to its proto representation.
+    static viam::component::motor::v1::GetPropertiesResponse to_proto(properties properties);
+
+    /// @brief converts an `moving_status` struct to its proto representation.
+    static viam::component::motor::v1::IsMovingResponse to_proto(moving_status moving_status);
+
+    /// SetPower sets the percentage of the motor's total power that should be employed expressed a
+    /// value between -1 and 1 where negative values indicate a backwards direction and positive
+    /// values a forward direction
+    /// @param power_pct Percentage of motor's power, between -1 and 1
+    virtual void set_power(double power_pct) = 0;
+
+    /// GoFor instructs the motor to turn at a specified speed, which is expressed in RPM, for a
+    /// specified number of rotations relative to its starting position This method will return an
+    /// error if position reporting is not supported If revolutions is 0, this will run the motor at
+    /// rpm indefinitely If revolutions != 0, this will block until the number of revolutions has
+    /// been completed or another operation comes in.
+    /// @param rpm Speed of motor travel in rotations per minute
+    /// @param revolutions Number of revolutions relative to motor's start position
+    virtual void go_for(double rpm, double revolutions) = 0;
+
+    /// GoTo requests the robot's motor to move to a specific position that is relative to its home
+    /// position at a specified speed which is expressed in RPM This method will return an error if
+    /// position reporting is not supported
+    /// @param rpm Speed of motor travel in rotations per minute
+    /// @param position_revolutions Number of revolutions relative to motor's home home/zero
+    virtual void go_to(double rpm, double position_revolutions) = 0;
+
+    /// ResetZeroPosition sets the current position of the motor as the new zero position This
+    /// method will return an error if position reporting is not supported
+    /// @param offset Motor position
+    virtual void reset_zero_position(double offset) = 0;
+
+    /// Position reports the position of the robot's motor relative to its zero position This method
+    /// will return an error if position reporting is not supported
+    virtual position get_position() = 0;
+
+    /// GetProperties returns a message of booleans indicating which optional features the robot's
+    /// motor supports
+    virtual properties get_properties() = 0;
+
+    /// Stop turns the robot's motor off
+    virtual void stop_motor() = 0;
+
+    /// IsPowered returns true if the robot's motor is on
+    virtual power_status get_power_status() = 0;
+
+    /// IsMoving reports if a component is in motion
+    virtual moving_status is_moving() = 0;
+
+    /// DoCommand sends/receives arbitrary commands
+    /// @param TODO TODO
+    virtual AttributeMap do_command(AttributeMap command) = 0;
+
+   protected:
+    explicit Motor(std::string name) : ComponentBase(std::move(name)){};
 };
 
-
 bool operator==(const Motor::position& lhs, const Motor::position& rhs);
-
 bool operator==(const Motor::power_status& lhs, const Motor::power_status& rhs);
-
 bool operator==(const Motor::properties& lhs, const Motor::properties& rhs);
-
 bool operator==(const Motor::moving_status& lhs, const Motor::moving_status& rhs);
 
+}  // namespace cppsdk
+}  // namespace viam

--- a/src/components/motor/motor.hpp
+++ b/src/components/motor/motor.hpp
@@ -3,6 +3,11 @@
 /// @brief Defines a `Motor` component.
 #pragma once
 
+// direct relevant
+// std::global
+// third party
+// local proto
+// sdk local
 #include <common/proto_type.hpp>
 #include <common/utils.hpp>
 #include <component/motor/v1/motor.pb.h>

--- a/src/components/motor/motor.hpp
+++ b/src/components/motor/motor.hpp
@@ -30,7 +30,7 @@ class MotorSubtype : public ResourceSubtype {
 };
 
 /// @class Motor motor.hpp "components/motor/motor.hpp"
-/// @brief TODO
+/// @brief A `Motor` represents physical hardware that controls the rotation of an axle
 /// @ingroup Motor
 ///
 /// This acts as an abstract base class to be inherited from by any drivers representing
@@ -38,121 +38,100 @@ class MotorSubtype : public ResourceSubtype {
 class Motor : public ComponentBase {
    public:
     /// @struct position
-    /// @brief TODO.
-    struct position {
-        /// Current position of the motor relative to its home
-        double position;
-    };
+    /// Current position of the motor relative to its home
+    typedef double position;
 
     /// @struct power_status
-    /// @brief TODO.
+    /// @brief Information about power-state of the motor
     struct power_status {
-        /// Returns true if the motor is on
+        /// True if the motor is on
         bool is_on;
-        /// Returns power percent (from 0 to 1, or from -1 to 1 for motors that support negative
+        /// Power percent (from 0 to 1, or from -1 to 1 for motors that support negative
         /// power), based on the last command sent to motor. If the last command was a stop command,
         /// this value will be 0.
         double power_pct;
     };
 
     /// @struct properties
-    /// @brief TODO.
+    /// @brief Features that the specific motor supports
     struct properties {
-        /// Returns true if the motor supports reporting its position
+        /// True if the motor supports reporting its position
         bool position_reporting;
-    };
-
-    /// @struct moving_status
-    /// @brief TODO.
-    struct moving_status {
-        /// TODO
-        bool is_moving;
     };
 
     // functions shared across all components
     static std::shared_ptr<ResourceSubtype> resource_subtype();
     static Subtype subtype();
 
-    /// @brief creates an `position` struct from its proto representation.
+    /// @brief Creates an `position` struct from its proto representation.
     static position from_proto(viam::component::motor::v1::GetPositionResponse proto);
 
-    /// @brief creates an `power_status` struct from its proto representation.
+    /// @brief Creates an `power_status` struct from its proto representation.
     static power_status from_proto(viam::component::motor::v1::IsPoweredResponse proto);
 
-    /// @brief creates an `properties` struct from its proto representation.
+    /// @brief Creates an `properties` struct from its proto representation.
     static properties from_proto(viam::component::motor::v1::GetPropertiesResponse proto);
 
-    /// @brief creates an `moving_status` struct from its proto representation.
-    static moving_status from_proto(viam::component::motor::v1::IsMovingResponse proto);
-
-    /// @brief converts an `position` struct to its proto representation.
+    /// @brief Converts an `position` struct to its proto representation.
     static viam::component::motor::v1::GetPositionResponse to_proto(position position);
 
-    /// @brief converts an `power_status` struct to its proto representation.
+    /// @brief Converts an `power_status` struct to its proto representation.
     static viam::component::motor::v1::IsPoweredResponse to_proto(power_status power_status);
 
-    /// @brief converts an `properties` struct to its proto representation.
+    /// @brief Converts an `properties` struct to its proto representation.
     static viam::component::motor::v1::GetPropertiesResponse to_proto(properties properties);
 
-    /// @brief converts an `moving_status` struct to its proto representation.
-    static viam::component::motor::v1::IsMovingResponse to_proto(moving_status moving_status);
-
-    /// SetPower sets the percentage of the motor's total power that should be employed expressed a
+    /// set_power sets the percentage of the motor's total power that should be employed expressed a
     /// value between -1 and 1 where negative values indicate a backwards direction and positive
     /// values a forward direction
     /// @param power_pct Percentage of motor's power, between -1 and 1
     virtual void set_power(double power_pct) = 0;
 
-    /// GoFor instructs the motor to turn at a specified speed, which is expressed in RPM, for a
-    /// specified number of rotations relative to its starting position This method will return an
-    /// error if position reporting is not supported If revolutions is 0, this will run the motor at
-    /// rpm indefinitely If revolutions != 0, this will block until the number of revolutions has
-    /// been completed or another operation comes in.
+    /// go_for instructs the motor to turn at a specified speed, which is expressed in RPM, for a
+    /// specified number of rotations relative to its starting position. If revolutions is 0, this
+    /// will run the motor at rpm indefinitely. If revolutions != 0, this will block until the
+    /// number of revolutions has been completed or another operation comes in.
     /// @param rpm Speed of motor travel in rotations per minute
     /// @param revolutions Number of revolutions relative to motor's start position
     virtual void go_for(double rpm, double revolutions) = 0;
 
-    /// GoTo requests the robot's motor to move to a specific position that is relative to its home
-    /// position at a specified speed which is expressed in RPM This method will return an error if
-    /// position reporting is not supported
+    /// go_to requests the robot's motor to move to a specific position that is relative to its home
+    /// position at a specified speed which is expressed in RPM.
     /// @param rpm Speed of motor travel in rotations per minute
     /// @param position_revolutions Number of revolutions relative to motor's home home/zero
     virtual void go_to(double rpm, double position_revolutions) = 0;
 
-    /// ResetZeroPosition sets the current position of the motor as the new zero position This
-    /// method will return an error if position reporting is not supported
+    /// reset_zero_position sets the current position of the motor as the new zero position.
     /// @param offset Motor position
     virtual void reset_zero_position(double offset) = 0;
 
-    /// Position reports the position of the robot's motor relative to its zero position This method
-    /// will return an error if position reporting is not supported
+    /// get_position reports the position of the robot's motor relative to its zero position.
     virtual position get_position() = 0;
 
-    /// GetProperties returns a message of booleans indicating which optional features the robot's
-    /// motor supports
+    /// get_properties returns the properties of the motor which comprises the booleans indicating
+    /// which optional features the robot's motor supports
     virtual properties get_properties() = 0;
 
-    /// Stop turns the robot's motor off
+    /// stop_motor turns the robot's motor off
     virtual void stop_motor() = 0;
 
-    /// IsPowered returns true if the robot's motor is on
+    /// @return the motor's current power_status
     virtual power_status get_power_status() = 0;
 
-    /// IsMoving reports if a component is in motion
-    virtual moving_status is_moving() = 0;
+    /// is_moving reports if a component is in motion
+    virtual bool is_moving() = 0;
 
-    /// DoCommand sends/receives arbitrary commands
-    /// @param TODO TODO
+    /// Send/receive arbitrary commands to the resource.
+    /// @param Command the command to execute.
+    /// @return The result of the executed command.
     virtual AttributeMap do_command(AttributeMap command) = 0;
 
    protected:
     explicit Motor(std::string name) : ComponentBase(std::move(name)){};
 };
 
-bool operator==(const Motor::position& lhs, const Motor::position& rhs);
 bool operator==(const Motor::power_status& lhs, const Motor::power_status& rhs);
 bool operator==(const Motor::properties& lhs, const Motor::properties& rhs);
-bool operator==(const Motor::moving_status& lhs, const Motor::moving_status& rhs);
 
 }  // namespace cppsdk
 }  // namespace viam

--- a/src/components/motor/motor.hpp
+++ b/src/components/motor/motor.hpp
@@ -3,17 +3,14 @@
 /// @brief Defines a `Motor` component.
 #pragma once
 
-// direct relevant
-// std::global
-// third party
-// local proto
-// sdk local
+#include <string>
+
+#include <component/motor/v1/motor.pb.h>
+
 #include <common/proto_type.hpp>
 #include <common/utils.hpp>
-#include <component/motor/v1/motor.pb.h>
 #include <config/resource.hpp>
 #include <registry/registry.hpp>
-#include <string>
 #include <subtype/subtype.hpp>
 
 namespace viam {
@@ -43,7 +40,7 @@ class MotorSubtype : public ResourceSubtype {
 class Motor : public ComponentBase {
    public:
     /// @struct position
-    /// Current position of the motor relative to its home
+    /// @brief Current position of the motor relative to its home
     typedef double position;
 
     /// @struct power_status
@@ -68,65 +65,69 @@ class Motor : public ComponentBase {
     static std::shared_ptr<ResourceSubtype> resource_subtype();
     static Subtype subtype();
 
-    /// @brief Creates an `position` struct from its proto representation.
+    /// @brief Creates a `position` struct from its proto representation.
     static position from_proto(viam::component::motor::v1::GetPositionResponse proto);
 
-    /// @brief Creates an `power_status` struct from its proto representation.
+    /// @brief Creates a `power_status` struct from its proto representation.
     static power_status from_proto(viam::component::motor::v1::IsPoweredResponse proto);
 
-    /// @brief Creates an `properties` struct from its proto representation.
+    /// @brief Creates a `properties` struct from its proto representation.
     static properties from_proto(viam::component::motor::v1::GetPropertiesResponse proto);
 
-    /// @brief Converts an `position` struct to its proto representation.
+    /// @brief Converts a `position` struct to its proto representation.
     static viam::component::motor::v1::GetPositionResponse to_proto(position position);
 
-    /// @brief Converts an `power_status` struct to its proto representation.
+    /// @brief Converts a `power_status` struct to its proto representation.
     static viam::component::motor::v1::IsPoweredResponse to_proto(power_status power_status);
 
-    /// @brief Converts an `properties` struct to its proto representation.
+    /// @brief Converts a `properties` struct to its proto representation.
     static viam::component::motor::v1::GetPropertiesResponse to_proto(properties properties);
 
-    /// set_power sets the percentage of the motor's total power that should be employed expressed a
-    /// value between -1 and 1 where negative values indicate a backwards direction and positive
-    /// values a forward direction
-    /// @param power_pct Percentage of motor's power, between -1 and 1
+    /// @brief Sets the percentage of the motor's total power that should be employed.
+    /// @param power_pct Percentage of motor's power, between -1 and 1, where negative values
+    /// indicate a backwards direction and positive values, a forward direction.
     virtual void set_power(double power_pct) = 0;
 
-    /// go_for instructs the motor to turn at a specified speed, which is expressed in RPM, for a
-    /// specified number of rotations relative to its starting position. If revolutions is 0, this
-    /// will run the motor at rpm indefinitely. If revolutions != 0, this will block until the
-    /// number of revolutions has been completed or another operation comes in.
+    /// @brief Instructs the motor to turn at a specified speed, which is expressed in RPM, for a
+    /// specified number of rotations relative to its starting position.
     /// @param rpm Speed of motor travel in rotations per minute
-    /// @param revolutions Number of revolutions relative to motor's start position
+    /// @param revolutions Number of revolutions relative to motor's start position. If
+    /// `revolutions` == 0, this will run the motor at `rpm` indefinetely. If `revolutions` != 0,
+    /// this will block until the number of revolutions has been completed or another operation
+    /// comes in.
+    /// @throws runtime_error if position reporting is not supported
     virtual void go_for(double rpm, double revolutions) = 0;
 
-    /// go_to requests the robot's motor to move to a specific position that is relative to its home
-    /// position at a specified speed which is expressed in RPM.
+    /// @brief Move the motor to a specific position that is relative to its
+    /// home position at a specified speed which is expressed in RPM.
     /// @param rpm Speed of motor travel in rotations per minute
     /// @param position_revolutions Number of revolutions relative to motor's home home/zero
+    /// @throws runtime_error if position reporting is not supported
     virtual void go_to(double rpm, double position_revolutions) = 0;
 
-    /// reset_zero_position sets the current position of the motor as the new zero position.
+    /// @brief Sets the current position of the motor as the new zero position.
     /// @param offset Motor position
+    /// @throws runtime_error if position reporting is not supported
     virtual void reset_zero_position(double offset) = 0;
 
-    /// get_position reports the position of the robot's motor relative to its zero position.
+    /// @brief Reports the position of the robot's motor relative to its zero position.
+    /// @throws runtime_error if position reporting is not supported
     virtual position get_position() = 0;
 
-    /// get_properties returns the properties of the motor which comprises the booleans indicating
+    /// @brief Returns the properties of the motor which comprises the booleans indicating
     /// which optional features the robot's motor supports
     virtual properties get_properties() = 0;
 
-    /// stop_motor turns the robot's motor off
+    /// @brief Turns the robot's motor off
     virtual void stop_motor() = 0;
 
-    /// @return the motor's current power_status
+    /// @return The motor's current power_status
     virtual power_status get_power_status() = 0;
 
-    /// is_moving reports if a component is in motion
+    /// @brief Reports if a component is in motion
     virtual bool is_moving() = 0;
 
-    /// Send/receive arbitrary commands to the resource.
+    /// @brief Send/receive arbitrary commands to the resource.
     /// @param Command the command to execute.
     /// @return The result of the executed command.
     virtual AttributeMap do_command(AttributeMap command) = 0;

--- a/src/components/motor/motor.hpp
+++ b/src/components/motor/motor.hpp
@@ -1,0 +1,146 @@
+/// @file components/motor/motor.hpp
+///
+/// @brief Defines a `Motor` component.
+#pragma once
+
+#include <common/proto_type.hpp>
+#include <common/utils.hpp>
+#include <component/motor/v1/motor.pb.h>
+#include <config/resource.hpp>
+#include <registry/registry.hpp>
+#include <string>
+#include <subtype/subtype.hpp>
+
+/// @defgroup Motor Classes related to the `Motor` component.
+
+/// @class MotorSubtype
+/// @brief Defines a `ResourceSubtype` for the `Motor` component.
+/// @ingroup Motor
+class MotorSubtype : public ResourceSubtype {
+public:
+  std::shared_ptr<ResourceServerBase> create_resource_server(
+      std::shared_ptr<SubtypeService> svc) override;
+  std::shared_ptr<ResourceBase> create_rpc_client(
+      std::string name, std::shared_ptr<grpc::Channel> chan) override;
+  MotorSubtype(const google::protobuf::ServiceDescriptor *service_descriptor)
+      : ResourceSubtype(service_descriptor){};
+};
+
+/// @class Motor motor.hpp "components/motor/motor.hpp"
+/// @brief TODO
+/// @ingroup Motor
+///
+/// This acts as an abstract base class to be inherited from by any drivers representing
+/// specific motor implementations. This class cannot be used on its own.
+class Motor : public ComponentBase {
+public:
+  
+  /// @struct position
+  /// @brief TODO.
+  struct position {
+        /// Current position of the motor relative to its home
+        double position;
+  };
+  
+  /// @struct power_status
+  /// @brief TODO.
+  struct power_status {
+        /// Returns true if the motor is on
+        bool is_on;
+        /// Returns power percent (from 0 to 1, or from -1 to 1 for motors that support negative power), based on the last command sent to motor. If the last command was a stop command, this value will be 0.
+        double power_pct;
+  };
+  
+  /// @struct properties
+  /// @brief TODO.
+  struct properties {
+        /// Returns true if the motor supports reporting its position
+        bool position_reporting;
+  };
+  
+  /// @struct moving_status
+  /// @brief TODO.
+  struct moving_status {
+        ///
+        bool is_moving;
+  };
+  
+  
+
+  // functions shared across all components
+  static std::shared_ptr<ResourceSubtype> resource_subtype();
+  static Subtype subtype();
+
+  
+  /// @brief creates an `position` struct from its proto representation.
+  static position from_proto(viam::component::motor::v1::GetPositionResponse proto);
+    
+  /// @brief creates an `power_status` struct from its proto representation.
+  static power_status from_proto(viam::component::motor::v1::IsPoweredResponse proto);
+    
+  /// @brief creates an `properties` struct from its proto representation.
+  static properties from_proto(viam::component::motor::v1::GetPropertiesResponse proto);
+    
+  /// @brief creates an `moving_status` struct from its proto representation.
+  static moving_status from_proto(viam::component::motor::v1::IsMovingResponse proto);
+    
+
+  
+  /// @brief converts an `position` struct to its proto representation.
+  static viam::component::motor::v1::GetPositionResponse to_proto(position position);
+  
+  /// @brief converts an `power_status` struct to its proto representation.
+  static viam::component::motor::v1::IsPoweredResponse to_proto(power_status power_status);
+  
+  /// @brief converts an `properties` struct to its proto representation.
+  static viam::component::motor::v1::GetPropertiesResponse to_proto(properties properties);
+  
+  /// @brief converts an `moving_status` struct to its proto representation.
+  static viam::component::motor::v1::IsMovingResponse to_proto(moving_status moving_status);
+  
+
+  
+  ///  SetPower sets the percentage of the motor's total power that should be employed expressed a value between -1 and 1 where negative values indicate a backwards direction and positive values a forward direction
+  virtual void set_power(double power_pct) = 0;
+  
+  ///  GoFor instructs the motor to turn at a specified speed, which is expressed in RPM, for a specified number of rotations relative to its starting position This method will return an error if position reporting is not supported If revolutions is 0, this will run the motor at rpm indefinitely If revolutions != 0, this will block until the number of revolutions has been completed or another operation comes in.
+  virtual void go_for(double rpm, double revolutions) = 0;
+  
+  ///  GoTo requests the robot's motor to move to a specific position that is relative to its home position at a specified speed which is expressed in RPM This method will return an error if position reporting is not supported
+  virtual void go_to(double rpm, double position_revolutions) = 0;
+  
+  ///  ResetZeroPosition sets the current position of the motor as the new zero position This method will return an error if position reporting is not supported
+  virtual void reset_zero_position(double offset) = 0;
+  
+  ///  Position reports the position of the robot's motor relative to its zero position This method will return an error if position reporting is not supported
+  virtual position get_position() = 0;
+  
+  ///  GetProperties returns a message of booleans indicating which optional features the robot's motor supports
+  virtual properties get_properties() = 0;
+  
+  ///  Stop turns the robot's motor off
+  virtual void stop() = 0;
+  
+  ///  IsPowered returns true if the robot's motor is on
+  virtual power_status get_power_status() = 0;
+  
+  ///  IsMoving reports if a component is in motion
+  virtual moving_status is_moving() = 0;
+  
+  ///  DoCommand sends/receives arbitrary commands
+  virtual AttributeMap do_command(ERROR TODO) = 0;
+  
+
+protected:
+  explicit Motor(std::string name) : ComponentBase(std::move(name)){};
+};
+
+
+bool operator==(const Motor::position& lhs, const Motor::position& rhs);
+
+bool operator==(const Motor::power_status& lhs, const Motor::power_status& rhs);
+
+bool operator==(const Motor::properties& lhs, const Motor::properties& rhs);
+
+bool operator==(const Motor::moving_status& lhs, const Motor::moving_status& rhs);
+

--- a/src/components/motor/motor.hpp
+++ b/src/components/motor/motor.hpp
@@ -118,9 +118,6 @@ class Motor : public ComponentBase {
     /// which optional features the robot's motor supports
     virtual properties get_properties() = 0;
 
-    /// @brief Turns the robot's motor off
-    virtual void stop_motor() = 0;
-
     /// @return The motor's current power_status
     virtual power_status get_power_status() = 0;
 

--- a/src/components/motor/server.cpp
+++ b/src/components/motor/server.cpp
@@ -148,7 +148,7 @@ namespace cppsdk {
 
     std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
 
-    motor->stop_motor();
+    motor->stop(AttributeMap());
 
     return ::grpc::Status();
 }

--- a/src/components/motor/server.cpp
+++ b/src/components/motor/server.cpp
@@ -213,7 +213,6 @@ namespace cppsdk {
     AttributeMap result = motor->do_command(struct_to_map(request->command()));
 
     *response->mutable_result() = map_to_struct(result);
-    /* response->mutable_result()->CopyFrom(map_to_struct(result)); */
 
     return ::grpc::Status();
 }

--- a/src/components/motor/server.cpp
+++ b/src/components/motor/server.cpp
@@ -218,9 +218,7 @@ namespace cppsdk {
 }
 
 void MotorServer::register_server(std::shared_ptr<Server> server) {
-    viam::component::motor::v1::MotorService::Service* motor =
-        static_cast<viam::component::motor::v1::MotorService::Service*>(this);
-    server->register_service(motor);
+    server->register_service(this);
 }
 
 std::shared_ptr<SubtypeService> MotorServer::get_sub_svc() {

--- a/src/components/motor/server.cpp
+++ b/src/components/motor/server.cpp
@@ -1,0 +1,214 @@
+#include <components/motor/server.hpp>
+
+#include <common/utils.hpp>
+#include <components/motor/motor.hpp>
+#include <config/resource.hpp>
+#include <rpc/server.hpp>
+
+
+
+::grpc::Status MotorServer::SetPower(::grpc::ServerContext* context,
+                        const ::viam::component::motor::v1::SetPowerRequest* request,
+                        ::viam::component::motor::v1::SetPowerResponse* response) {
+    
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Motor::SetPower] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+    
+    std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+    return ::grpc::Status();
+}
+
+::grpc::Status MotorServer::GoFor(::grpc::ServerContext* context,
+                        const ::viam::component::motor::v1::GoForRequest* request,
+                        ::viam::component::motor::v1::GoForResponse* response) {
+    
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Motor::GoFor] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+    
+    std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+    return ::grpc::Status();
+}
+
+::grpc::Status MotorServer::GoTo(::grpc::ServerContext* context,
+                        const ::viam::component::motor::v1::GoToRequest* request,
+                        ::viam::component::motor::v1::GoToResponse* response) {
+    
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Motor::GoTo] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+    
+    std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+    return ::grpc::Status();
+}
+
+::grpc::Status MotorServer::ResetZeroPosition(::grpc::ServerContext* context,
+                        const ::viam::component::motor::v1::ResetZeroPositionRequest* request,
+                        ::viam::component::motor::v1::ResetZeroPositionResponse* response) {
+    
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Motor::ResetZeroPosition] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+    
+    std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+    return ::grpc::Status();
+}
+
+::grpc::Status MotorServer::GetPosition(::grpc::ServerContext* context,
+                        const ::viam::component::motor::v1::GetPositionRequest* request,
+                        ::viam::component::motor::v1::GetPositionResponse* response) {
+    
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Motor::GetPosition] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+    
+    std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+    
+    Motor::position result = motor->get_position();
+    *response->mutable_position() = result.position;
+    return ::grpc::Status();
+}
+
+::grpc::Status MotorServer::GetProperties(::grpc::ServerContext* context,
+                        const ::viam::component::motor::v1::GetPropertiesRequest* request,
+                        ::viam::component::motor::v1::GetPropertiesResponse* response) {
+    
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Motor::GetProperties] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+    
+    std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+    
+    Motor::properties result = motor->get_properties();
+    *response->mutable_position_reporting() = result.position_reporting;
+    return ::grpc::Status();
+}
+
+::grpc::Status MotorServer::Stop(::grpc::ServerContext* context,
+                        const ::viam::component::motor::v1::StopRequest* request,
+                        ::viam::component::motor::v1::StopResponse* response) {
+    
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Motor::Stop] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+    
+    std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+    return ::grpc::Status();
+}
+
+::grpc::Status MotorServer::IsPowered(::grpc::ServerContext* context,
+                        const ::viam::component::motor::v1::IsPoweredRequest* request,
+                        ::viam::component::motor::v1::IsPoweredResponse* response) {
+    
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Motor::IsPowered] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+    
+    std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+    
+    Motor::power_status result = motor->get_power_status();
+    *response->mutable_is_on() = result.is_on;
+    *response->mutable_power_pct() = result.power_pct;
+    return ::grpc::Status();
+}
+
+::grpc::Status MotorServer::IsMoving(::grpc::ServerContext* context,
+                        const ::viam::component::motor::v1::IsMovingRequest* request,
+                        ::viam::component::motor::v1::IsMovingResponse* response) {
+    
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Motor::IsMoving] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+    
+    std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+    
+    Motor::moving_status result = motor->is_moving();
+    *response->mutable_is_moving() = result.is_moving;
+    return ::grpc::Status();
+}
+
+::grpc::Status MotorServer::DoCommand(::grpc::ServerContext* context,
+                        const ::viam::component::motor::v1::common.v1.DoCommandRequest* request,
+                        ::viam::component::motor::v1::common.v1.DoCommandResponse* response) {
+    
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Motor::DoCommand] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+    
+    std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+    
+    Motor::ERROR/TODO result = motor->do_command(request->TODO());
+    return ::grpc::Status();
+}
+
+
+void MotorServer::register_server(std::shared_ptr<Server> server) {
+    viam::component::motor::v1::MotorService::Service* motor =
+        static_cast<viam::component::motor::v1::MotorService::Service*>(this);
+    server->register_service(motor);
+}
+
+std::shared_ptr<SubtypeService> MotorServer::get_sub_svc() {
+    return sub_svc;
+}

--- a/src/components/motor/server.cpp
+++ b/src/components/motor/server.cpp
@@ -5,12 +5,12 @@
 #include <config/resource.hpp>
 #include <rpc/server.hpp>
 
-
+namespace viam {
+namespace cppsdk {
 
 ::grpc::Status MotorServer::SetPower(::grpc::ServerContext* context,
-                        const ::viam::component::motor::v1::SetPowerRequest* request,
-                        ::viam::component::motor::v1::SetPowerResponse* response) {
-    
+                                     const ::viam::component::motor::v1::SetPowerRequest* request,
+                                     ::viam::component::motor::v1::SetPowerResponse* response) {
     if (request == nullptr) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Motor::SetPower] without a request");
@@ -20,15 +20,17 @@
     if (rb == nullptr) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
-    
+
     std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+
+    motor->set_power(request->power_pct());
+
     return ::grpc::Status();
 }
 
 ::grpc::Status MotorServer::GoFor(::grpc::ServerContext* context,
-                        const ::viam::component::motor::v1::GoForRequest* request,
-                        ::viam::component::motor::v1::GoForResponse* response) {
-    
+                                  const ::viam::component::motor::v1::GoForRequest* request,
+                                  ::viam::component::motor::v1::GoForResponse* response) {
     if (request == nullptr) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Motor::GoFor] without a request");
@@ -38,15 +40,17 @@
     if (rb == nullptr) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
-    
+
     std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+
+    motor->go_for(request->rpm(), request->revolutions());
+
     return ::grpc::Status();
 }
 
 ::grpc::Status MotorServer::GoTo(::grpc::ServerContext* context,
-                        const ::viam::component::motor::v1::GoToRequest* request,
-                        ::viam::component::motor::v1::GoToResponse* response) {
-    
+                                 const ::viam::component::motor::v1::GoToRequest* request,
+                                 ::viam::component::motor::v1::GoToResponse* response) {
     if (request == nullptr) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Motor::GoTo] without a request");
@@ -56,15 +60,18 @@
     if (rb == nullptr) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
-    
+
     std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+
+    motor->go_to(request->rpm(), request->position_revolutions());
+
     return ::grpc::Status();
 }
 
-::grpc::Status MotorServer::ResetZeroPosition(::grpc::ServerContext* context,
-                        const ::viam::component::motor::v1::ResetZeroPositionRequest* request,
-                        ::viam::component::motor::v1::ResetZeroPositionResponse* response) {
-    
+::grpc::Status MotorServer::ResetZeroPosition(
+    ::grpc::ServerContext* context,
+    const ::viam::component::motor::v1::ResetZeroPositionRequest* request,
+    ::viam::component::motor::v1::ResetZeroPositionResponse* response) {
     if (request == nullptr) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Motor::ResetZeroPosition] without a request");
@@ -74,15 +81,18 @@
     if (rb == nullptr) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
-    
+
     std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+
+    motor->reset_zero_position(request->offset());
+
     return ::grpc::Status();
 }
 
-::grpc::Status MotorServer::GetPosition(::grpc::ServerContext* context,
-                        const ::viam::component::motor::v1::GetPositionRequest* request,
-                        ::viam::component::motor::v1::GetPositionResponse* response) {
-    
+::grpc::Status MotorServer::GetPosition(
+    ::grpc::ServerContext* context,
+    const ::viam::component::motor::v1::GetPositionRequest* request,
+    ::viam::component::motor::v1::GetPositionResponse* response) {
     if (request == nullptr) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Motor::GetPosition] without a request");
@@ -92,18 +102,18 @@
     if (rb == nullptr) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
-    
+
     std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
-    
+
     Motor::position result = motor->get_position();
-    *response->mutable_position() = result.position;
+
     return ::grpc::Status();
 }
 
-::grpc::Status MotorServer::GetProperties(::grpc::ServerContext* context,
-                        const ::viam::component::motor::v1::GetPropertiesRequest* request,
-                        ::viam::component::motor::v1::GetPropertiesResponse* response) {
-    
+::grpc::Status MotorServer::GetProperties(
+    ::grpc::ServerContext* context,
+    const ::viam::component::motor::v1::GetPropertiesRequest* request,
+    ::viam::component::motor::v1::GetPropertiesResponse* response) {
     if (request == nullptr) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Motor::GetProperties] without a request");
@@ -113,18 +123,17 @@
     if (rb == nullptr) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
-    
+
     std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
-    
+
     Motor::properties result = motor->get_properties();
-    *response->mutable_position_reporting() = result.position_reporting;
+
     return ::grpc::Status();
 }
 
 ::grpc::Status MotorServer::Stop(::grpc::ServerContext* context,
-                        const ::viam::component::motor::v1::StopRequest* request,
-                        ::viam::component::motor::v1::StopResponse* response) {
-    
+                                 const ::viam::component::motor::v1::StopRequest* request,
+                                 ::viam::component::motor::v1::StopResponse* response) {
     if (request == nullptr) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Motor::Stop] without a request");
@@ -134,15 +143,17 @@
     if (rb == nullptr) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
-    
+
     std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
+
+    motor->stop_motor();
+
     return ::grpc::Status();
 }
 
 ::grpc::Status MotorServer::IsPowered(::grpc::ServerContext* context,
-                        const ::viam::component::motor::v1::IsPoweredRequest* request,
-                        ::viam::component::motor::v1::IsPoweredResponse* response) {
-    
+                                      const ::viam::component::motor::v1::IsPoweredRequest* request,
+                                      ::viam::component::motor::v1::IsPoweredResponse* response) {
     if (request == nullptr) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Motor::IsPowered] without a request");
@@ -152,19 +163,17 @@
     if (rb == nullptr) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
-    
+
     std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
-    
+
     Motor::power_status result = motor->get_power_status();
-    *response->mutable_is_on() = result.is_on;
-    *response->mutable_power_pct() = result.power_pct;
+
     return ::grpc::Status();
 }
 
 ::grpc::Status MotorServer::IsMoving(::grpc::ServerContext* context,
-                        const ::viam::component::motor::v1::IsMovingRequest* request,
-                        ::viam::component::motor::v1::IsMovingResponse* response) {
-    
+                                     const ::viam::component::motor::v1::IsMovingRequest* request,
+                                     ::viam::component::motor::v1::IsMovingResponse* response) {
     if (request == nullptr) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Motor::IsMoving] without a request");
@@ -174,34 +183,33 @@
     if (rb == nullptr) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
-    
+
     std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
-    
+
     Motor::moving_status result = motor->is_moving();
-    *response->mutable_is_moving() = result.is_moving;
+
     return ::grpc::Status();
 }
 
-::grpc::Status MotorServer::DoCommand(::grpc::ServerContext* context,
-                        const ::viam::component::motor::v1::common.v1.DoCommandRequest* request,
-                        ::viam::component::motor::v1::common.v1.DoCommandResponse* response) {
-    
-    if (request == nullptr) {
-        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
-                              "Called [Motor::DoCommand] without a request");
-    };
+::grpc::Status MotorServer::DoCommand(grpc::ServerContext* context,
+                                      const viam::common::v1::DoCommandRequest* request,
+                                      viam::common::v1::DoCommandResponse* response) {
+    if (!request) {
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                            "Called [DoCommand] without a request");
+    }
 
-    std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
-    if (rb == nullptr) {
+    std::shared_ptr<ResourceBase> resource = sub_svc->resource(request->name());
+    if (!resource) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
-    
-    std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(rb);
-    
-    Motor::ERROR/TODO result = motor->do_command(request->TODO());
-    return ::grpc::Status();
-}
 
+    std::shared_ptr<Motor> motor = std::dynamic_pointer_cast<Motor>(resource);
+    auto result = motor->do_command(struct_to_map(request->command()));
+    response->mutable_result()->CopyFrom(map_to_struct(result));
+
+    return grpc::Status::OK;
+}
 
 void MotorServer::register_server(std::shared_ptr<Server> server) {
     viam::component::motor::v1::MotorService::Service* motor =
@@ -212,3 +220,6 @@ void MotorServer::register_server(std::shared_ptr<Server> server) {
 std::shared_ptr<SubtypeService> MotorServer::get_sub_svc() {
     return sub_svc;
 }
+
+}  // namespace cppsdk
+}  // namespace viam

--- a/src/components/motor/server.hpp
+++ b/src/components/motor/server.hpp
@@ -9,53 +9,57 @@
 #include <resource/resource_server_base.hpp>
 #include <subtype/subtype.hpp>
 
+namespace viam {
+namespace cppsdk {
+
 /// @class MotorServer
 /// @brief gRPC server implementation of a `Motor` component.
 /// @ingroup Motor
 class MotorServer : public ResourceServerBase,
-                     public viam::component::motor::v1::MotorService::Service {
+                    public viam::component::motor::v1::MotorService::Service {
    public:
-   
     ::grpc::Status SetPower(::grpc::ServerContext* context,
                             const ::viam::component::motor::v1::SetPowerRequest* request,
                             ::viam::component::motor::v1::SetPowerResponse* response) override;
-   
+
     ::grpc::Status GoFor(::grpc::ServerContext* context,
-                            const ::viam::component::motor::v1::GoForRequest* request,
-                            ::viam::component::motor::v1::GoForResponse* response) override;
-   
+                         const ::viam::component::motor::v1::GoForRequest* request,
+                         ::viam::component::motor::v1::GoForResponse* response) override;
+
     ::grpc::Status GoTo(::grpc::ServerContext* context,
-                            const ::viam::component::motor::v1::GoToRequest* request,
-                            ::viam::component::motor::v1::GoToResponse* response) override;
-   
-    ::grpc::Status ResetZeroPosition(::grpc::ServerContext* context,
-                            const ::viam::component::motor::v1::ResetZeroPositionRequest* request,
-                            ::viam::component::motor::v1::ResetZeroPositionResponse* response) override;
-   
-    ::grpc::Status GetPosition(::grpc::ServerContext* context,
-                            const ::viam::component::motor::v1::GetPositionRequest* request,
-                            ::viam::component::motor::v1::GetPositionResponse* response) override;
-   
-    ::grpc::Status GetProperties(::grpc::ServerContext* context,
-                            const ::viam::component::motor::v1::GetPropertiesRequest* request,
-                            ::viam::component::motor::v1::GetPropertiesResponse* response) override;
-   
+                        const ::viam::component::motor::v1::GoToRequest* request,
+                        ::viam::component::motor::v1::GoToResponse* response) override;
+
+    ::grpc::Status ResetZeroPosition(
+        ::grpc::ServerContext* context,
+        const ::viam::component::motor::v1::ResetZeroPositionRequest* request,
+        ::viam::component::motor::v1::ResetZeroPositionResponse* response) override;
+
+    ::grpc::Status GetPosition(
+        ::grpc::ServerContext* context,
+        const ::viam::component::motor::v1::GetPositionRequest* request,
+        ::viam::component::motor::v1::GetPositionResponse* response) override;
+
+    ::grpc::Status GetProperties(
+        ::grpc::ServerContext* context,
+        const ::viam::component::motor::v1::GetPropertiesRequest* request,
+        ::viam::component::motor::v1::GetPropertiesResponse* response) override;
+
     ::grpc::Status Stop(::grpc::ServerContext* context,
-                            const ::viam::component::motor::v1::StopRequest* request,
-                            ::viam::component::motor::v1::StopResponse* response) override;
-   
+                        const ::viam::component::motor::v1::StopRequest* request,
+                        ::viam::component::motor::v1::StopResponse* response) override;
+
     ::grpc::Status IsPowered(::grpc::ServerContext* context,
-                            const ::viam::component::motor::v1::IsPoweredRequest* request,
-                            ::viam::component::motor::v1::IsPoweredResponse* response) override;
-   
+                             const ::viam::component::motor::v1::IsPoweredRequest* request,
+                             ::viam::component::motor::v1::IsPoweredResponse* response) override;
+
     ::grpc::Status IsMoving(::grpc::ServerContext* context,
                             const ::viam::component::motor::v1::IsMovingRequest* request,
                             ::viam::component::motor::v1::IsMovingResponse* response) override;
-   
-    ::grpc::Status DoCommand(::grpc::ServerContext* context,
-                            const ::viam::component::motor::v1::common.v1.DoCommandRequest* request,
-                            ::viam::component::motor::v1::common.v1.DoCommandResponse* response) override;
-   
+
+    ::grpc::Status DoCommand(grpc::ServerContext* context,
+                             const viam::common::v1::DoCommandRequest* request,
+                             viam::common::v1::DoCommandResponse* response) override;
 
     void register_server(std::shared_ptr<Server> server) override;
 
@@ -67,3 +71,6 @@ class MotorServer : public ResourceServerBase,
    private:
     std::shared_ptr<SubtypeService> sub_svc;
 };
+
+}  // namespace cppsdk
+}  // namespace viam

--- a/src/components/motor/server.hpp
+++ b/src/components/motor/server.hpp
@@ -1,0 +1,69 @@
+/// @file components/motor/server.hpp
+///
+/// @brief Implements a gRPC server for the `Motor` component.
+#pragma once
+
+#include <common/v1/common.pb.h>
+#include <component/motor/v1/motor.grpc.pb.h>
+
+#include <resource/resource_server_base.hpp>
+#include <subtype/subtype.hpp>
+
+/// @class MotorServer
+/// @brief gRPC server implementation of a `Motor` component.
+/// @ingroup Motor
+class MotorServer : public ResourceServerBase,
+                     public viam::component::motor::v1::MotorService::Service {
+   public:
+   
+    ::grpc::Status SetPower(::grpc::ServerContext* context,
+                            const ::viam::component::motor::v1::SetPowerRequest* request,
+                            ::viam::component::motor::v1::SetPowerResponse* response) override;
+   
+    ::grpc::Status GoFor(::grpc::ServerContext* context,
+                            const ::viam::component::motor::v1::GoForRequest* request,
+                            ::viam::component::motor::v1::GoForResponse* response) override;
+   
+    ::grpc::Status GoTo(::grpc::ServerContext* context,
+                            const ::viam::component::motor::v1::GoToRequest* request,
+                            ::viam::component::motor::v1::GoToResponse* response) override;
+   
+    ::grpc::Status ResetZeroPosition(::grpc::ServerContext* context,
+                            const ::viam::component::motor::v1::ResetZeroPositionRequest* request,
+                            ::viam::component::motor::v1::ResetZeroPositionResponse* response) override;
+   
+    ::grpc::Status GetPosition(::grpc::ServerContext* context,
+                            const ::viam::component::motor::v1::GetPositionRequest* request,
+                            ::viam::component::motor::v1::GetPositionResponse* response) override;
+   
+    ::grpc::Status GetProperties(::grpc::ServerContext* context,
+                            const ::viam::component::motor::v1::GetPropertiesRequest* request,
+                            ::viam::component::motor::v1::GetPropertiesResponse* response) override;
+   
+    ::grpc::Status Stop(::grpc::ServerContext* context,
+                            const ::viam::component::motor::v1::StopRequest* request,
+                            ::viam::component::motor::v1::StopResponse* response) override;
+   
+    ::grpc::Status IsPowered(::grpc::ServerContext* context,
+                            const ::viam::component::motor::v1::IsPoweredRequest* request,
+                            ::viam::component::motor::v1::IsPoweredResponse* response) override;
+   
+    ::grpc::Status IsMoving(::grpc::ServerContext* context,
+                            const ::viam::component::motor::v1::IsMovingRequest* request,
+                            ::viam::component::motor::v1::IsMovingResponse* response) override;
+   
+    ::grpc::Status DoCommand(::grpc::ServerContext* context,
+                            const ::viam::component::motor::v1::common.v1.DoCommandRequest* request,
+                            ::viam::component::motor::v1::common.v1.DoCommandResponse* response) override;
+   
+
+    void register_server(std::shared_ptr<Server> server) override;
+
+    std::shared_ptr<SubtypeService> get_sub_svc();
+
+    MotorServer() : sub_svc(std::make_shared<SubtypeService>()){};
+    MotorServer(std::shared_ptr<SubtypeService> sub_svc) : sub_svc(sub_svc){};
+
+   private:
+    std::shared_ptr<SubtypeService> sub_svc;
+};

--- a/src/tests/mocks/mock_motor.cpp
+++ b/src/tests/mocks/mock_motor.cpp
@@ -17,24 +17,20 @@ namespace motor {
 using namespace viam::cppsdk;
 
 void MockMotor::set_power(double power_pct) {
-    if (std::abs(power_pct) > 1.0) {
-        throw std::range_error("power_pct");
-    }
     power_status.is_on = power_pct != 0.0;
     power_status.power_pct = power_pct;
 };
 void MockMotor::go_for(double rpm, double revolutions) {
+    // This is the actual behavior from rdk:builtin:fake_motor
+    if (rpm == 0.0) {
+        throw std::runtime_error("Cannot move motor at 0 RPM");
+    }
     position += revolutions;
 };
 void MockMotor::go_to(double rpm, double position_revolutions) {
     position = position_revolutions;
 };
 void MockMotor::reset_zero_position(double offset) {
-    // If position = x
-    // offset = x-y
-    // new pos = y,
-    // This is not idential to the real world but
-    // is equivalent for this mock
     position -= offset;
 };
 Motor::position MockMotor::get_position() {
@@ -45,7 +41,7 @@ Motor::properties MockMotor::get_properties() {
 };
 void MockMotor::stop_motor() {
     // None of these functions are async and this mock is not
-    // thread-safe (Send, not Sync). The motor should never be
+    // thread-safe (Send, not Sync). The mock motor should never be
     // moving when this is called
     set_power(0.0);
 };

--- a/src/tests/mocks/mock_motor.cpp
+++ b/src/tests/mocks/mock_motor.cpp
@@ -8,22 +8,25 @@
 #include <components/motor/server.hpp>
 #include <tests/test_utils.hpp>
 
-AttributeMap MockMotor::do_command(AttributeMap command) {
-    return map;
-}
-Motor::void MockMotor::set_power(double power_pct) {
+namespace viam {
+namespace cppsdktests {
+namespace motor {
+
+using namespace viam::cppsdk;
+
+void MockMotor::set_power(double power_pct) {
     // TODO impl
     return; 
 };
-Motor::void MockMotor::go_for(double rpm, double revolutions) {
+void MockMotor::go_for(double rpm, double revolutions) {
     // TODO impl
     return; 
 };
-Motor::void MockMotor::go_to(double rpm, double position_revolutions) {
+void MockMotor::go_to(double rpm, double position_revolutions) {
     // TODO impl
     return; 
 };
-Motor::void MockMotor::reset_zero_position(double offset) {
+void MockMotor::reset_zero_position(double offset) {
     // TODO impl
     return; 
 };
@@ -35,7 +38,7 @@ Motor::properties MockMotor::get_properties() {
     // TODO impl
     return; 
 };
-Motor::void MockMotor::stop() {
+void MockMotor::stop_motor() {
     // TODO impl
     return; 
 };
@@ -47,18 +50,18 @@ Motor::moving_status MockMotor::is_moving() {
     // TODO impl
     return; 
 };
-Motor::AttributeMap MockMotor::do_command(ERROR TODO) {
+AttributeMap MockMotor::do_command(ERROR TODO) {
     // TODO impl
     return; 
 };
-Motor::raw_image MockMotor::get_image(std::string mime_type) {
-    return image;
-}
-
 
 std::shared_ptr<MockMotor> MockMotor::get_mock_motor() {
-    auto motor = std::make_shared<MockMotor>("motor");
+    auto motor = std::make_shared<MockMotor>("mock_motor");
     // TODO motor->attr = fake_attr();
 
     return motor;
 }
+
+}  // namespace motor
+}  // namespace cppsdktests
+}  // namespace viam

--- a/src/tests/mocks/mock_motor.cpp
+++ b/src/tests/mocks/mock_motor.cpp
@@ -39,11 +39,12 @@ Motor::position MockMotor::get_position() {
 Motor::properties MockMotor::get_properties() {
     return properties;
 };
-void MockMotor::stop_motor() {
+grpc::StatusCode MockMotor::stop(AttributeMap extra) {
     // None of these functions are async and this mock is not
     // thread-safe (Send, not Sync). The mock motor should never be
     // moving when this is called
     set_power(0.0);
+    return grpc::StatusCode();
 };
 Motor::power_status MockMotor::get_power_status() {
     return power_status;

--- a/src/tests/mocks/mock_motor.cpp
+++ b/src/tests/mocks/mock_motor.cpp
@@ -1,5 +1,7 @@
 #include <tests/mocks/mock_motor.hpp>
 
+#include <stdexcept>
+
 #include <common/v1/common.pb.h>
 #include <component/motor/v1/motor.grpc.pb.h>
 #include <component/motor/v1/motor.pb.h>
@@ -15,6 +17,9 @@ namespace motor {
 using namespace viam::cppsdk;
 
 void MockMotor::set_power(double power_pct) {
+    if (std::abs(power_pct) > 1.0) {
+        throw std::range_error("power_pct");
+    }
     power_status.is_on = power_pct != 0.0;
     power_status.power_pct = power_pct;
 };

--- a/src/tests/mocks/mock_motor.cpp
+++ b/src/tests/mocks/mock_motor.cpp
@@ -15,51 +15,73 @@ namespace motor {
 using namespace viam::cppsdk;
 
 void MockMotor::set_power(double power_pct) {
-    // TODO impl
-    return; 
+    power_status.is_on = power_pct != 0.0;
+    power_status.power_pct = power_pct;
 };
 void MockMotor::go_for(double rpm, double revolutions) {
-    // TODO impl
-    return; 
+    position += revolutions;
 };
 void MockMotor::go_to(double rpm, double position_revolutions) {
-    // TODO impl
-    return; 
+    position = position_revolutions;
 };
 void MockMotor::reset_zero_position(double offset) {
-    // TODO impl
-    return; 
+    // If position = x
+    // offset = x-y
+    // new pos = y,
+    // This is not idential to the real world but
+    // is equivalent for this mock
+    position -= offset;
 };
 Motor::position MockMotor::get_position() {
-    // TODO impl
-    return; 
+    return position;
 };
 Motor::properties MockMotor::get_properties() {
-    // TODO impl
-    return; 
+    return properties;
 };
 void MockMotor::stop_motor() {
-    // TODO impl
-    return; 
+    // None of these functions are async and this mock is not
+    // thread-safe (Send, not Sync). The motor should never be
+    // moving when this is called
+    set_power(0.0);
 };
 Motor::power_status MockMotor::get_power_status() {
-    // TODO impl
-    return; 
+    return power_status;
 };
-Motor::moving_status MockMotor::is_moving() {
-    // TODO impl
-    return; 
+bool MockMotor::is_moving() {
+    // None of these functions are async and this mock is not
+    // thread-safe (Send, not Sync)
+    return false;
 };
-AttributeMap MockMotor::do_command(ERROR TODO) {
-    // TODO impl
-    return; 
+AttributeMap MockMotor::do_command(AttributeMap _command) {
+    return map;
 };
 
 std::shared_ptr<MockMotor> MockMotor::get_mock_motor() {
     auto motor = std::make_shared<MockMotor>("mock_motor");
-    // TODO motor->attr = fake_attr();
+
+    motor->power_status = fake_power_status();
+    motor->position = fake_position();
+    motor->properties = fake_properties();
+    motor->map = fake_map();
 
     return motor;
+}
+
+Motor::power_status fake_power_status() {
+    Motor::power_status power_status;
+    power_status.is_on = true;
+    power_status.power_pct = 0.5;
+    return power_status;
+}
+
+Motor::position fake_position() {
+    return 0.0;
+}
+
+Motor::properties fake_properties() {
+    Motor::properties properties;
+    properties.position_reporting = true;
+    return properties;
 }
 
 }  // namespace motor

--- a/src/tests/mocks/mock_motor.cpp
+++ b/src/tests/mocks/mock_motor.cpp
@@ -1,0 +1,64 @@
+#include <tests/mocks/mock_motor.hpp>
+
+#include <common/v1/common.pb.h>
+#include <component/motor/v1/motor.grpc.pb.h>
+#include <component/motor/v1/motor.pb.h>
+
+#include <components/motor/motor.hpp>
+#include <components/motor/server.hpp>
+#include <tests/test_utils.hpp>
+
+AttributeMap MockMotor::do_command(AttributeMap command) {
+    return map;
+}
+Motor::void MockMotor::set_power(double power_pct) {
+    // TODO impl
+    return; 
+};
+Motor::void MockMotor::go_for(double rpm, double revolutions) {
+    // TODO impl
+    return; 
+};
+Motor::void MockMotor::go_to(double rpm, double position_revolutions) {
+    // TODO impl
+    return; 
+};
+Motor::void MockMotor::reset_zero_position(double offset) {
+    // TODO impl
+    return; 
+};
+Motor::position MockMotor::get_position() {
+    // TODO impl
+    return; 
+};
+Motor::properties MockMotor::get_properties() {
+    // TODO impl
+    return; 
+};
+Motor::void MockMotor::stop() {
+    // TODO impl
+    return; 
+};
+Motor::power_status MockMotor::get_power_status() {
+    // TODO impl
+    return; 
+};
+Motor::moving_status MockMotor::is_moving() {
+    // TODO impl
+    return; 
+};
+Motor::AttributeMap MockMotor::do_command(ERROR TODO) {
+    // TODO impl
+    return; 
+};
+Motor::raw_image MockMotor::get_image(std::string mime_type) {
+    return image;
+}
+
+
+std::shared_ptr<MockMotor> MockMotor::get_mock_motor() {
+    auto motor = std::make_shared<MockMotor>("motor");
+    // TODO motor->attr = fake_attr();
+
+    return motor;
+}

--- a/src/tests/mocks/mock_motor.cpp
+++ b/src/tests/mocks/mock_motor.cpp
@@ -81,9 +81,7 @@ Motor::position fake_position() {
 }
 
 Motor::properties fake_properties() {
-    Motor::properties properties;
-    properties.position_reporting = true;
-    return properties;
+    return {true};
 }
 
 }  // namespace motor

--- a/src/tests/mocks/mock_motor.hpp
+++ b/src/tests/mocks/mock_motor.hpp
@@ -22,18 +22,23 @@ class MockMotor : public viam::cppsdk::Motor {
     viam::cppsdk::Motor::properties get_properties() override;
     void stop_motor() override;
     viam::cppsdk::Motor::power_status get_power_status() override;
-    viam::cppsdk::Motor::moving_status is_moving() override;
-    AttributeMap do_command(AttributeMap command) override;
+    bool is_moving() override;
+    viam::cppsdk::AttributeMap do_command(viam::cppsdk::AttributeMap command) override;
     static std::shared_ptr<MockMotor> get_mock_motor();
 
     MockMotor(std::string name) : Motor(std::move(name)){};
 
    private:
-    // TODO add private members for mock
-    std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> map;
+    viam::cppsdk::Motor::position position;
+    viam::cppsdk::Motor::power_status power_status;
+    viam::cppsdk::Motor::properties properties;
+    // TODO(RSDK-2747) swap to AttributeMap
+    std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<viam::cppsdk::ProtoType>>> map;
 };
 
-// TODO create fake_xxx functions
+viam::cppsdk::Motor::position fake_position();
+viam::cppsdk::Motor::power_status fake_power_status();
+viam::cppsdk::Motor::properties fake_properties();
 
 }  // namespace motor
 }  // namespace cppsdktests

--- a/src/tests/mocks/mock_motor.hpp
+++ b/src/tests/mocks/mock_motor.hpp
@@ -4,22 +4,26 @@
 #include <component/motor/v1/motor.grpc.pb.h>
 #include <component/motor/v1/motor.pb.h>
 
-#include <components/motor/motor.hpp>
 #include <components/motor/client.hpp>
+#include <components/motor/motor.hpp>
 #include <components/motor/server.hpp>
 
-class MockMotor : public Motor {
-    public:
+namespace viam {
+namespace cppsdktests {
+namespace motor {
+
+class MockMotor : public viam::cppsdk::Motor {
+   public:
     void set_power(double power_pct) override;
     void go_for(double rpm, double revolutions) override;
     void go_to(double rpm, double position_revolutions) override;
     void reset_zero_position(double offset) override;
-    position get_position() override;
-    properties get_properties() override;
-    void stop() override;
-    power_status get_power_status() override;
-    moving_status is_moving() override;
-    AttributeMap do_command(ERROR TODO) override;
+    viam::cppsdk::Motor::position get_position() override;
+    viam::cppsdk::Motor::properties get_properties() override;
+    void stop_motor() override;
+    viam::cppsdk::Motor::power_status get_power_status() override;
+    viam::cppsdk::Motor::moving_status is_moving() override;
+    AttributeMap do_command(AttributeMap command) override;
     static std::shared_ptr<MockMotor> get_mock_motor();
 
     MockMotor(std::string name) : Motor(std::move(name)){};
@@ -30,3 +34,7 @@ class MockMotor : public Motor {
 };
 
 // TODO create fake_xxx functions
+
+}  // namespace motor
+}  // namespace cppsdktests
+}  // namespace viam

--- a/src/tests/mocks/mock_motor.hpp
+++ b/src/tests/mocks/mock_motor.hpp
@@ -12,16 +12,18 @@ namespace viam {
 namespace cppsdktests {
 namespace motor {
 
-class MockMotor : public viam::cppsdk::Motor {
+using viam::cppsdk::Motor;
+
+class MockMotor : public Motor {
    public:
     void set_power(double power_pct) override;
     void go_for(double rpm, double revolutions) override;
     void go_to(double rpm, double position_revolutions) override;
     void reset_zero_position(double offset) override;
-    viam::cppsdk::Motor::position get_position() override;
-    viam::cppsdk::Motor::properties get_properties() override;
+    Motor::position get_position() override;
+    Motor::properties get_properties() override;
     void stop_motor() override;
-    viam::cppsdk::Motor::power_status get_power_status() override;
+    Motor::power_status get_power_status() override;
     bool is_moving() override;
     viam::cppsdk::AttributeMap do_command(viam::cppsdk::AttributeMap command) override;
     static std::shared_ptr<MockMotor> get_mock_motor();
@@ -29,16 +31,16 @@ class MockMotor : public viam::cppsdk::Motor {
     MockMotor(std::string name) : Motor(std::move(name)){};
 
    private:
-    viam::cppsdk::Motor::position position;
-    viam::cppsdk::Motor::power_status power_status;
-    viam::cppsdk::Motor::properties properties;
+    Motor::position position;
+    Motor::power_status power_status;
+    Motor::properties properties;
     // TODO(RSDK-2747) swap to AttributeMap
     std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<viam::cppsdk::ProtoType>>> map;
 };
 
-viam::cppsdk::Motor::position fake_position();
-viam::cppsdk::Motor::power_status fake_power_status();
-viam::cppsdk::Motor::properties fake_properties();
+Motor::position fake_position();
+Motor::power_status fake_power_status();
+Motor::properties fake_properties();
 
 }  // namespace motor
 }  // namespace cppsdktests

--- a/src/tests/mocks/mock_motor.hpp
+++ b/src/tests/mocks/mock_motor.hpp
@@ -22,7 +22,7 @@ class MockMotor : public Motor {
     void reset_zero_position(double offset) override;
     Motor::position get_position() override;
     Motor::properties get_properties() override;
-    void stop_motor() override;
+    grpc::StatusCode stop(viam::cppsdk::AttributeMap extra) override;
     Motor::power_status get_power_status() override;
     bool is_moving() override;
     viam::cppsdk::AttributeMap do_command(viam::cppsdk::AttributeMap command) override;

--- a/src/tests/mocks/mock_motor.hpp
+++ b/src/tests/mocks/mock_motor.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <common/v1/common.pb.h>
+#include <component/motor/v1/motor.grpc.pb.h>
+#include <component/motor/v1/motor.pb.h>
+
+#include <components/motor/motor.hpp>
+#include <components/motor/client.hpp>
+#include <components/motor/server.hpp>
+
+class MockMotor : public Motor {
+    public:
+    void set_power(double power_pct) override;
+    void go_for(double rpm, double revolutions) override;
+    void go_to(double rpm, double position_revolutions) override;
+    void reset_zero_position(double offset) override;
+    position get_position() override;
+    properties get_properties() override;
+    void stop() override;
+    power_status get_power_status() override;
+    moving_status is_moving() override;
+    AttributeMap do_command(ERROR TODO) override;
+    static std::shared_ptr<MockMotor> get_mock_motor();
+
+    MockMotor(std::string name) : Motor(std::move(name)){};
+
+   private:
+    // TODO add private members for mock
+    std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> map;
+};
+
+// TODO create fake_xxx functions

--- a/src/tests/test_motor.cpp
+++ b/src/tests/test_motor.cpp
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(test_do_command) {
 
 BOOST_AUTO_TEST_CASE(test_exception_creation) {
     std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
-    BOOST_CHECK_THROW(motor->set_power(1.5), std::range_error);
+    BOOST_CHECK_THROW(motor->go_for(0.0, 1.0), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(test_do_command) {
 
 BOOST_AUTO_TEST_CASE(test_exception_creation) {
     server_to_mock_pipeline([](Motor& client) -> void {
-        BOOST_CHECK_THROW(client.set_power(1.5), std::runtime_error);
+        BOOST_CHECK_THROW(client.go_for(0.0, 1.0), std::runtime_error);
     });
 }
 

--- a/src/tests/test_motor.cpp
+++ b/src/tests/test_motor.cpp
@@ -1,0 +1,86 @@
+#define BOOST_TEST_MODULE test module test_motor
+
+#include <typeinfo>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <boost/test/included/unit_test.hpp>
+
+#include <common/v1/common.pb.h>
+#include <component/motor/v1/motor.grpc.pb.h>
+#include <component/motor/v1/motor.pb.h>
+
+#include <common/proto_type.hpp>
+#include <components/motor/motor.hpp>
+#include <components/motor/client.hpp>
+#include <components/motor/server.hpp>
+#include <tests/mocks/mock_motor.hpp>
+#include <tests/test_utils.hpp>
+
+BOOST_AUTO_TEST_SUITE(test_motor)
+
+
+BOOST_AUTO_TEST_CASE(test_set_power) {
+    std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
+    // TODO impl
+    BOOST_CHECK(false);
+}
+
+BOOST_AUTO_TEST_CASE(test_go_for) {
+    std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
+    // TODO impl
+    BOOST_CHECK(false);
+}
+
+BOOST_AUTO_TEST_CASE(test_go_to) {
+    std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
+    // TODO impl
+    BOOST_CHECK(false);
+}
+
+BOOST_AUTO_TEST_CASE(test_reset_zero_position) {
+    std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
+    // TODO impl
+    BOOST_CHECK(false);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_position) {
+    std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
+    // TODO impl
+    BOOST_CHECK(false);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_properties) {
+    std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
+    // TODO impl
+    BOOST_CHECK(false);
+}
+
+BOOST_AUTO_TEST_CASE(test_stop) {
+    std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
+    // TODO impl
+    BOOST_CHECK(false);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_power_status) {
+    std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
+    // TODO impl
+    BOOST_CHECK(false);
+}
+
+BOOST_AUTO_TEST_CASE(test_is_moving) {
+    std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
+    // TODO impl
+    BOOST_CHECK(false);
+}
+
+BOOST_AUTO_TEST_CASE(test_do_command) {
+    std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
+    // TODO impl
+    BOOST_CHECK(false);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/src/tests/test_motor.cpp
+++ b/src/tests/test_motor.cpp
@@ -18,6 +18,13 @@
 #include <tests/mocks/mock_motor.hpp>
 #include <tests/test_utils.hpp>
 
+namespace viam {
+namespace cppsdktests {
+
+using namespace motor;
+
+using namespace viam::cppsdk;
+
 BOOST_AUTO_TEST_SUITE(test_motor)
 
 
@@ -57,7 +64,7 @@ BOOST_AUTO_TEST_CASE(test_get_properties) {
     BOOST_CHECK(false);
 }
 
-BOOST_AUTO_TEST_CASE(test_stop) {
+BOOST_AUTO_TEST_CASE(test_stop_motor) {
     std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
     // TODO impl
     BOOST_CHECK(false);
@@ -84,3 +91,5 @@ BOOST_AUTO_TEST_CASE(test_do_command) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+} // namespace cppsdktests
+} // namespace viam

--- a/src/tests/test_motor.cpp
+++ b/src/tests/test_motor.cpp
@@ -61,11 +61,11 @@ BOOST_AUTO_TEST_CASE(mock_get_properties) {
     BOOST_CHECK(motor->get_properties().position_reporting);
 }
 
-BOOST_AUTO_TEST_CASE(mock_stop_motor) {
-    // This test is a no-op for now because is_moving will always
-    // return false
+BOOST_AUTO_TEST_CASE(mock_stop) {
     std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
-    motor->stop_motor();
+    AttributeMap extra_map = fake_map();
+    motor->stop(std::move(extra_map));
+    BOOST_CHECK(motor->get_power_status().power_pct == 0.0);
     BOOST_CHECK(!motor->is_moving());
 }
 
@@ -177,12 +177,12 @@ BOOST_AUTO_TEST_CASE(test_get_properties) {
         [](Motor& client) -> void { BOOST_CHECK(client.get_properties().position_reporting); });
 }
 
-BOOST_AUTO_TEST_CASE(test_stop_motor) {
+BOOST_AUTO_TEST_CASE(test_stop) {
     server_to_mock_pipeline([](Motor& client) -> void {
         client.set_power(1.0);
         BOOST_CHECK(client.get_power_status().power_pct == 1.0);
         BOOST_CHECK(client.get_power_status().is_on);
-        client.stop_motor();
+        client.stop(AttributeMap());
         BOOST_CHECK(client.get_power_status().power_pct == 0.0);
         BOOST_CHECK(!client.get_power_status().is_on);
         // This test is a no-op for now because is_moving will always

--- a/src/tests/test_motor.cpp
+++ b/src/tests/test_motor.cpp
@@ -25,28 +25,30 @@ using namespace viam::cppsdk;
 
 BOOST_AUTO_TEST_SUITE(test_mock)
 
-BOOST_AUTO_TEST_CASE(test_set_power) {
+BOOST_AUTO_TEST_CASE(mock_set_power) {
     std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
     motor->set_power(1.0);
     BOOST_CHECK(motor->get_power_status().power_pct == 1.0);
+    BOOST_CHECK(motor->get_power_status().is_on);
     motor->set_power(0.0);
     BOOST_CHECK(motor->get_power_status().power_pct == 0.0);
+    BOOST_CHECK(!motor->get_power_status().is_on);
 }
 
-BOOST_AUTO_TEST_CASE(test_go_for) {
+BOOST_AUTO_TEST_CASE(mock_go_for) {
     std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
     motor->go_for(1.0, 1.0);
     motor->go_for(1.0, 1.5);
     BOOST_CHECK(motor->get_position() == 2.5);
 }
 
-BOOST_AUTO_TEST_CASE(test_go_to) {
+BOOST_AUTO_TEST_CASE(mock_go_to) {
     std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
     motor->go_to(1.0, 1.0);
     BOOST_CHECK(motor->get_position() == 1.0);
 }
 
-BOOST_AUTO_TEST_CASE(test_reset_zero_position) {
+BOOST_AUTO_TEST_CASE(mock_reset_zero_position) {
     std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
     motor->go_to(1.0, 1.0);
     BOOST_CHECK(motor->get_position() == 1.0);
@@ -54,12 +56,12 @@ BOOST_AUTO_TEST_CASE(test_reset_zero_position) {
     BOOST_CHECK(motor->get_position() == -0.5);
 }
 
-BOOST_AUTO_TEST_CASE(test_get_properties) {
+BOOST_AUTO_TEST_CASE(mock_get_properties) {
     std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
     BOOST_CHECK(motor->get_properties().position_reporting);
 }
 
-BOOST_AUTO_TEST_CASE(test_stop_motor) {
+BOOST_AUTO_TEST_CASE(mock_stop_motor) {
     // This test is a no-op for now because is_moving will always
     // return false
     std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
@@ -67,7 +69,7 @@ BOOST_AUTO_TEST_CASE(test_stop_motor) {
     BOOST_CHECK(!motor->is_moving());
 }
 
-BOOST_AUTO_TEST_CASE(test_do_command) {
+BOOST_AUTO_TEST_CASE(mock_do_command) {
     std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
     AttributeMap expected = fake_map();
 
@@ -80,7 +82,7 @@ BOOST_AUTO_TEST_CASE(test_do_command) {
     BOOST_CHECK(result_pt == expected_pt);
 }
 
-BOOST_AUTO_TEST_CASE(test_exception_creation) {
+BOOST_AUTO_TEST_CASE(mock_exception_creation) {
     std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
     BOOST_CHECK_THROW(motor->go_for(0.0, 1.0), std::runtime_error);
 }


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-796

This adds wrappers for the motor component.

Major design decisions:
- Currently hiding all grpc errors (like Camera)
- Doxygen comments are in a slightly different format because of how long they are
- Tests are redundant (I am in favor of de-duping)
- I have moved from `component_mocks.xpp` -> `mock_component.xpp` because we no longer need to have multiple types of mocks for each component