### PR TITLE
RSDK-2751 Add Example Camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,22 +41,6 @@ packages.
 Instructions for running examples follows. More robust instructions
 for setting up a project to come.
 
-### Echo Streaming Example
-The echo example communicates with the goutils sample server. It
-demonstrates individual, streamed, and bidirectional communication. To
-test, navigate to your goutils clone and run
-
-``` shell
-go run rpc/examples/echo/server/cmd/main.go
-```
-
-Then, run the `example_echo` program (it will be in the `bin`
-directory of your SDK installation)
-
-``` shell
-ninja install && ./build/install/bin/example_echo
-```
-
 ### Dial Example
 
 If you are connecting to a robot with authentication you will need to
@@ -106,6 +90,21 @@ override and only use direct gRPC calls, you will need to use a
 `.local` address for your robot's uri,
 e.g. `name.xxxx.local.viam.cloud:8080` instead of
 `name.xxxx.viam.cloud`.
+
+### Camera Example
+The camera example demonstrates how to get an image from the a remote camera and save it to a local file.
+
+First, download and start the [rdk](https://github.com/viamrobotics/rdk) with the provided config
+``` shell
+./viam-server-binary --config ./src/viam/examples/camera/example_config.json
+```
+
+Then build the c++ sdk using the instructions below and run
+``` shell
+./build/src/viam/examples/camera/example_camera
+```
+This will save the image from the fake camera to `img.png`.
+
 
 ## Building Documentation Locally for Testing
 The C++ sdk uses [Doxygen](https://www.doxygen.nl/) to generate documentation.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@
 > is not guaranteed. Breaking changes are likely to occur, and occur
 > often.
 
+## Resources
+* [Documentation](https://cpp.viam.dev)
+* [Examples](https://github.com/viamrobotics/viam-cpp-sdk/tree/main/src/viam/examples)
+
 ## Repository Layout
-- `src` The implementation of the C++ sdk library
-- `src/gen` All the google and viam api autogen files
-- `examples` A list of examples
+- `src/viam/sdk` The implementation of the C++ sdk library
+- `src/viam/api` All the google and viam api autogen files
+- `src/viam/examples` A list of examples
 
 ## Getting Started
 
@@ -36,75 +40,6 @@ packages.
    files on your local filesystem. When it comes time to
    testing/building/running the program, do so inside the docker
    environment you opened in the previous step.
-
-## Usage
-Instructions for running examples follows. More robust instructions
-for setting up a project to come.
-
-### Dial Example
-
-If you are connecting to a robot with authentication you will need to
-add credentials. Update path code :
-
-``` c++
-void *ptr = init_rust_runtime();
-char *path = dial("<your robot uri here>", "<your robot credentials here>", false, ptr);
-```
-
-Then to obtain a robot client do :
-
-``` c++
-std::string address("unix://");
-address += path;
-RobotServiceClient client(grpc::CreateChannel(address, grpc::InsecureChannelCredentials()));
-```
-
-Now if we want to get the metadata of the robots we just have to do :
-
-``` c++
-ResourceNamesRequest req;
-ResourceNamesResponse resp;
-ClientContext context;
-
-Status status = stub_->ResourceNames(&context, req, &resp);
-if (!status.ok()) {
-  return;
-}
-
-for (auto i = 0; i < resp.resource_size(); i++) {
-  std::cout << "Resource " << i << " " << resp.resources(i).type() << std::endl;
-}
-```
-
-Then simply run
-
-``` shell
-ninja install && ./build/install/bin/example_dial
-```
-
-If you want to connect to a robot without credentials then just simply
-pass a null pointer for the credentials.
-
-Note also that this will attempt to connect over webRTC by default. To
-override and only use direct gRPC calls, you will need to use a
-`.local` address for your robot's uri,
-e.g. `name.xxxx.local.viam.cloud:8080` instead of
-`name.xxxx.viam.cloud`.
-
-### Camera Example
-The camera example demonstrates how to get an image from the a remote camera and save it to a local file.
-
-First, download and start the [rdk](https://github.com/viamrobotics/rdk) with the provided config
-``` shell
-./viam-server-binary --config ./src/viam/examples/camera/example_config.json
-```
-
-Then build the c++ sdk using the instructions below and run
-``` shell
-./build/src/viam/examples/camera/example_camera
-```
-This will save the image from the fake camera to `img.png`.
-
 
 ## Building Documentation Locally for Testing
 The C++ sdk uses [Doxygen](https://www.doxygen.nl/) to generate documentation.

--- a/src/viam/examples/README.md
+++ b/src/viam/examples/README.md
@@ -1,0 +1,84 @@
+# Component & Service Examples
+Examples: 
+ - camera
+ - motor
+ 
+These examples demonstrate basic functionality of Viam components and services while connecting to a local Viam server instance. 
+If you wish to build & run these examples:
+
+Download and build the RDK by following the instructions [here](https://github.com/viamrobotics/rdk#building-and-using).
+
+Then run:
+``` shell
+[viam-server-command] --config viam-cpp-sdk/src/viam/examples/[component name]/example_config.json
+```
+This will setup a server running on `localhost:8080` that has a mock setup of the example component. Leave this running. Now we can use the C++ sdk to connect to that component and perform some action.
+
+Download and build the C++ SDK by following the instructions [here](https://github.com/viamrobotics/viam-cpp-sdk#getting-started).
+
+Then run: 
+``` shell
+viam-cpp-sdk/build/viam/examples/[component name]/example_[component name]
+```
+
+
+
+# Generic Examples
+
+## Project example
+This example shows how to setup a simple CMake-based project that uses Viam's C++ SDK. 
+
+## Module example
+This example goes through how to create custom modular resources using Viam's C++ SDK, and how to connect it to a Robot.
+
+## Dial Example
+
+If you are connecting to a robot with authentication you will need to
+add credentials. Update path code :
+
+``` c++
+void *ptr = init_rust_runtime();
+char *path = dial("<your robot uri here>", "<your robot credentials here>", false, ptr);
+```
+
+Then to obtain a robot client do :
+
+``` c++
+std::string address("unix://");
+address += path;
+RobotServiceClient client(grpc::CreateChannel(address, grpc::InsecureChannelCredentials()));
+```
+
+Now if we want to get the metadata of the robots we just have to do :
+
+``` c++
+ResourceNamesRequest req;
+ResourceNamesResponse resp;
+ClientContext context;
+
+Status status = stub_->ResourceNames(&context, req, &resp);
+if (!status.ok()) {
+  return;
+}
+
+for (auto i = 0; i < resp.resource_size(); i++) {
+  std::cout << "Resource " << i << " " << resp.resources(i).type() << std::endl;
+}
+```
+
+If you want to run this locally, you can download and build the C++ SDK by following the instructions [here](https://github.com/viamrobotics/viam-cpp-sdk#getting-started).
+
+Then run:
+
+``` shell
+./build/viam/examples/dial/example_dial
+```
+
+If you want to connect to a robot without credentials then just simply
+pass a null pointer for the credentials.
+
+Note also that this will attempt to connect over webRTC by default. To
+override and only use direct gRPC calls, you will need to use a
+`.local` address for your robot's uri,
+e.g. `name.xxxx.local.viam.cloud:8080` instead of
+`name.xxxx.viam.cloud`.

--- a/src/viam/examples/camera/CMakeLists.txt
+++ b/src/viam/examples/camera/CMakeLists.txt
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(dial)
-add_subdirectory(modules)
-add_subdirectory(motor)
-add_subdirectory(camera)
+add_executable(example_camera
+  example_camera.cpp
+)
+
+target_link_libraries(example_camera
+  viam-cpp-sdk::viamsdk
+)
+
+install(
+  TARGETS example_camera
+  COMPONENT viam-cpp-sdk_examples
+)

--- a/src/viam/examples/camera/example_camera.cpp
+++ b/src/viam/examples/camera/example_camera.cpp
@@ -74,7 +74,7 @@ int main() {
     cout << "Getting and saving image to " << output_file << endl;
     ofstream fout;
     fout.open(output_file, std::ios::binary | std::ios::out);
-    fout.write((char*)&img.bytes[0], img.bytes.size());
+    fout.write(reinterpret_cast<char*>(img.bytes.data()), img.bytes.size());
     fout.close();
 
     return EXIT_SUCCESS;

--- a/src/viam/examples/camera/example_camera.cpp
+++ b/src/viam/examples/camera/example_camera.cpp
@@ -1,0 +1,98 @@
+#include <chrono>
+#include <cstddef>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <boost/optional.hpp>
+#include <boost/program_options.hpp>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/support/status.h>
+#include <unistd.h>
+
+#include <viam/api/common/v1/common.pb.h>
+#include <viam/api/robot/v1/robot.grpc.pb.h>
+#include <viam/api/robot/v1/robot.pb.h>
+
+#include <viam/sdk/components/camera/camera.hpp>
+#include <viam/sdk/components/camera/client.hpp>
+#include <viam/sdk/components/camera/server.hpp>
+#include <viam/sdk/robot/client.hpp>
+#include <viam/sdk/robot/service.hpp>
+#include <viam/sdk/rpc/dial.hpp>
+
+using namespace viam::sdk;
+using namespace std;
+
+using viam::robot::v1::Status;
+
+int main() {
+    // If you want to connect to a remote robot, this should be the url of the robot
+    // Ex: xxx.xxx.viam.cloud
+    string robot_address("localhost:8080");
+    // If you want to connect to a remote robot, you will need the robot secret
+    // You can find this on app.viam.com
+    Credentials credentials("");
+
+    DialOptions dial_options;
+
+    // This is for an example. You should NOT have this option enabled in real systems.
+    dial_options.allow_insecure_downgrade = credentials.payload.length() == 0;
+
+    // Set the refresh interval of the robot (in seconds) (0 = auto refresh)
+    Options options = Options(1, dial_options);
+
+    shared_ptr<RobotClient> robot;
+    try {
+        robot = RobotClient::at_address(robot_address, options);
+        robot->refresh();
+        cout << "Successfully connected to the robot" << endl;
+    } catch (const std::exception& e) {
+        cout << "Failed to connect to the robot. Exiting." << endl;
+        cout << "Exception: " << string(e.what()) << endl;
+        return 1;
+    }
+
+    vector<ResourceName>* resource_names = robot->resource_names();
+
+    cout << "Resources of the robot:" << endl;
+    for (ResourceName resource : *resource_names) {
+        cout << " - " << resource.name() << " (" << resource.subtype() << ")" << endl;
+    }
+
+    string camera_name("camera1");
+
+    cout << "Getting camera: " << camera_name << endl;
+    shared_ptr<CameraClient> camera;
+    try {
+        camera = robot->resource_by_name<CameraClient>(camera_name);
+    } catch (const std::exception& e) {
+        cout << "Failed to find " << camera_name << ". Exiting." << endl;
+        cout << "Exception: " << e.what() << endl;
+        robot->close();
+        return 1;
+    }
+    Camera::properties props = camera->get_properties();
+    Camera::intrinsic_parameters intrinsics = props.intrinsic_parameters;
+    cout << "Image dimensions: " << intrinsics.width_px << " x " << intrinsics.height_px << endl;
+
+    string output_file = "img.png";
+    string image_mime_type = "image/png";
+
+    std::cout << "Getting and saving image to " << output_file << std::endl;
+    Camera::raw_image img = camera->get_image(image_mime_type);
+    std::ofstream fout;
+    fout.open(output_file, std::ios::binary | std::ios::out);
+    fout.write((char*)&img.bytes, sizeof(img.bytes.size()));
+    fout.close();
+
+    robot->close();
+    return 0;
+}

--- a/src/viam/examples/camera/example_camera.cpp
+++ b/src/viam/examples/camera/example_camera.cpp
@@ -45,7 +45,7 @@ int main() {
     // dial_options.credentials = credentials;
 
     // This is for an example. You should **not** have this option enabled in real systems.
-    dial_options.allow_insecure_downgrade = credentials.payload.length() == 0;
+    dial_options.allow_insecure_downgrade = credentials.payload.empty();
 
     // Set the refresh interval of the robot (in seconds) (0 = auto refresh) and the dial options
     Options options = Options(1, dial_options);

--- a/src/viam/examples/camera/example_camera.cpp
+++ b/src/viam/examples/camera/example_camera.cpp
@@ -31,22 +31,23 @@
 using namespace viam::sdk;
 using namespace std;
 
-using viam::robot::v1::Status;
-
 int main() {
     // If you want to connect to a remote robot, this should be the url of the robot
     // Ex: xxx.xxx.viam.cloud
     string robot_address("localhost:8080");
-    // If you want to connect to a remote robot, you will need the robot secret
-    // You can find this on app.viam.com
+    // If you want to connect to a remote robot, you need the robot location secret (not
+    // the part secret) You can find this on app.viam.com
     Credentials credentials("");
 
     DialOptions dial_options;
 
-    // This is for an example. You should NOT have this option enabled in real systems.
+    // If you have credentials, use this to pass them to the robot
+    // dial_options.credentials = credentials;
+
+    // This is for an example. You should **not** have this option enabled in real systems.
     dial_options.allow_insecure_downgrade = credentials.payload.length() == 0;
 
-    // Set the refresh interval of the robot (in seconds) (0 = auto refresh)
+    // Set the refresh interval of the robot (in seconds) (0 = auto refresh) and the dial options
     Options options = Options(1, dial_options);
 
     shared_ptr<RobotClient> robot;
@@ -86,11 +87,18 @@ int main() {
     string output_file = "img.png";
     string image_mime_type = "image/png";
 
-    std::cout << "Getting and saving image to " << output_file << std::endl;
+    cout << "Getting image from camera " << endl;
     Camera::raw_image img = camera->get_image(image_mime_type);
-    std::ofstream fout;
+    cout << "Got image of mime type: " << img.mime_type << endl;
+
+    // Depending on how you use the image, you may need to convert the
+    // data to a string
+    string img_data(img.bytes.begin(), img.bytes.end());
+
+    cout << "Getting and saving image to " << output_file << endl;
+    ofstream fout;
     fout.open(output_file, std::ios::binary | std::ios::out);
-    fout.write((char*)&img.bytes, sizeof(img.bytes.size()));
+    fout.write(img_data.c_str(), img_data.length());
     fout.close();
 
     robot->close();

--- a/src/viam/examples/camera/example_camera.cpp
+++ b/src/viam/examples/camera/example_camera.cpp
@@ -9,73 +9,87 @@
 #include <viam/sdk/robot/service.hpp>
 #include <viam/sdk/rpc/dial.hpp>
 
-using namespace viam::sdk;
-using namespace std;
-
 int main() {
-    // If you want to connect to a remote robot, this should be the url of the robot
-    // Ex: xxx.xxx.viam.cloud
-    string robot_address("localhost:8080");
-    // If you want to connect to a remote robot, you need the robot location secret (not
-    // the part secret) You can find this on app.viam.com
-    Credentials credentials("");
-
-    DialOptions dial_options;
-
-    // If you have credentials, use this to pass them to the robot
-    // dial_options.credentials = credentials;
-
-    // This is for an example. Care should be taken before exercising this option in production.
-    dial_options.allow_insecure_downgrade = credentials.payload.empty();
-
-    // Set the refresh interval of the robot (in seconds) (0 = auto refresh) and the dial
-    // options
-    Options options = Options(1, dial_options);
-
-    shared_ptr<RobotClient> robot;
+    using std::cerr;
+    using std::cout;
+    using std::endl;
+    namespace vs = ::viam::sdk;
     try {
-        robot = RobotClient::at_address(robot_address, options);
-        cout << "Successfully connected to the robot" << endl;
-    } catch (const std::exception& e) {
-        cout << "Failed to connect to the robot. Exiting." << endl;
-        cout << "Exception: " << string(e.what()) << endl;
+        // If you want to connect to a remote robot, this should be the url of the robot
+        // Ex: xxx.xxx.viam.cloud
+        std::string robot_address("localhost:8080");
+        // If you want to connect to a remote robot, you need the robot location secret (not
+        // the part secret) You can find this on app.viam.com
+        vs::Credentials credentials("");
+
+        vs::DialOptions dial_options;
+
+        // If you have credentials, use this to pass them to the robot
+        // dial_options.credentials = credentials;
+
+        // This is for an example. Care should be taken before exercising this option in production.
+        dial_options.allow_insecure_downgrade = credentials.payload.empty();
+
+        // Set the refresh interval of the robot (in seconds) (0 = auto refresh) and the dial
+        // options
+        vs::Options options = vs::Options(1, dial_options);
+
+        std::shared_ptr<vs::RobotClient> robot;
+        try {
+            robot = vs::RobotClient::at_address(robot_address, options);
+            cout << "Successfully connected to the robot" << endl;
+        } catch (const std::exception& e) {
+            cerr << "Failed to connect to the robot. Exiting." << endl;
+            throw;
+        }
+
+        std::vector<vs::ResourceName>* resource_names = robot->resource_names();
+
+        cout << "Resources of the robot:" << endl;
+        for (vs::ResourceName resource : *resource_names) {
+            cout << " - " << resource.name() << " (" << resource.subtype() << ")" << endl;
+        }
+
+        std::string camera_name("camera1");
+
+        cout << "Getting camera: " << camera_name << endl;
+        std::shared_ptr<vs::CameraClient> camera;
+        try {
+            camera = robot->resource_by_name<vs::CameraClient>(camera_name);
+        } catch (const std::exception& e) {
+            cerr << "Failed to find " << camera_name << ". Exiting." << endl;
+            throw;
+        }
+        vs::Camera::properties props = camera->get_properties();
+        vs::Camera::intrinsic_parameters intrinsics = props.intrinsic_parameters;
+        cout << "Image dimensions: " << intrinsics.width_px << " x " << intrinsics.height_px
+             << endl;
+
+        std::string output_file("img.png");
+        std::string image_mime_type("image/png");
+
+        cout << "Getting image from camera " << endl;
+        vs::Camera::raw_image img = camera->get_image(image_mime_type);
+        cout << "Got image of mime type: " << img.mime_type << endl;
+
+        cout << "Getting and saving image to " << output_file << endl;
+        std::ofstream fout;
+        fout.open(output_file, std::ios::binary | std::ios::out);
+        if (fout.fail()) {
+            throw std::runtime_error("Failed to open output file " + output_file);
+        }
+        fout.write(reinterpret_cast<char*>(img.bytes.data()), img.bytes.size());
+        fout.close();
+        if (fout.fail()) {
+            throw std::runtime_error("Failed to write and close output file " + output_file);
+        }
+    } catch (const std::exception& ex) {
+        cerr << "Program failed. Exception: " << std::string(ex.what()) << endl;
+        return EXIT_FAILURE;
+    } catch (...) {
+        cerr << "Program failed without exception message." << endl;
         return EXIT_FAILURE;
     }
-
-    vector<ResourceName>* resource_names = robot->resource_names();
-
-    cout << "Resources of the robot:" << endl;
-    for (ResourceName resource : *resource_names) {
-        cout << " - " << resource.name() << " (" << resource.subtype() << ")" << endl;
-    }
-
-    string camera_name("camera1");
-
-    cout << "Getting camera: " << camera_name << endl;
-    shared_ptr<CameraClient> camera;
-    try {
-        camera = robot->resource_by_name<CameraClient>(camera_name);
-    } catch (const std::exception& e) {
-        cout << "Failed to find " << camera_name << ". Exiting." << endl;
-        cout << "Exception: " << e.what() << endl;
-        return EXIT_FAILURE;
-    }
-    Camera::properties props = camera->get_properties();
-    Camera::intrinsic_parameters intrinsics = props.intrinsic_parameters;
-    cout << "Image dimensions: " << intrinsics.width_px << " x " << intrinsics.height_px << endl;
-
-    string output_file = "img.png";
-    string image_mime_type = "image/png";
-
-    cout << "Getting image from camera " << endl;
-    Camera::raw_image img = camera->get_image(image_mime_type);
-    cout << "Got image of mime type: " << img.mime_type << endl;
-
-    cout << "Getting and saving image to " << output_file << endl;
-    ofstream fout;
-    fout.open(output_file, std::ios::binary | std::ios::out);
-    fout.write(reinterpret_cast<char*>(img.bytes.data()), img.bytes.size());
-    fout.close();
 
     return EXIT_SUCCESS;
 }

--- a/src/viam/examples/camera/example_camera.cpp
+++ b/src/viam/examples/camera/example_camera.cpp
@@ -25,7 +25,7 @@ int main() {
     // If you have credentials, use this to pass them to the robot
     // dial_options.credentials = credentials;
 
-    // This is for an example. You should **not** have this option enabled in real systems.
+    // This is for an example. Care should be taken before exercising this option in production.
     dial_options.allow_insecure_downgrade = credentials.payload.empty();
 
     // Set the refresh interval of the robot (in seconds) (0 = auto refresh) and the dial

--- a/src/viam/examples/camera/example_config.json
+++ b/src/viam/examples/camera/example_config.json
@@ -1,0 +1,9 @@
+{
+  "components": [
+    {
+      "name": "camera1",
+      "type": "camera",
+      "model": "fake"
+    }
+  ]
+}

--- a/src/viam/examples/dial/example_dial.cpp
+++ b/src/viam/examples/dial/example_dial.cpp
@@ -37,7 +37,6 @@ int main() {
 
     // connect to robot, ensure we can refresh it
     std::shared_ptr<RobotClient> robot = RobotClient::at_address(address, options);
-    robot->refresh();
 
     // ensure we can query resources
     std::vector<ResourceName>* resource_names = robot->resource_names();
@@ -65,6 +64,5 @@ int main() {
     auto gc = robot->resource_by_name<GenericClient>("generic1");
     std::cout << "got generic client named " << gc->name() << std::endl;
 
-    robot->close();
-    return 0;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This is part of: https://viam.atlassian.net/browse/RSDK-2751

I want to create a model example that the other components can use to show off proper use.

I think it makes sense for us to have a number of examples at the component/service level for two reasons:
1) It allows customers to find the code example they are looking for faster
2) It makes it easier for us to run manual QA on our code and debug customer issues

Though, we might not want/need examples every component (ex: simple ones like encoder).




Important design decisions:
1) `using namespace std` because I think it is cleaner for examples. Happy to remove if we feel otherwise.
2) Included an `example_config.json` that spins up a `fake` camera so people can easily test locally.
3) Placed info for example in root `README.md`. This is following the current paradigm for examples, but I also think we could create a `src/viam/examples/README.md` that keeps all of the information close to the actual examples and then link to that README. Opinions?
4) The README info does not say how to install RDK. Do we want to include this info? We could add the classic `git clone github.com/.../rdk && make setup && go run web/server/.../main.go` however this is very ugly. We could also direct them to download the static binaries. Looking for feedback here.
5) Added try/catch statements around main blocks that can fail but not every every block that could throw (ex: `get_image` could fail if grpc conn dies). 
6) Didn't use `auto`. I find `auto` in examples frustrating because it forces me to go look elsewhere to figure out what type is actually being returned. Happy to discuss this.