### PR TITLE
Remove src/CMakeLists.txt 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,7 +343,7 @@ else()
 endif()
 
 # Pull in our subdirectories
-add_subdirectory(src)
+add_subdirectory(src/viam)
 
 
 # Define some custom targets to install different subsets of files.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,0 @@
-add_subdirectory(viam)


### PR DESCRIPTION
Removing `src/CMakeLists.txt` means that Github will auto-collapse `src` into `src/viam` like the Python SDK https://github.com/viamrobotics/viam-python-sdk/

I don't think there is any clear benefit of having a `CMakeLists.txt` file at this level and it makes our repo slightly more annoying to navigate.