### PR TITLE
RSDK-2822 Add default case to switch statements

### DIFF
--- a/src/viam/sdk/common/proto_type.cpp
+++ b/src/viam/sdk/common/proto_type.cpp
@@ -47,7 +47,8 @@ ProtoType ProtoType::of_value(Value value) {
             return ProtoType(map);
         }
         case Value::KindCase::KIND_NOT_SET:
-        case Value::KindCase::kNullValue: {
+        case Value::KindCase::kNullValue:
+        default: {
             return ProtoType();
         }
     }

--- a/src/viam/sdk/spatialmath/geometry.cpp
+++ b/src/viam/sdk/spatialmath/geometry.cpp
@@ -84,7 +84,8 @@ viam::common::v1::Geometry GeometryConfig::to_proto() {
 
             return geometry_;
         }
-        case unknown: {
+        case unknown:
+        default: {
             if (x == 0 && y == 0 && z == 0) {
                 *geometry_.mutable_box() = box_proto();
             } else {

--- a/src/viam/sdk/spatialmath/orientation.cpp
+++ b/src/viam/sdk/spatialmath/orientation.cpp
@@ -77,8 +77,9 @@ OrientationConfig OrientationConfig::from_proto(proto::Orientation proto) {
             quat.y = 0;
             quat.z = 0;
         }
-        case proto::Orientation::TypeCase::TYPE_NOT_SET: {
-            throw "orientation type not known";
+        case proto::Orientation::TypeCase::TYPE_NOT_SET:
+        default: {
+            throw std::runtime_error("orientation type not known");
         }
     }
     return cfg;
@@ -135,6 +136,9 @@ proto::Orientation OrientationConfig::to_proto() {
             quat.set_z(q.z);
             orientation.set_allocated_quaternion(&quat);
             return orientation;
+        };
+        default: {
+            throw std::runtime_error("orientation type not known");
         }
     }
 }

--- a/src/viam/sdk/spatialmath/orientation.cpp
+++ b/src/viam/sdk/spatialmath/orientation.cpp
@@ -76,6 +76,8 @@ OrientationConfig OrientationConfig::from_proto(proto::Orientation proto) {
             quat.x = 0;
             quat.y = 0;
             quat.z = 0;
+            cfg.orientation_ = quat;
+            break;
         }
         case proto::Orientation::TypeCase::TYPE_NOT_SET:
         default: {


### PR DESCRIPTION
This fixes the following compile warnings by adding default cases to switch statements:
```
/viam-cpp-sdk/src/viam/sdk/common/proto_type.cpp: In static member function ‘static viam::sdk::ProtoType viam::sdk::ProtoType::of_value(google::protobuf::Value)’:
/viam-cpp-sdk/src/viam/sdk/common/proto_type.cpp:54:1: warning: control reaches end of non-void function [-Wreturn-type]
   54 | }
      | ^
[45/76] Building CXX object src/viam/sdk/CMakeFiles/viamsdk.dir/spatialmath/geometry.cpp.o
/viam-cpp-sdk/src/viam/sdk/spatialmath/geometry.cpp: In member function ‘viam::common::v1::Geometry viam::sdk::GeometryConfig::to_proto()’:
/viam-cpp-sdk/src/viam/sdk/spatialmath/geometry.cpp:96:1: warning: control reaches end of non-void function [-Wreturn-type]
   96 | };
      | ^
[47/76] Building CXX object src/viam/sdk/CMakeFiles/viamsdk.dir/spatialmath/orientation.cpp.o
/viam-cpp-sdk/src/viam/sdk/spatialmath/orientation.cpp: In member function ‘viam::app::v1::Orientation viam::sdk::OrientationConfig::to_proto()’:
/viam-cpp-sdk/src/viam/sdk/spatialmath/orientation.cpp:140:1: warning: control reaches end of non-void function [-Wreturn-type]
  140 | }
```