### PR TITLE
RSDK-2703 - Document existing wrappers

### DIFF
--- a/src/components/camera/camera.hpp
+++ b/src/components/camera/camera.hpp
@@ -72,6 +72,8 @@ class Camera : public ComponentBase {
         std::vector<unsigned char> pc;
     };
 
+    const static std::string lazy_suffix;
+
     /// @struct raw_image
     /// @brief the raw bytes and mime type of an image.
     // TODO: update documentaiton to show how to deserialize a `raw_image`
@@ -129,9 +131,6 @@ class Camera : public ComponentBase {
 
    protected:
     explicit Camera(std::string name) : ComponentBase(std::move(name)){};
-
-   private:
-    const static std::string lazy_suffix;
 };
 
 bool operator==(const Camera::raw_image& lhs, const Camera::raw_image& rhs);

--- a/src/components/camera/camera.hpp
+++ b/src/components/camera/camera.hpp
@@ -1,3 +1,6 @@
+/// @file components/camera/camera.hpp
+///
+/// @brief Defines a `Camera` component.
 #pragma once
 
 #include <bitset>
@@ -12,6 +15,8 @@
 #include <registry/registry.hpp>
 #include <subtype/subtype.hpp>
 
+/// @class CameraSubtype
+/// @brief Defines a `ResourceSubtype` for the `Camera` component.
 class CameraSubtype : public ResourceSubtype {
    public:
     std::shared_ptr<ResourceServerBase> create_resource_server(
@@ -22,8 +27,15 @@ class CameraSubtype : public ResourceSubtype {
         : ResourceSubtype(service_descriptor){};
 };
 
+/// @class Camera camera.hpp "components/camera/camera.hpp"
+/// @brief A `Camera` represents any physical hardware that can capture frames.
+///
+/// This acts as an abstract base class to be inherited from by any drivers representing
+/// specific camera implementations. This class cannot be used on its own.
 class Camera : public ComponentBase {
    public:
+    /// @struct intrinsic parameters
+    /// @brief The properties of the camera.
     struct intrinsic_parameters {
         int width_px;
         int height_px;
@@ -33,47 +45,93 @@ class Camera : public ComponentBase {
         double center_y_px;
     };
 
+    /// @struct distortion_parameters
+    /// @brief The distortion parameters of the camera.
     struct distortion_parameters {
         std::string model;
         std::vector<double> parameters;
     };
 
+    /// @struct properties
+    /// @brief The camera's supported features and settings.
+    ///
+    /// `supports_pcd` indicates whether the camera has a valid implementation of `get_point_cloud`.
+    /// `intrinsic_parameters` contains the camera's intrinsic parameters.
+    /// `distortion_parameters` contains the camera's distortion parameters.
     struct properties {
         bool supports_pcd;
         struct intrinsic_parameters intrinsic_parameters;
         struct distortion_parameters distortion_parameters;
     };
 
+    /// @struct point_cloud
+    /// @brief The points and mime type of a point cloud.
+    // TODO: update documentation to show how to deserialize a `point_cloud`
     struct point_cloud {
         std::string mime_type;
         std::vector<unsigned char> pc;
     };
 
+    /// @struct raw_image
+    /// @brief the raw bytes and mime type of an image.
+    // TODO: update documentaiton to show how to deserialize a `raw_image`
     struct raw_image {
         std::string mime_type;
         std::vector<unsigned char> bytes;
     };
 
-    const static std::string lazy_suffix;
-
+    /// @brief Creates a `ResourceSubtype` for the `Camera` component.
     static std::shared_ptr<ResourceSubtype> resource_subtype();
+
+    /// @brief Creates a `Camera` `Subtype`.
     static Subtype subtype();
+
+    /// @brief Creates a `raw_image` struct from its proto representation.
     static raw_image from_proto(viam::component::camera::v1::GetImageResponse proto);
+
+    /// @brief Creates a `point_cloud` struct from its proto representation.
     static point_cloud from_proto(viam::component::camera::v1::GetPointCloudResponse proto);
+
+    /// @brief creates an `intrinsic_parameters` struct from its proto representation.
     static intrinsic_parameters from_proto(viam::component::camera::v1::IntrinsicParameters proto);
+
+    /// @brief creats a `distortion_parameters` struct from its proto representation.
     static distortion_parameters from_proto(
         viam::component::camera::v1::DistortionParameters proto);
+
+    /// @brief creates a `properties` struct from its proto representation.
     static properties from_proto(viam::component::camera::v1::GetPropertiesResponse proto);
+
+    /// @brief converts a `distortion_parameters` struct to its proto representation.
     static viam::component::camera::v1::DistortionParameters to_proto(distortion_parameters);
+
+    /// @brief converts an `intrinsic_parameters` struct to its proto representation.
     static viam::component::camera::v1::IntrinsicParameters to_proto(intrinsic_parameters);
 
+    /// @brief Send/receive arbitrary commands to the resource.
+    /// @param Command the command to execute.
+    /// @return The result of the executed command.
     virtual AttributeMap do_command(AttributeMap command) = 0;
+
+    /// @brief Get the next image from the camera as a raw image.
+    /// @param mime_type the desired mime_type of the image (does not guarantee output type).
+    /// @return The frame as a `raw_image`.
     virtual raw_image get_image(std::string mime_type) = 0;
+
+    /// @brief Get the next `point_cloud` from the camera.
+    /// @param mime_type the desired mime_type of the point_cloud (does not guarantee output type).
+    /// @return The requested `point_cloud`.
     virtual point_cloud get_point_cloud(std::string mime_type) = 0;
+
+    /// @brief Get the camera's properties.
+    /// @return The camera properties.
     virtual properties get_properties() = 0;
 
    protected:
     explicit Camera(std::string name) : ComponentBase(std::move(name)){};
+
+   private:
+    const static std::string lazy_suffix;
 };
 
 bool operator==(const Camera::raw_image& lhs, const Camera::raw_image& rhs);

--- a/src/components/camera/camera.hpp
+++ b/src/components/camera/camera.hpp
@@ -15,8 +15,11 @@
 #include <registry/registry.hpp>
 #include <subtype/subtype.hpp>
 
+/// @defgroup Camera Classes related to the `Camera` component.
+
 /// @class CameraSubtype
 /// @brief Defines a `ResourceSubtype` for the `Camera` component.
+/// @ingroup Camera
 class CameraSubtype : public ResourceSubtype {
    public:
     std::shared_ptr<ResourceServerBase> create_resource_server(
@@ -29,6 +32,7 @@ class CameraSubtype : public ResourceSubtype {
 
 /// @class Camera camera.hpp "components/camera/camera.hpp"
 /// @brief A `Camera` represents any physical hardware that can capture frames.
+/// @ingroup Camera
 ///
 /// This acts as an abstract base class to be inherited from by any drivers representing
 /// specific camera implementations. This class cannot be used on its own.

--- a/src/components/camera/client.hpp
+++ b/src/components/camera/client.hpp
@@ -12,6 +12,9 @@
 #include <config/resource.hpp>
 #include <robot/client.hpp>
 
+/// @class CameraClient
+/// @brief gRPC client implementation of a `Camera` component.
+/// @ingroup Camera
 class CameraClient : public Camera {
    public:
     AttributeMap do_command(AttributeMap command) override;

--- a/src/components/camera/client.hpp
+++ b/src/components/camera/client.hpp
@@ -1,3 +1,6 @@
+/// @file components/camera/client.hpp
+///
+/// @brief Implements a gRPC client for the `Camera` component.
 #pragma once
 
 #include <grpcpp/channel.h>

--- a/src/components/camera/server.hpp
+++ b/src/components/camera/server.hpp
@@ -9,6 +9,9 @@
 #include <resource/resource_server_base.hpp>
 #include <subtype/subtype.hpp>
 
+/// @class CameraServer
+/// @brief gRPC server implementation of a `Camera` component.
+/// @ingroup Camera
 class CameraServer : public ResourceServerBase,
                      public viam::component::camera::v1::CameraService::Service {
    public:

--- a/src/components/camera/server.hpp
+++ b/src/components/camera/server.hpp
@@ -1,3 +1,6 @@
+/// @file components/camera/server.hpp
+///
+/// @brief Implements a gRPC server for the `Camera` component.
 #pragma once
 
 #include <common/v1/common.pb.h>

--- a/src/components/generic/client.hpp
+++ b/src/components/generic/client.hpp
@@ -1,4 +1,4 @@
-/// @file generic/client.hpp
+/// @file components/generic/client.hpp
 ///
 /// @brief Implements a gRPC client for the `Generic` component.
 #pragma once
@@ -12,9 +12,6 @@
 
 class GenericClient : public Generic {
    public:
-    /// @brief Send/receive arbitrary commands to the resource.
-    /// @param Command the command to execute.
-    /// @return The result of the executed command.
     AttributeMap do_command(AttributeMap command) override;
     GenericClient(std::string name, std::shared_ptr<grpc::Channel> channel)
         : Generic(std::move(name)),

--- a/src/components/generic/client.hpp
+++ b/src/components/generic/client.hpp
@@ -10,6 +10,9 @@
 #include <components/generic/generic.hpp>
 #include <robot/client.hpp>
 
+/// @class GenericClient
+/// @brief gRPC client implementation of a `Generic` component.
+/// @ingroup Generic
 class GenericClient : public Generic {
    public:
     AttributeMap do_command(AttributeMap command) override;

--- a/src/components/generic/generic.hpp
+++ b/src/components/generic/generic.hpp
@@ -12,6 +12,8 @@
 #include <subtype/subtype.hpp>
 
 // TODO(RSDK-1742): one class per header
+/// @class GenericSubtype
+/// @brief Defines a `ResourceSubtype` for the `Generic` component.
 class GenericSubtype : public ResourceSubtype {
    public:
     std::shared_ptr<ResourceServerBase> create_resource_server(
@@ -24,8 +26,15 @@ class GenericSubtype : public ResourceSubtype {
 
 class Generic : public ComponentBase {
    public:
+    /// @brief Creates a `ResourceSubtype` for the `Generic` component.
     static std::shared_ptr<ResourceSubtype> resource_subtype();
+
+    /// @brief Creates a `Generic` `Subtype`.
     static Subtype subtype();
+
+    /// @brief Send/receive arbitrary commands to the resource.
+    /// @param Command the command to execute.
+    /// @return The result of the executed command.
     virtual AttributeMap do_command(AttributeMap command) = 0;
 
    protected:

--- a/src/components/generic/generic.hpp
+++ b/src/components/generic/generic.hpp
@@ -12,8 +12,11 @@
 #include <subtype/subtype.hpp>
 
 // TODO(RSDK-1742): one class per header
+/// @defgroup Generic Classes related to the `Generic` component.
+
 /// @class GenericSubtype
 /// @brief Defines a `ResourceSubtype` for the `Generic` component.
+/// @ingroup Generic
 class GenericSubtype : public ResourceSubtype {
    public:
     std::shared_ptr<ResourceServerBase> create_resource_server(
@@ -24,6 +27,12 @@ class GenericSubtype : public ResourceSubtype {
         : ResourceSubtype(service_descriptor){};
 };
 
+/// @class Generic generic.hpp "components/generic/generic.hpp"
+/// @brief A `Generic` represents any component that can execute arbitrary commands.
+/// @ingroup Generic
+///
+/// This acts as an abstract base class to be inherited from by any drivers representing
+/// specific generic implementations. This class cannot be used on its own.
 class Generic : public ComponentBase {
    public:
     /// @brief Creates a `ResourceSubtype` for the `Generic` component.

--- a/src/components/generic/generic.hpp
+++ b/src/components/generic/generic.hpp
@@ -42,7 +42,7 @@ class Generic : public ComponentBase {
     static Subtype subtype();
 
     /// @brief Send/receive arbitrary commands to the resource.
-    /// @param Command the command to execute.
+    /// @param command the command to execute.
     /// @return The result of the executed command.
     virtual AttributeMap do_command(AttributeMap command) = 0;
 

--- a/src/components/generic/server.hpp
+++ b/src/components/generic/server.hpp
@@ -1,4 +1,4 @@
-/// @file generic/server.hpp
+/// @file components/generic/server.hpp
 ///
 /// @brief Implements a gRPC server for the `Generic` component.
 #pragma once

--- a/src/components/generic/server.hpp
+++ b/src/components/generic/server.hpp
@@ -9,6 +9,9 @@
 #include <resource/resource_server_base.hpp>
 #include <subtype/subtype.hpp>
 
+/// @class GenericServer
+/// @brief gRPC server implementation of a `Generic` component.
+/// @ingroup Generic
 class GenericServer : public ResourceServerBase,
                       public viam::component::generic::v1::GenericService::Service {
    public:

--- a/src/registry/registry.hpp
+++ b/src/registry/registry.hpp
@@ -33,6 +33,8 @@ class ResourceSubtype {
     // TODO: it doesn't look like we actually use this. Confirm, then remove.
     std::function<ProtoType(ResourceBase)> create_status;
 
+    const google::protobuf::ServiceDescriptor* service_descriptor;
+
     /// @brief Create a resource's gRPC server.
     /// @param svc The server's `SubtypeService`.
     /// @return a `shared_ptr` to the gRPC server.
@@ -48,9 +50,6 @@ class ResourceSubtype {
 
     ResourceSubtype(const google::protobuf::ServiceDescriptor* service_descriptor)
         : service_descriptor(service_descriptor){};
-
-   private:
-    const google::protobuf::ServiceDescriptor* service_descriptor;
 };
 
 /// @class ModelRegistration

--- a/src/registry/registry.hpp
+++ b/src/registry/registry.hpp
@@ -1,3 +1,6 @@
+/// @file registry/registry.hpp
+///
+/// @brief Defines the resource registry and associated types.
 #pragma once
 
 #include <string>
@@ -20,13 +23,26 @@
 // TODO(RSDK-1742): instead of std::functions, consider making these functions
 // virtual
 // TODO(RSDK-1742): one class per header
+/// @class ResourceSubtype registry.hpp "registry/registry.hpp"
+/// @brief Defines registered `Resource` creation functionality.
 class ResourceSubtype {
    public:
+    /// @brief Add `Reconfigure` functionality to a resource.
     std::function<ResourceBase(ResourceBase, Name)> create_reconfigurable;
+
+    // TODO: it doesn't look like we actually use this. Confirm, then remove.
     std::function<ProtoType(ResourceBase)> create_status;
-    const google::protobuf::ServiceDescriptor* service_descriptor;
+
+    /// @brief Create a resource's gRPC server.
+    /// @param svc The server's `SubtypeService`.
+    /// @return a `shared_ptr` to the gRPC server.
     virtual std::shared_ptr<ResourceServerBase> create_resource_server(
         std::shared_ptr<SubtypeService> svc) = 0;
+
+    /// @brief Create gRPC client to a resource.
+    /// @param name The name of the resource.
+    /// @param channel A channel connected to the client.
+    /// @return A `shared_ptr` to the resource client.
     virtual std::shared_ptr<ResourceBase> create_rpc_client(
         std::string name, std::shared_ptr<grpc::Channel> channel) = 0;
 
@@ -34,8 +50,11 @@ class ResourceSubtype {
         : service_descriptor(service_descriptor){};
 
    private:
+    const google::protobuf::ServiceDescriptor* service_descriptor;
 };
 
+/// @class ModelRegistration
+/// @brief Information about a registered model, including a constructor and config validator.
 class ModelRegistration {
    public:
     ModelRegistration(ResourceType rt)
@@ -64,8 +83,14 @@ class ModelRegistration {
     Subtype subtype;
     Model model;
     ResourceType resource_type;
+
+    /// @brief Constructs a resource from a map of dependencies and a resource config.
     std::function<std::shared_ptr<ResourceBase>(Dependencies, Resource)> construct_resource;
+
+    /// @brief Validates a resource config.
     std::function<std::vector<std::string>(Resource)> validate;
+
+    /// @brief Creates a `Status` object for a given resource.
     viam::robot::v1::Status create_status(std::shared_ptr<ResourceBase> resource);
 
    private:
@@ -76,21 +101,39 @@ class ModelRegistration {
     };
 };
 
+/// @class Registry
+/// @brief A registry of known resources.
 class Registry {
    public:
-    /// Registers a resource with the Registry
-    /// Args:
-    /// 	resource (ModelRegistration): object containing resource registration
-    /// data
-    ///
-    /// Raises:
-    /// 	throws error if resource already exists in the registry
+    /// @brief Registers a resource with the Registry.
+    /// @param resource An object containing resource registration information.
+    /// @throws `std::runtime_error` if the resource has already been registered.
     static void register_resource(std::shared_ptr<ModelRegistration> resource);
+
+    /// @brief Lookup a given registered resource.
+    /// @param name The name of the resource to lookup.
+    /// @return a `shared_ptr` to the resource's registration data.
     static std::shared_ptr<ModelRegistration> lookup_resource(std::string name);
+
+    /// @brief Lookup a given registered resource.
+    /// @param subtype The subtype of the resource to lookup.
+    /// @param model The model of the resource to lookup.
+    /// @return a `shared_ptr` to the resource's registration data.
     static std::shared_ptr<ModelRegistration> lookup_resource(Subtype subtype, Model model);
+
+    /// @brief Register a subtype.
+    /// @param subtype The subtype to be registered.
+    /// @param resource_subtype `ResourceSubtype` with resource functionality.
     static void register_subtype(Subtype subtype,
                                  std::shared_ptr<ResourceSubtype> resource_subtype);
+
+    /// @brief Lookup a registered subtype.
+    /// @param subtype The subtype to lookup.
+    /// @return A `shared_ptr` to the registered subtype's `ResourceSubtype`.
     static std::shared_ptr<ResourceSubtype> lookup_subtype(Subtype subtype);
+
+    /// @brief Provide information on registered resources.
+    /// @return A map from name to `ModelRegistration` of all registered resources.
     static std::unordered_map<std::string, std::shared_ptr<ModelRegistration>>
     registered_resources();
 

--- a/src/robot/client.cpp
+++ b/src/robot/client.cpp
@@ -57,12 +57,14 @@ using Viam::SDK::ViamChannel;
 const std::string k_stream_removed = "Stream removed";
 
 RobotClient::~RobotClient() {
-    this->close();
+    if (should_close_channel) {
+        this->close();
+    }
 }
 
 void RobotClient::close() {
     should_refresh.store(false);
-    for (std::shared_ptr<std::thread> t : threads) {
+    for (std::shared_ptr<std::thread> t : threads_) {
         t->~thread();
     }
     stop_all();
@@ -241,7 +243,7 @@ std::shared_ptr<RobotClient> RobotClient::with_channel(ViamChannel channel, Opti
         // close/destructor lets us shutdown gracefully. See also address sanitizer,
         // UB sanitizer
         t->detach();
-        robot->threads.push_back(t);
+        robot->threads_.push_back(t);
     };
 
     robot->refresh();

--- a/src/robot/client.hpp
+++ b/src/robot/client.hpp
@@ -30,12 +30,14 @@ using Viam::SDK::Options;
 using Viam::SDK::ViamChannel;
 
 // TODO(RSDK-1742) replace all `ResourceName` references in API with `Name`
+/// @defgroup Robot Classes related to a `Robot` representation.
 
 /// @class RobotClient client.h "robot/client.h"
 /// @brief gRPC client for a robot, to be used for all interactions with a robot.
 /// There are two ways to instantiate a robot:
 ///   - `RobotClient::at_address(...)`
 ///   - `RobotClient::with_channel(...)`
+/// @ingroup Robot
 ///
 /// You must `close()` a robot when finished with it in order to release its resources.
 /// Robots creates via `at_address` will automatically close, but robots created via

--- a/src/robot/client.hpp
+++ b/src/robot/client.hpp
@@ -1,3 +1,6 @@
+/// @file robot/client.cpp
+///
+/// @brief gRPC client implementation for a `robot`.
 #pragma once
 
 #include <string>
@@ -26,41 +29,47 @@ using viam::robot::v1::Status;
 using Viam::SDK::Options;
 using Viam::SDK::ViamChannel;
 
-/// gRPC client for a robot. This class should be used for all interactions with
-/// a robot.
 // TODO(RSDK-1742) replace all `ResourceName` references in API with `Name`
+
+/// @class RobotClient client.h "robot/client.h"
+/// @brief gRPC client for a robot, to be used for all interactions with a robot.
+/// There are two ways to instantiate a robot:
+///   - `RobotClient::at_address(...)`
+///   - `RobotClient::with_channel(...)`
+///
+/// You must `close()` a robot when finished with it in order to release its resources.
+/// Robots creates via `at_address` will automatically close, but robots created via
+/// `with_channel` require a user call to `close()`.
 class RobotClient {
    public:
     ~RobotClient();
     void refresh();
     void close();
-    /// Create a robot client that is connected to the robot at the provided
-    /// address. Uses the underlying rust-utils library and webRTC to dial the
-    /// address.
-    ///
-    /// Args:
-    /// 	address: Address of the robot (IP address, URI, URL, etc.)
-    /// 	options: Options for connecting and refreshing
+    /// @brief Create a robot client connected to the robot at the provided address.
+    /// @param address The addrxess of the robot (IP address, URI, URL, etc.)
+    /// @param options Options for connecting and refreshing.
     static std::shared_ptr<RobotClient> at_address(std::string address, Options options);
-    /// Create a robot client that is connected to the robot at the provided
-    /// local socket. Creates a direct connection to the robot using the `unix://`
-    /// scheme. Only useful for connecting to robots across Unix sockets.
-    ///
-    /// Args:
-    /// 	address: Local socket of the robot (a .sock file, etc.)
-    /// 	options: Options for connecting and refreshing
+    /// @brief Creates a robot client connected to the robot at the provided local socket.
+    /// @param address The local socket of the robot (a .sock file, etc.).
+    /// @param options Options for connecting and refreshing.
+    /// Creates a direct connection to the robot using the `unix://` scheme.
+    /// Only useful for connecting to robots across Unix sockets.
     static std::shared_ptr<RobotClient> at_local_socket(std::string address, Options options);
+
+    /// @brief Creates a robot client connected to the provided channel.
+    /// @param channel The channel to connect with.
+    /// @param options Options for connecting and refreshing.
+    /// Connects directly to a pre-existing channel. A robot created this way must be
+    /// `close()`d manually.
     static std::shared_ptr<RobotClient> with_channel(ViamChannel channel, Options options);
     RobotClient(ViamChannel channel);
     std::vector<ResourceName>* resource_names();
     std::unique_ptr<RobotService::Stub> stub_;
-    /// Gets a `shared_ptr` to a Resource Base.
-    ///
-    /// Args:
-    /// 	name: the name of the resource
-    ///
-    /// Raises:
-    /// 	Throws an error if the requested resource doesn't exist or is of the wrong type.
+
+    /// @brief Lookup and return a `shared_ptr` to a resource.
+    /// @param name The `ResourceName` of the resource.
+    /// @throws `std::runtime_error` if the requested resource doesn't exist or is the wrong type.
+    /// @return a `shared_ptr` to the requested resource as an uncasted `ResourceBase`.
     ///
     /// This method should not be called directly except in specific cases. The
     /// type-annotated `resource_by_name<T>(name)` overload is the preferred method
@@ -69,7 +78,12 @@ class RobotClient {
     /// Because the return type here is a `ResourceBase`, the user will need to manually
     /// cast to the desired type.
     std::shared_ptr<ResourceBase> resource_by_name(const ResourceName& name);
+
     template <typename T>
+    /// @brief Lookup and return a `shared_ptr` to a resource of the requested type.
+    /// @param name The ordinary name of the resource.
+    /// @throws `std::runtime_error` if the requested resource doesn't exist or is the wrong type.
+    /// @return a `shared_ptr` to the requested resource.
     std::shared_ptr<T> resource_by_name(std::string name) {
         ResourceName r;
         Subtype subtype = T::subtype();
@@ -81,29 +95,53 @@ class RobotClient {
         auto resource = this->resource_by_name(std::move(r));
         return std::dynamic_pointer_cast<T>(resource);
     }
+
+    /// @brief Get the configuration of the frame system of the given robot.
+    /// @return The configuration of the calling robot's frame system.
     std::vector<FrameSystemConfig> get_frame_system_config(
         std::vector<Transform> additional_transforms = std::vector<Transform>());
+
+    /// @brief Get the list of operations currently running on a robot.
+    /// @return The list of operations currently running on the calling robot.
     std::vector<viam::robot::v1::Operation> get_operations();
+
+    /// @brief Get the status of the robot's components.
+    /// @param components An optional list of the specific components for which status is desired.
+    /// @return A list of statuses.
     std::vector<Status> get_status(
         std::vector<ResourceName> components = std::vector<ResourceName>());
     std::vector<viam::robot::v1::Discovery> discover_components(
         std::vector<viam::robot::v1::DiscoveryQuery> queries);
 
-    std::vector<std::shared_ptr<std::thread>> threads;
-
+    /// @brief Transform a given `Pose` to a new specified destination which is a reference frame.
+    /// @param query The pose that should be transformed.
+    /// @param destination The name of the reference frame to transform the given pose to.
+    /// @return the `PoseInFrame` of the transformed pose.
     viam::common::v1::PoseInFrame transform_pose(
         viam::common::v1::PoseInFrame query,
         std::string destination,
         std::vector<Transform> additional_transforms = std::vector<Transform>());
+
+    /// @brief Blocks on the specified operation of the robot, returning when it is complete.
+    /// @param id The ID of the operation to block on.
     void block_for_operation(std::string id);
+
+    /// @brief Cancel all operations for the robot and stop all actuators and movement.
     void stop_all();
+
+    /// @brief Cancel all operations for the robot and stop all actuators and movement.
+    /// @param extra Any extra params to pass to resources' `stop` methods, keyed by `ResourceName`.
     void stop_all(std::unordered_map<ResourceName,
                                      std::unordered_map<std::string, std::shared_ptr<ProtoType>>,
                                      ResourceNameHasher,
                                      ResourceNameEqual> extra);
+
+    /// @brief Cancel a specified operation on the robot.
+    /// @param id The ID of the operation to cancel.
     void cancel_operation(std::string id);
 
    private:
+    std::vector<std::shared_ptr<std::thread>> threads_;
     std::atomic<bool> should_refresh;
     unsigned int refresh_interval;
     // (RSDK-919): make use of should_close_channel

--- a/src/robot/service.hpp
+++ b/src/robot/service.hpp
@@ -24,6 +24,9 @@ using google::protobuf::RepeatedPtrField;
 using viam::common::v1::ResourceName;
 using viam::robot::v1::Status;
 
+/// @class RobotService_ service.hpp "robot/service.hpp"
+/// @brief a gRPC service for a robot.
+/// @ingroup Robot
 class RobotService_ : public ComponentServiceBase, public viam::robot::v1::RobotService::Service {
    public:
     RobotService_();

--- a/src/robot/service.hpp
+++ b/src/robot/service.hpp
@@ -1,3 +1,6 @@
+/// @file robot/service.cpp
+///
+/// @brief gRPC service implementation for a `robot`.
 #pragma once
 
 #include <string>

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -19,7 +19,7 @@ void Server::register_service(grpc::Service* service) {
 
 void Server::start() {
     if (server_) {
-        throw "Attempted to start server that was already running";
+        throw std::runtime_error("Attempted to start server that was already running");
     }
 
     grpc::reflection::InitProtoReflectionServerBuilderPlugin();

--- a/src/rpc/server.hpp
+++ b/src/rpc/server.hpp
@@ -15,7 +15,7 @@ class Server {
     ~Server();
 
     /// @brief Starts the grpc server. Can only be called once.
-    /// @raises `std::runtime_error` if the server was already `start`ed.
+    /// @throws `std::runtime_error` if the server was already `start`ed.
     /// repeated calls.
     void start();
 
@@ -28,7 +28,7 @@ class Server {
 
     /// @brief Adds a listening port to the server.
     /// @param address The address to listen at.
-    /// @param The server credentials; defaults to a insecure server credentials.
+    /// @param creds The server credentials; defaults to a insecure server credentials.
     /// @throws `std::runtime_error` if called after the server has been `start`ed.
     void add_listening_port(std::string address,
                             std::shared_ptr<grpc::ServerCredentials> creds = nullptr);

--- a/src/rpc/server.hpp
+++ b/src/rpc/server.hpp
@@ -1,46 +1,42 @@
+/// @file rpc/server.hpp
+///
+/// @brief Defines the `Server` class.
 #pragma once
 
 #include <grpcpp/impl/service_type.h>
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server_builder.h>
 
-/// A grpc server
+/// @class Server server.hpp "rpc/server.hpp"
+/// @brief Defines gRPC `Server` functionality.
 class Server {
    public:
     Server();
     ~Server();
 
-    /// Starts the grpc server. This can only be called once, and will throw on
+    /// @brief Starts the grpc server. Can only be called once.
+    /// @raises `std::runtime_error` if the server was already `start`ed.
     /// repeated calls.
     void start();
 
     // TODO: make `register_service` take one of our types as an arg rather than a
     // grpc service type, and convert under the hood
-    /// registers a grpc service.
-    ///
-    /// Args:
-    /// 	service: the grpc service to be registered
-    ///
-    /// Raises:
-    /// 	Must be called before starting the server; new services cannot be
-    /// registered after 	the server starts. Attempting to do so will throw an
-    /// error
+    /// @brief Registers a gRPC service.
+    /// @param service The gRPC service to be registered.
+    /// @raises `std::runtime_error` if called after the server has been `start`ed.
     void register_service(grpc::Service* service);
 
-    /// Adds a listening port to the server.
-    /// Args:
-    /// 	address: the address to listen at
-    ///		creds: server credentials. defaults to insecure server
-    /// credentials
-    ///
-    ///	Raises:
-    ///		Must be called before starting the server. Attempting to call
-    /// after
-    /// the server has 		started will throw an error
+    /// @brief Adds a listening port to the server.
+    /// @param address The address to listen at.
+    /// @creds The server credentials; defaults to a insecure server credentials.
+    /// @thows `std::runtime_error` if called after the server has been `start`ed.
     void add_listening_port(std::string address,
                             std::shared_ptr<grpc::ServerCredentials> creds = nullptr);
 
+    /// @brief waits on server close, only returning when the server is closed.
     void wait();
+
+    /// @brief Shutdown the gRPC server.
     void shutdown();
 
    private:

--- a/src/rpc/server.hpp
+++ b/src/rpc/server.hpp
@@ -23,13 +23,13 @@ class Server {
     // grpc service type, and convert under the hood
     /// @brief Registers a gRPC service.
     /// @param service The gRPC service to be registered.
-    /// @raises `std::runtime_error` if called after the server has been `start`ed.
+    /// @throws `std::runtime_error` if called after the server has been `start`ed.
     void register_service(grpc::Service* service);
 
     /// @brief Adds a listening port to the server.
     /// @param address The address to listen at.
-    /// @creds The server credentials; defaults to a insecure server credentials.
-    /// @thows `std::runtime_error` if called after the server has been `start`ed.
+    /// @param The server credentials; defaults to a insecure server credentials.
+    /// @throws `std::runtime_error` if called after the server has been `start`ed.
     void add_listening_port(std::string address,
                             std::shared_ptr<grpc::ServerCredentials> creds = nullptr);
 


### PR DESCRIPTION
#### Major Changes
- Provides more comprehensive, doxygen-formatted documentation for `robot`, `camera`, `generic`, `rpc/server`, and `registry`

#### Minor changes
- Make use of `should_close_channel` in robot client
- make `threads` `private` in robot client
- 