### PR TITLE
RSDK-797 Add base wrapper

### DIFF
--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -89,6 +89,10 @@ if (VIAMCPPSDK_USE_DYNAMIC_PROTOS)
     ${PROTO_GEN_DIR}/common/v1/common.grpc.pb.h
     ${PROTO_GEN_DIR}/common/v1/common.pb.cc
     ${PROTO_GEN_DIR}/common/v1/common.pb.h
+    ${PROTO_GEN_DIR}/component/base/v1/base.grpc.pb.cc
+    ${PROTO_GEN_DIR}/component/base/v1/base.grpc.pb.h
+    ${PROTO_GEN_DIR}/component/base/v1/base.pb.cc
+    ${PROTO_GEN_DIR}/component/base/v1/base.pb.h
     ${PROTO_GEN_DIR}/component/camera/v1/camera.grpc.pb.cc
     ${PROTO_GEN_DIR}/component/camera/v1/camera.grpc.pb.h
     ${PROTO_GEN_DIR}/component/camera/v1/camera.pb.cc
@@ -172,6 +176,8 @@ target_sources(viamapi
     ${PROTO_GEN_DIR}/app/v1/robot.pb.cc
     ${PROTO_GEN_DIR}/common/v1/common.grpc.pb.cc
     ${PROTO_GEN_DIR}/common/v1/common.pb.cc
+    ${PROTO_GEN_DIR}/component/base/v1/base.grpc.pb.cc
+    ${PROTO_GEN_DIR}/component/base/v1/base.pb.cc
     ${PROTO_GEN_DIR}/component/camera/v1/camera.grpc.pb.cc
     ${PROTO_GEN_DIR}/component/camera/v1/camera.pb.cc
     ${PROTO_GEN_DIR}/component/encoder/v1/encoder.grpc.pb.cc
@@ -199,6 +205,8 @@ target_sources(viamapi
       ${PROTO_GEN_DIR}/../../viam/api/app/v1/robot.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/common/v1/common.grpc.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/common/v1/common.pb.h
+      ${PROTO_GEN_DIR}/../../viam/api/component/base/v1/base.grpc.pb.h
+      ${PROTO_GEN_DIR}/../../viam/api/component/base/v1/base.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/camera/v1/camera.grpc.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/camera/v1/camera.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/encoder/v1/encoder.grpc.pb.h

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -39,9 +39,9 @@ target_sources(viamsdk
     # consider making all necessary runtime values a single `context` that has to
     # be initialized within main before anything else happens?
     registry/registry.cpp
+    common/linear_algebra.cpp
     common/proto_type.cpp
     common/utils.cpp
-    common/linear_algebra.cpp
     components/base/base.cpp
     components/base/client.cpp
     components/base/server.cpp
@@ -86,9 +86,9 @@ target_sources(viamsdk
     BASE_DIRS
       ../..
     FILES
+      ../../viam/sdk/common/linear_algebra.hpp
       ../../viam/sdk/common/proto_type.hpp
       ../../viam/sdk/common/utils.hpp
-      ../../viam/sdk/common/linear_algebra.hpp
       ../../viam/sdk/components/base/base.hpp
       ../../viam/sdk/components/base/client.hpp
       ../../viam/sdk/components/base/server.hpp

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -41,6 +41,9 @@ target_sources(viamsdk
     registry/registry.cpp
     common/proto_type.cpp
     common/utils.cpp
+    components/base/base.cpp
+    components/base/client.cpp
+    components/base/server.cpp
     components/camera/camera.cpp
     components/camera/client.cpp
     components/camera/server.cpp
@@ -75,6 +78,7 @@ target_sources(viamsdk
     tests/test_utils.cpp
     tests/mocks/camera_mocks.cpp
     tests/mocks/generic_mocks.cpp
+    tests/mocks/mock_base.cpp
     tests/mocks/mock_encoder.cpp
     tests/mocks/mock_motor.cpp
   PUBLIC FILE_SET viamsdk_public_includes TYPE HEADERS
@@ -83,6 +87,9 @@ target_sources(viamsdk
     FILES
       ../../viam/sdk/common/proto_type.hpp
       ../../viam/sdk/common/utils.hpp
+      ../../viam/sdk/components/base/base.hpp
+      ../../viam/sdk/components/base/client.hpp
+      ../../viam/sdk/components/base/server.hpp
       ../../viam/sdk/components/camera/camera.hpp
       ../../viam/sdk/components/camera/client.hpp
       ../../viam/sdk/components/camera/server.hpp
@@ -118,6 +125,7 @@ target_sources(viamsdk
       ../../viam/sdk/tests/test_utils.hpp
       ../../viam/sdk/tests/mocks/camera_mocks.hpp
       ../../viam/sdk/tests/mocks/generic_mocks.hpp
+      ../../viam/sdk/tests/mocks/mock_base.hpp
       ../../viam/sdk/tests/mocks/mock_encoder.hpp
       ../../viam/sdk/tests/mocks/mock_motor.hpp
 )

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(viamsdk
     registry/registry.cpp
     common/proto_type.cpp
     common/utils.cpp
+    common/linear_algebra.cpp
     components/base/base.cpp
     components/base/client.cpp
     components/base/server.cpp
@@ -87,6 +88,7 @@ target_sources(viamsdk
     FILES
       ../../viam/sdk/common/proto_type.hpp
       ../../viam/sdk/common/utils.hpp
+      ../../viam/sdk/common/linear_algebra.hpp
       ../../viam/sdk/components/base/base.hpp
       ../../viam/sdk/components/base/client.hpp
       ../../viam/sdk/components/base/server.hpp

--- a/src/viam/sdk/common/linear_algebra.cpp
+++ b/src/viam/sdk/common/linear_algebra.cpp
@@ -5,6 +5,9 @@
 namespace viam {
 namespace sdk {
 
+Vector3::Vector3(scalar_type x, scalar_type y, scalar_type z) : data_{x, y, z} {};
+Vector3::Vector3() : Vector3(0.0, 0.0, 0.0){};
+
 double Vector3::x() const {
     return this->data_[0];
 }
@@ -36,7 +39,7 @@ const std::array<double, 3>& Vector3::data() const {
     return this->data_;
 }
 
-std::array<double, 3>& Vector3::mutable_data() {
+std::array<double, 3>& Vector3::data() {
     return this->data_;
 }
 

--- a/src/viam/sdk/common/linear_algebra.cpp
+++ b/src/viam/sdk/common/linear_algebra.cpp
@@ -1,0 +1,44 @@
+#include <viam/sdk/common/linear_algebra.hpp>
+
+#include <viam/api/common/v1/common.pb.h>
+
+namespace viam {
+namespace sdk {
+
+double Vector3::x() const {
+    return this->data_[0];
+}
+double Vector3::y() const {
+    return this->data_[1];
+}
+double Vector3::z() const {
+    return this->data_[2];
+}
+void Vector3::set_x(double x) {
+    this->data_[0] = x;
+}
+void Vector3::set_y(double y) {
+    this->data_[1] = y;
+}
+void Vector3::set_z(double z) {
+    this->data_[2] = z;
+}
+std::array<double, 3> Vector3::data() const {
+    return this->data_;
+}
+std::array<double, 3>& Vector3::mutable_data() {
+    return this->data_;
+}
+viam::common::v1::Vector3 Vector3::to_proto(const Vector3& vec) {
+    viam::common::v1::Vector3 result;
+    result.set_x(vec.x());
+    result.set_y(vec.y());
+    result.set_z(vec.z());
+    return result;
+};
+Vector3 Vector3::from_proto(viam::common::v1::Vector3 vec) {
+    return Vector3(vec.x(), vec.y(), vec.z());
+}
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/common/linear_algebra.cpp
+++ b/src/viam/sdk/common/linear_algebra.cpp
@@ -8,27 +8,38 @@ namespace sdk {
 double Vector3::x() const {
     return this->data_[0];
 }
+
 double Vector3::y() const {
     return this->data_[1];
 }
+
 double Vector3::z() const {
     return this->data_[2];
 }
-void Vector3::set_x(double x) {
+
+Vector3& Vector3::set_x(double x) {
     this->data_[0] = x;
+    return *this;
 }
-void Vector3::set_y(double y) {
+
+Vector3& Vector3::set_y(double y) {
     this->data_[1] = y;
+    return *this;
 }
-void Vector3::set_z(double z) {
+
+Vector3& Vector3::set_z(double z) {
     this->data_[2] = z;
+    return *this;
 }
-std::array<double, 3> Vector3::data() const {
+
+const std::array<double, 3>& Vector3::data() const {
     return this->data_;
 }
+
 std::array<double, 3>& Vector3::mutable_data() {
     return this->data_;
 }
+
 viam::common::v1::Vector3 Vector3::to_proto(const Vector3& vec) {
     viam::common::v1::Vector3 result;
     result.set_x(vec.x());
@@ -36,8 +47,9 @@ viam::common::v1::Vector3 Vector3::to_proto(const Vector3& vec) {
     result.set_z(vec.z());
     return result;
 };
+
 Vector3 Vector3::from_proto(viam::common::v1::Vector3 vec) {
-    return Vector3(vec.x(), vec.y(), vec.z());
+    return {vec.x(), vec.y(), vec.z()};
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/common/linear_algebra.hpp
+++ b/src/viam/sdk/common/linear_algebra.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <boost/numeric/ublas/storage.hpp>
+namespace viam {
+namespace sdk {
+
+/* typedef boost::numeric::ublas::bounded_array<double, 3> Vector3; */
+typedef std::array<double, 3> Vector3;
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/common/linear_algebra.hpp
+++ b/src/viam/sdk/common/linear_algebra.hpp
@@ -6,24 +6,33 @@
 namespace viam {
 namespace sdk {
 
+// In the future, we may wish to inline this whole class
+// for performance reasons.
+
 class Vector3 {
    public:
-    Vector3(double x, double y, double z) : data_{x, y, z} {};
+    using scalar_type = double;
+
+    Vector3(scalar_type x, scalar_type y, scalar_type z) : data_{x, y, z} {};
     Vector3() : Vector3(0.0, 0.0, 0.0){};
 
-    double x() const;
-    double y() const;
-    double z() const;
-    void set_x(double x);
-    void set_y(double y);
-    void set_z(double z);
-    std::array<double, 3> data() const;
-    std::array<double, 3>& mutable_data();
+    scalar_type x() const;
+    scalar_type y() const;
+    scalar_type z() const;
+    /// Set the x value of the vector (can be chained)
+    Vector3& set_x(scalar_type x);
+    /// Set the y value of the vector (can be chained)
+    Vector3& set_y(scalar_type y);
+    /// Set the z value of the vector (can be chained)
+    Vector3& set_z(scalar_type z);
+
+    const std::array<scalar_type, 3>& data() const;
+    std::array<scalar_type, 3>& mutable_data();
     static viam::common::v1::Vector3 to_proto(const Vector3& vec);
     static Vector3 from_proto(viam::common::v1::Vector3 vec);
 
    private:
-    std::array<double, 3> data_;
+    std::array<scalar_type, 3> data_;
 };
 
 }  // namespace sdk
@@ -35,23 +44,24 @@ namespace qvm {
 template <>
 struct vec_traits<viam::sdk::Vector3> {
     static int const dim = 3;
-    typedef double scalar_type;
+    using vec_type = ::viam::sdk::Vector3;
+    using scalar_type = vec_type::scalar_type;
 
     template <int I>
-    static inline scalar_type& write_element(viam::sdk::Vector3& v) {
+    static inline scalar_type& write_element(vec_type& v) {
         return v.mutable_data()[I];
     }
 
     template <int I>
-    static inline scalar_type read_element(viam::sdk::Vector3 const& v) {
+    static inline scalar_type read_element(vec_type const& v) {
         return v.data()[I];
     }
 
-    static inline scalar_type& write_element_idx(int i, viam::sdk::Vector3& v) {
+    static inline scalar_type& write_element_idx(int i, vec_type& v) {
         return v.mutable_data()[i];
     }
 
-    static inline scalar_type read_element_idx(int i, viam::sdk::Vector3 const& v) {
+    static inline scalar_type read_element_idx(int i, vec_type const& v) {
         return v.data()[i];
     }
 };

--- a/src/viam/sdk/common/linear_algebra.hpp
+++ b/src/viam/sdk/common/linear_algebra.hpp
@@ -1,10 +1,60 @@
 #pragma once
-#include <boost/numeric/ublas/storage.hpp>
+#include <boost/qvm/vec.hpp>
+#include <boost/qvm/vec_traits.hpp>
+
+#include <viam/api/common/v1/common.pb.h>
 namespace viam {
 namespace sdk {
 
-/* typedef boost::numeric::ublas::bounded_array<double, 3> Vector3; */
-typedef std::array<double, 3> Vector3;
+class Vector3 {
+   public:
+    Vector3(double x, double y, double z) : data_{x, y, z} {};
+    Vector3() : Vector3(0.0, 0.0, 0.0){};
+
+    double x() const;
+    double y() const;
+    double z() const;
+    void set_x(double x);
+    void set_y(double y);
+    void set_z(double z);
+    std::array<double, 3> data() const;
+    std::array<double, 3>& mutable_data();
+    static viam::common::v1::Vector3 to_proto(const Vector3& vec);
+    static Vector3 from_proto(viam::common::v1::Vector3 vec);
+
+   private:
+    std::array<double, 3> data_;
+};
 
 }  // namespace sdk
 }  // namespace viam
+
+namespace boost {
+namespace qvm {
+
+template <>
+struct vec_traits<viam::sdk::Vector3> {
+    static int const dim = 3;
+    typedef double scalar_type;
+
+    template <int I>
+    static inline scalar_type& write_element(viam::sdk::Vector3& v) {
+        return v.mutable_data()[I];
+    }
+
+    template <int I>
+    static inline scalar_type read_element(viam::sdk::Vector3 const& v) {
+        return v.data()[I];
+    }
+
+    static inline scalar_type& write_element_idx(int i, viam::sdk::Vector3& v) {
+        return v.mutable_data()[i];
+    }
+
+    static inline scalar_type read_element_idx(int i, viam::sdk::Vector3 const& v) {
+        return v.data()[i];
+    }
+};
+
+}  // namespace qvm
+}  // namespace boost

--- a/src/viam/sdk/common/linear_algebra.hpp
+++ b/src/viam/sdk/common/linear_algebra.hpp
@@ -12,9 +12,8 @@ namespace sdk {
 class Vector3 {
    public:
     using scalar_type = double;
-
-    Vector3(scalar_type x, scalar_type y, scalar_type z) : data_{x, y, z} {};
-    Vector3() : Vector3(0.0, 0.0, 0.0){};
+    Vector3(scalar_type x, scalar_type y, scalar_type z);
+    Vector3();
 
     scalar_type x() const;
     scalar_type y() const;
@@ -27,7 +26,7 @@ class Vector3 {
     Vector3& set_z(scalar_type z);
 
     const std::array<scalar_type, 3>& data() const;
-    std::array<scalar_type, 3>& mutable_data();
+    std::array<scalar_type, 3>& data();
     static viam::common::v1::Vector3 to_proto(const Vector3& vec);
     static Vector3 from_proto(viam::common::v1::Vector3 vec);
 
@@ -49,7 +48,7 @@ struct vec_traits<viam::sdk::Vector3> {
 
     template <int I>
     static inline scalar_type& write_element(vec_type& v) {
-        return v.mutable_data()[I];
+        return v.data()[I];
     }
 
     template <int I>
@@ -58,7 +57,7 @@ struct vec_traits<viam::sdk::Vector3> {
     }
 
     static inline scalar_type& write_element_idx(int i, vec_type& v) {
-        return v.mutable_data()[i];
+        return v.data()[i];
     }
 
     static inline scalar_type read_element_idx(int i, vec_type const& v) {

--- a/src/viam/sdk/components/base/base.cpp
+++ b/src/viam/sdk/components/base/base.cpp
@@ -14,6 +14,11 @@
 namespace viam {
 namespace sdk {
 
+BaseClient::BaseClient(std::string name, std::shared_ptr<grpc::Channel> channel)
+    : Base(std::move(name)),
+      stub_(viam::component::base::v1::BaseService::NewStub(channel)),
+      channel_(std::move(channel)){};
+
 std::shared_ptr<ResourceServerBase> BaseSubtype::create_resource_server(
     std::shared_ptr<ResourceManager> manager) {
     return std::make_shared<BaseServer>(manager);
@@ -38,13 +43,15 @@ Subtype Base::subtype() {
     return Subtype(RDK, COMPONENT, "base");
 }
 
+Base::Base(std::string name) : ComponentBase(std::move(name)){};
+
 namespace {
 bool init() {
     Registry::register_subtype(Base::subtype(), Base::resource_subtype());
     return true;
 };
 
-bool inited = init();
+const bool inited = init();
 }  // namespace
 
 }  // namespace sdk

--- a/src/viam/sdk/components/base/base.cpp
+++ b/src/viam/sdk/components/base/base.cpp
@@ -1,0 +1,51 @@
+#include <viam/sdk/components/base/base.hpp>
+
+#include <google/protobuf/descriptor.h>
+
+#include <viam/api/component/base/v1/base.grpc.pb.h>
+#include <viam/api/component/base/v1/base.pb.h>
+
+#include <viam/sdk/common/utils.hpp>
+#include <viam/sdk/components/base/client.hpp>
+#include <viam/sdk/components/base/server.hpp>
+#include <viam/sdk/registry/registry.hpp>
+#include <viam/sdk/resource/resource.hpp>
+
+namespace viam {
+namespace sdk {
+
+std::shared_ptr<ResourceServerBase> BaseSubtype::create_resource_server(
+    std::shared_ptr<SubtypeService> svc) {
+    return std::make_shared<BaseServer>(svc);
+};
+
+std::shared_ptr<ResourceBase> BaseSubtype::create_rpc_client(std::string name,
+                                                             std::shared_ptr<grpc::Channel> chan) {
+    return std::make_shared<BaseClient>(std::move(name), std::move(chan));
+};
+
+std::shared_ptr<ResourceSubtype> Base::resource_subtype() {
+    const google::protobuf::DescriptorPool* p = google::protobuf::DescriptorPool::generated_pool();
+    const google::protobuf::ServiceDescriptor* sd =
+        p->FindServiceByName(viam::component::base::v1::BaseService::service_full_name());
+    if (sd == nullptr) {
+        throw std::runtime_error("Unable to get service descriptor for the base service");
+    }
+    return std::make_shared<BaseSubtype>(sd);
+}
+
+Subtype Base::subtype() {
+    return Subtype(RDK, COMPONENT, "base");
+}
+
+namespace {
+bool init() {
+    Registry::register_subtype(Base::subtype(), Base::resource_subtype());
+    return true;
+};
+
+bool inited = init();
+}  // namespace
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/base/base.cpp
+++ b/src/viam/sdk/components/base/base.cpp
@@ -15,8 +15,8 @@ namespace viam {
 namespace sdk {
 
 std::shared_ptr<ResourceServerBase> BaseSubtype::create_resource_server(
-    std::shared_ptr<SubtypeService> svc) {
-    return std::make_shared<BaseServer>(svc);
+    std::shared_ptr<ResourceManager> manager) {
+    return std::make_shared<BaseServer>(manager);
 };
 
 std::shared_ptr<ResourceBase> BaseSubtype::create_rpc_client(std::string name,
@@ -28,7 +28,7 @@ std::shared_ptr<ResourceSubtype> Base::resource_subtype() {
     const google::protobuf::DescriptorPool* p = google::protobuf::DescriptorPool::generated_pool();
     const google::protobuf::ServiceDescriptor* sd =
         p->FindServiceByName(viam::component::base::v1::BaseService::service_full_name());
-    if (sd == nullptr) {
+    if (!sd) {
         throw std::runtime_error("Unable to get service descriptor for the base service");
     }
     return std::make_shared<BaseSubtype>(sd);

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -1,0 +1,85 @@
+/// @file components/base/base.hpp
+///
+/// @brief Defines a `Base` component.
+#pragma once
+
+#include <string>
+
+#include <viam/api/component/base/v1/base.pb.h>
+
+#include <viam/sdk/common/proto_type.hpp>
+#include <viam/sdk/common/utils.hpp>
+#include <viam/sdk/config/resource.hpp>
+#include <viam/sdk/registry/registry.hpp>
+#include <viam/sdk/subtype/subtype.hpp>
+
+namespace viam {
+namespace sdk {
+
+/// @defgroup Base Classes related to the `Base` component.
+
+/// @class BaseSubtype
+/// @brief Defines a `ResourceSubtype` for the `Base` component.
+/// @ingroup Base
+class BaseSubtype : public ResourceSubtype {
+   public:
+    std::shared_ptr<ResourceServerBase> create_resource_server(
+        std::shared_ptr<SubtypeService> svc) override;
+    std::shared_ptr<ResourceBase> create_rpc_client(std::string name,
+                                                    std::shared_ptr<grpc::Channel> chan) override;
+    BaseSubtype(const google::protobuf::ServiceDescriptor* service_descriptor)
+        : ResourceSubtype(service_descriptor){};
+};
+
+/// @class Base base.hpp "components/base/base.hpp"
+/// @brief A `Base` is the platform that the other parts of a mobile robot attach to.
+/// @ingroup Base
+///
+/// This acts as an abstract parent class to be inherited from by any drivers representing
+/// specific base implementations. This class cannot be used on its own.
+class Base : public ComponentBase {
+   public:
+    // functions shared across all components
+    static std::shared_ptr<ResourceSubtype> resource_subtype();
+    static Subtype subtype();
+
+    /// @brief Move a robot's base in a straight line by a given distance. This method blocks
+    /// until completed or cancelled
+    /// @param distance_mm Desired travel distance in millimeters
+    /// @param mm_per_sec Desired travel velocity in millimeters/second
+    virtual void move_straight(int64_t distance_mm, double mm_per_sec) = 0;
+
+    /// @brief Spins a robot's base by an given angle, expressed in degrees. This method blocks
+    /// until completed or cancelled
+    /// @param angle_deg Desired angle
+    /// @param degs_per_sec Desired angular velocity
+    virtual void spin(double angle_deg, double degs_per_sec) = 0;
+
+    /// @brief SetPower sets the linear and angular power of a base -1 -> 1 in terms of power for
+    /// each direction
+    /// @param linear Desired linear power percentage (-1 <= % <= 1) for each direction
+    /// @param angular Desired angular power percentage (-1 <= % <= 1) for each direction
+    virtual void set_power(std::array<double, 3> linear, std::array<double, 3> angular) = 0;
+
+    /// @brief Set the linear and angular velocity of a base
+    /// @param linear Desired linear velocity in mm per second for each direction
+    /// @param angular Desired angular velocity in degrees per second for each direction
+    virtual void set_velocity(std::array<double, 3> linear, std::array<double, 3> angular) = 0;
+
+    /// @brief Stop stops a robot's base
+    virtual grpc::StatusCode stop() override = 0;
+
+    /// @brief IsMoving reports if a component is in motion
+    virtual bool is_moving() = 0;
+
+    /// @brief Send/receive arbitrary commands to the resource.
+    /// @param Command the command to execute.
+    /// @return The result of the executed command.
+    virtual AttributeMap do_command(AttributeMap command) = 0;
+
+   protected:
+    explicit Base(std::string name) : ComponentBase(std::move(name)){};
+};
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -60,12 +60,12 @@ class Base : public ComponentBase {
     /// each direction
     /// @param linear Desired linear power percentage (-1 <= % <= 1) for each direction
     /// @param angular Desired angular power percentage (-1 <= % <= 1) for each direction
-    virtual void set_power(Vector3 linear, Vector3 angular) = 0;
+    virtual void set_power(const Vector3& linear, const Vector3& angular) = 0;
 
     /// @brief Set the linear and angular velocity of a base
     /// @param linear Desired linear velocity in mm per second for each direction
     /// @param angular Desired angular velocity in degrees per second for each direction
-    virtual void set_velocity(Vector3 linear, Vector3 angular) = 0;
+    virtual void set_velocity(const Vector3& linear, const Vector3& angular) = 0;
 
     /// @brief Stops a robot's base
     virtual grpc::StatusCode stop() override = 0;
@@ -79,7 +79,7 @@ class Base : public ComponentBase {
     virtual AttributeMap do_command(AttributeMap command) = 0;
 
    protected:
-    explicit Base(std::string name) : ComponentBase(std::move(name)){};
+    explicit Base(std::string name);
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -7,6 +7,7 @@
 
 #include <viam/api/component/base/v1/base.pb.h>
 
+#include <viam/sdk/common/linear_algebra.hpp>
 #include <viam/sdk/common/proto_type.hpp>
 #include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/config/resource.hpp>
@@ -59,12 +60,12 @@ class Base : public ComponentBase {
     /// each direction
     /// @param linear Desired linear power percentage (-1 <= % <= 1) for each direction
     /// @param angular Desired angular power percentage (-1 <= % <= 1) for each direction
-    virtual void set_power(std::array<double, 3> linear, std::array<double, 3> angular) = 0;
+    virtual void set_power(Vector3 linear, Vector3 angular) = 0;
 
     /// @brief Set the linear and angular velocity of a base
     /// @param linear Desired linear velocity in mm per second for each direction
     /// @param angular Desired angular velocity in degrees per second for each direction
-    virtual void set_velocity(std::array<double, 3> linear, std::array<double, 3> angular) = 0;
+    virtual void set_velocity(Vector3 linear, Vector3 angular) = 0;
 
     /// @brief Stop stops a robot's base
     virtual grpc::StatusCode stop() override = 0;

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -56,7 +56,7 @@ class Base : public ComponentBase {
     /// @param degs_per_sec Desired angular velocity
     virtual void spin(double angle_deg, double degs_per_sec) = 0;
 
-    /// @brief SetPower sets the linear and angular power of a base -1 -> 1 in terms of power for
+    /// @brief Sets the linear and angular power of a base -1 -> 1 in terms of power for
     /// each direction
     /// @param linear Desired linear power percentage (-1 <= % <= 1) for each direction
     /// @param angular Desired angular power percentage (-1 <= % <= 1) for each direction
@@ -67,10 +67,10 @@ class Base : public ComponentBase {
     /// @param angular Desired angular velocity in degrees per second for each direction
     virtual void set_velocity(Vector3 linear, Vector3 angular) = 0;
 
-    /// @brief Stop stops a robot's base
+    /// @brief Stops a robot's base
     virtual grpc::StatusCode stop() override = 0;
 
-    /// @brief IsMoving reports if a component is in motion
+    /// @brief Reports if the base is in motion
     virtual bool is_moving() = 0;
 
     /// @brief Send/receive arbitrary commands to the resource.

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -12,7 +12,7 @@
 #include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/config/resource.hpp>
 #include <viam/sdk/registry/registry.hpp>
-#include <viam/sdk/subtype/subtype.hpp>
+#include <viam/sdk/resource/resource_manager.hpp>
 
 namespace viam {
 namespace sdk {
@@ -25,7 +25,7 @@ namespace sdk {
 class BaseSubtype : public ResourceSubtype {
    public:
     std::shared_ptr<ResourceServerBase> create_resource_server(
-        std::shared_ptr<SubtypeService> svc) override;
+        std::shared_ptr<ResourceManager> manager) override;
     std::shared_ptr<ResourceBase> create_rpc_client(std::string name,
                                                     std::shared_ptr<grpc::Channel> chan) override;
     BaseSubtype(const google::protobuf::ServiceDescriptor* service_descriptor)

--- a/src/viam/sdk/components/base/client.cpp
+++ b/src/viam/sdk/components/base/client.cpp
@@ -9,6 +9,7 @@
 #include <viam/api/common/v1/common.pb.h>
 #include <viam/api/component/base/v1/base.grpc.pb.h>
 
+#include <viam/sdk/common/linear_algebra.hpp>
 #include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/components/base/base.hpp>
 #include <viam/sdk/config/resource.hpp>
@@ -49,7 +50,7 @@ void BaseClient::spin(double angle_deg, double degs_per_sec) {
     }
 }
 
-void BaseClient::set_power(std::array<double, 3> linear, std::array<double, 3> angular) {
+void BaseClient::set_power(Vector3 linear, Vector3 angular) {
     viam::component::base::v1::SetPowerRequest request;
     viam::component::base::v1::SetPowerResponse response;
 

--- a/src/viam/sdk/components/base/client.cpp
+++ b/src/viam/sdk/components/base/client.cpp
@@ -50,7 +50,7 @@ void BaseClient::spin(double angle_deg, double degs_per_sec) {
     }
 }
 
-void BaseClient::set_power(Vector3 linear, Vector3 angular) {
+void BaseClient::set_power(const Vector3& linear, const Vector3& angular) {
     viam::component::base::v1::SetPowerRequest request;
     viam::component::base::v1::SetPowerResponse response;
 
@@ -66,7 +66,7 @@ void BaseClient::set_power(Vector3 linear, Vector3 angular) {
     }
 }
 
-void BaseClient::set_velocity(Vector3 linear, Vector3 angular) {
+void BaseClient::set_velocity(const Vector3& linear, const Vector3& angular) {
     viam::component::base::v1::SetVelocityRequest request;
     viam::component::base::v1::SetVelocityResponse response;
 

--- a/src/viam/sdk/components/base/client.cpp
+++ b/src/viam/sdk/components/base/client.cpp
@@ -90,6 +90,10 @@ void BaseClient::set_velocity(std::array<double, 3> linear, std::array<double, 3
     }
 }
 
+grpc::StatusCode BaseClient::stop(AttributeMap extra) {
+    return this->stop();
+}
+
 grpc::StatusCode BaseClient::stop() {
     viam::component::base::v1::StopRequest request;
     viam::component::base::v1::StopResponse response;

--- a/src/viam/sdk/components/base/client.cpp
+++ b/src/viam/sdk/components/base/client.cpp
@@ -57,12 +57,8 @@ void BaseClient::set_power(Vector3 linear, Vector3 angular) {
     grpc::ClientContext ctx;
 
     *request.mutable_name() = this->name();
-    request.mutable_linear()->set_x(linear.at(0));
-    request.mutable_linear()->set_y(linear.at(1));
-    request.mutable_linear()->set_z(linear.at(2));
-    request.mutable_angular()->set_x(angular.at(0));
-    request.mutable_angular()->set_y(angular.at(1));
-    request.mutable_angular()->set_z(angular.at(2));
+    *request.mutable_linear() = Vector3::to_proto(linear);
+    *request.mutable_angular() = Vector3::to_proto(angular);
 
     grpc::Status status = stub_->SetPower(&ctx, request, &response);
     if (!status.ok()) {
@@ -70,19 +66,15 @@ void BaseClient::set_power(Vector3 linear, Vector3 angular) {
     }
 }
 
-void BaseClient::set_velocity(std::array<double, 3> linear, std::array<double, 3> angular) {
+void BaseClient::set_velocity(Vector3 linear, Vector3 angular) {
     viam::component::base::v1::SetVelocityRequest request;
     viam::component::base::v1::SetVelocityResponse response;
 
     grpc::ClientContext ctx;
 
     *request.mutable_name() = this->name();
-    request.mutable_linear()->set_x(linear.at(0));
-    request.mutable_linear()->set_y(linear.at(1));
-    request.mutable_linear()->set_z(linear.at(2));
-    request.mutable_angular()->set_x(angular.at(0));
-    request.mutable_angular()->set_y(angular.at(1));
-    request.mutable_angular()->set_z(angular.at(2));
+    *request.mutable_linear() = Vector3::to_proto(linear);
+    *request.mutable_angular() = Vector3::to_proto(angular);
 
     grpc::Status status = stub_->SetVelocity(&ctx, request, &response);
     if (!status.ok()) {

--- a/src/viam/sdk/components/base/client.cpp
+++ b/src/viam/sdk/components/base/client.cpp
@@ -1,0 +1,140 @@
+#include <viam/sdk/components/base/client.hpp>
+
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include <viam/api/common/v1/common.pb.h>
+#include <viam/api/component/base/v1/base.grpc.pb.h>
+
+#include <viam/sdk/common/utils.hpp>
+#include <viam/sdk/components/base/base.hpp>
+#include <viam/sdk/config/resource.hpp>
+#include <viam/sdk/robot/client.hpp>
+
+namespace viam {
+namespace sdk {
+
+void BaseClient::move_straight(int64_t distance_mm, double mm_per_sec) {
+    viam::component::base::v1::MoveStraightRequest request;
+    viam::component::base::v1::MoveStraightResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+    request.set_distance_mm(distance_mm);
+    request.set_mm_per_sec(mm_per_sec);
+
+    grpc::Status status = stub_->MoveStraight(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
+}
+
+void BaseClient::spin(double angle_deg, double degs_per_sec) {
+    viam::component::base::v1::SpinRequest request;
+    viam::component::base::v1::SpinResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+    request.set_angle_deg(angle_deg);
+    request.set_degs_per_sec(degs_per_sec);
+
+    grpc::Status status = stub_->Spin(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
+}
+
+void BaseClient::set_power(std::array<double, 3> linear, std::array<double, 3> angular) {
+    viam::component::base::v1::SetPowerRequest request;
+    viam::component::base::v1::SetPowerResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+    request.mutable_linear()->set_x(linear.at(0));
+    request.mutable_linear()->set_y(linear.at(1));
+    request.mutable_linear()->set_z(linear.at(2));
+    request.mutable_angular()->set_x(angular.at(0));
+    request.mutable_angular()->set_y(angular.at(1));
+    request.mutable_angular()->set_z(angular.at(2));
+
+    grpc::Status status = stub_->SetPower(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
+}
+
+void BaseClient::set_velocity(std::array<double, 3> linear, std::array<double, 3> angular) {
+    viam::component::base::v1::SetVelocityRequest request;
+    viam::component::base::v1::SetVelocityResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+    request.mutable_linear()->set_x(linear.at(0));
+    request.mutable_linear()->set_y(linear.at(1));
+    request.mutable_linear()->set_z(linear.at(2));
+    request.mutable_angular()->set_x(angular.at(0));
+    request.mutable_angular()->set_y(angular.at(1));
+    request.mutable_angular()->set_z(angular.at(2));
+
+    grpc::Status status = stub_->SetVelocity(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
+}
+
+grpc::StatusCode BaseClient::stop() {
+    viam::component::base::v1::StopRequest request;
+    viam::component::base::v1::StopResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+
+    grpc::Status status = stub_->Stop(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
+    return status.error_code();
+}
+
+bool BaseClient::is_moving() {
+    viam::component::base::v1::IsMovingRequest request;
+    viam::component::base::v1::IsMovingResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+
+    grpc::Status status = stub_->IsMoving(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
+    return response.is_moving();
+}
+
+AttributeMap BaseClient::do_command(AttributeMap command) {
+    viam::common::v1::DoCommandRequest request;
+    viam::common::v1::DoCommandResponse response;
+
+    grpc::ClientContext ctx;
+
+    google::protobuf::Struct proto_command = map_to_struct(command);
+    *request.mutable_command() = proto_command;
+    *request.mutable_name() = this->name();
+
+    grpc::Status status = stub_->DoCommand(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
+    return struct_to_map(response.result());
+}
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/base/client.hpp
+++ b/src/viam/sdk/components/base/client.hpp
@@ -1,0 +1,41 @@
+/// @file components/base/client.hpp
+///
+/// @brief Implements a gRPC client for the `Base` component.
+#pragma once
+
+#include <grpcpp/channel.h>
+
+#include <viam/api/component/base/v1/base.grpc.pb.h>
+
+#include <viam/sdk/components/base/base.hpp>
+#include <viam/sdk/components/base/server.hpp>
+#include <viam/sdk/config/resource.hpp>
+#include <viam/sdk/robot/client.hpp>
+
+namespace viam {
+namespace sdk {
+
+/// @class BaseClient
+/// @brief gRPC client implementation of a `Base` component.
+/// @ingroup Base
+class BaseClient : public Base {
+   public:
+    void move_straight(int64_t distance_mm, double mm_per_sec) override;
+    void spin(double angle_deg, double degs_per_sec) override;
+    void set_power(std::array<double, 3> linear, std::array<double, 3> angular) override;
+    void set_velocity(std::array<double, 3> linear, std::array<double, 3> angular) override;
+    grpc::StatusCode stop() override;
+    bool is_moving() override;
+    AttributeMap do_command(AttributeMap command) override;
+    BaseClient(std::string name, std::shared_ptr<grpc::Channel> channel)
+        : Base(std::move(name)),
+          stub_(viam::component::base::v1::BaseService::NewStub(channel)),
+          channel_(std::move(channel)){};
+
+   private:
+    std::unique_ptr<viam::component::base::v1::BaseService::StubInterface> stub_;
+    std::shared_ptr<grpc::Channel> channel_;
+};
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/base/client.hpp
+++ b/src/viam/sdk/components/base/client.hpp
@@ -26,6 +26,7 @@ class BaseClient : public Base {
     void set_power(Vector3 linear, Vector3 angular) override;
     void set_velocity(Vector3 linear, Vector3 angular) override;
     grpc::StatusCode stop() override;
+    grpc::StatusCode stop(AttributeMap extra) override;
     bool is_moving() override;
     AttributeMap do_command(AttributeMap command) override;
     BaseClient(std::string name, std::shared_ptr<grpc::Channel> channel)

--- a/src/viam/sdk/components/base/client.hpp
+++ b/src/viam/sdk/components/base/client.hpp
@@ -7,6 +7,7 @@
 
 #include <viam/api/component/base/v1/base.grpc.pb.h>
 
+#include <viam/sdk/common/linear_algebra.hpp>
 #include <viam/sdk/components/base/base.hpp>
 #include <viam/sdk/components/base/server.hpp>
 #include <viam/sdk/config/resource.hpp>
@@ -22,8 +23,8 @@ class BaseClient : public Base {
    public:
     void move_straight(int64_t distance_mm, double mm_per_sec) override;
     void spin(double angle_deg, double degs_per_sec) override;
-    void set_power(std::array<double, 3> linear, std::array<double, 3> angular) override;
-    void set_velocity(std::array<double, 3> linear, std::array<double, 3> angular) override;
+    void set_power(Vector3 linear, Vector3 angular) override;
+    void set_velocity(Vector3 linear, Vector3 angular) override;
     grpc::StatusCode stop() override;
     bool is_moving() override;
     AttributeMap do_command(AttributeMap command) override;

--- a/src/viam/sdk/components/base/client.hpp
+++ b/src/viam/sdk/components/base/client.hpp
@@ -21,18 +21,16 @@ namespace sdk {
 /// @ingroup Base
 class BaseClient : public Base {
    public:
+    BaseClient(std::string name, std::shared_ptr<grpc::Channel> channel);
+
     void move_straight(int64_t distance_mm, double mm_per_sec) override;
     void spin(double angle_deg, double degs_per_sec) override;
-    void set_power(Vector3 linear, Vector3 angular) override;
-    void set_velocity(Vector3 linear, Vector3 angular) override;
+    void set_power(const Vector3& linear, const Vector3& angular) override;
+    void set_velocity(const Vector3& linear, const Vector3& angular) override;
     grpc::StatusCode stop() override;
     grpc::StatusCode stop(AttributeMap extra) override;
     bool is_moving() override;
     AttributeMap do_command(AttributeMap command) override;
-    BaseClient(std::string name, std::shared_ptr<grpc::Channel> channel)
-        : Base(std::move(name)),
-          stub_(viam::component::base::v1::BaseService::NewStub(channel)),
-          channel_(std::move(channel)){};
 
    private:
     std::unique_ptr<viam::component::base::v1::BaseService::StubInterface> stub_;

--- a/src/viam/sdk/components/base/server.cpp
+++ b/src/viam/sdk/components/base/server.cpp
@@ -18,7 +18,7 @@ namespace sdk {
                               "Called [Base::MoveStraight] without a request");
     };
 
-    auto rb = get_sub_svc()->resource(request->name());
+    auto rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -38,7 +38,7 @@ namespace sdk {
                               "Called [Base::Spin] without a request");
     };
 
-    auto rb = get_sub_svc()->resource(request->name());
+    auto rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -58,7 +58,7 @@ namespace sdk {
                               "Called [Base::SetPower] without a request");
     };
 
-    auto rb = get_sub_svc()->resource(request->name());
+    auto rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -82,7 +82,7 @@ namespace sdk {
                               "Called [Base::SetVelocity] without a request");
     };
 
-    auto rb = get_sub_svc()->resource(request->name());
+    auto rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -105,7 +105,7 @@ namespace sdk {
                               "Called [Base::Stop] without a request");
     };
 
-    auto rb = get_sub_svc()->resource(request->name());
+    auto rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -125,7 +125,7 @@ namespace sdk {
                               "Called [Base::IsMoving] without a request");
     };
 
-    auto rb = get_sub_svc()->resource(request->name());
+    auto rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -146,7 +146,7 @@ namespace sdk {
                               "Called [Base::DoCommand] without a request");
     };
 
-    auto rb = get_sub_svc()->resource(request->name());
+    auto rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -160,13 +160,7 @@ namespace sdk {
 }
 
 void BaseServer::register_server(std::shared_ptr<Server> server) {
-    viam::component::base::v1::BaseService::Service* base =
-        static_cast<viam::component::base::v1::BaseService::Service*>(this);
-    server->register_service(base);
-}
-
-std::shared_ptr<SubtypeService> BaseServer::get_sub_svc() {
-    return sub_svc;
+    server->register_service(this);
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/components/base/server.cpp
+++ b/src/viam/sdk/components/base/server.cpp
@@ -13,13 +13,13 @@ namespace sdk {
     ::grpc::ServerContext* context,
     const ::viam::component::base::v1::MoveStraightRequest* request,
     ::viam::component::base::v1::MoveStraightResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Base::MoveStraight] without a request");
     };
 
     std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
-    if (rb == nullptr) {
+    if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
 
@@ -33,13 +33,13 @@ namespace sdk {
 ::grpc::Status BaseServer::Spin(::grpc::ServerContext* context,
                                 const ::viam::component::base::v1::SpinRequest* request,
                                 ::viam::component::base::v1::SpinResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Base::Spin] without a request");
     };
 
     std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
-    if (rb == nullptr) {
+    if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
 
@@ -53,13 +53,13 @@ namespace sdk {
 ::grpc::Status BaseServer::SetPower(::grpc::ServerContext* context,
                                     const ::viam::component::base::v1::SetPowerRequest* request,
                                     ::viam::component::base::v1::SetPowerResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Base::SetPower] without a request");
     };
 
     std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
-    if (rb == nullptr) {
+    if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
 
@@ -76,13 +76,13 @@ namespace sdk {
     ::grpc::ServerContext* context,
     const ::viam::component::base::v1::SetVelocityRequest* request,
     ::viam::component::base::v1::SetVelocityResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Base::SetVelocity] without a request");
     };
 
     std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
-    if (rb == nullptr) {
+    if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
 
@@ -98,13 +98,13 @@ namespace sdk {
 ::grpc::Status BaseServer::Stop(::grpc::ServerContext* context,
                                 const ::viam::component::base::v1::StopRequest* request,
                                 ::viam::component::base::v1::StopResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Base::Stop] without a request");
     };
 
     std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
-    if (rb == nullptr) {
+    if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
 
@@ -118,13 +118,13 @@ namespace sdk {
 ::grpc::Status BaseServer::IsMoving(::grpc::ServerContext* context,
                                     const ::viam::component::base::v1::IsMovingRequest* request,
                                     ::viam::component::base::v1::IsMovingResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Base::IsMoving] without a request");
     };
 
     std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
-    if (rb == nullptr) {
+    if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
 
@@ -139,13 +139,13 @@ namespace sdk {
 ::grpc::Status BaseServer::DoCommand(grpc::ServerContext* context,
                                      const viam::common::v1::DoCommandRequest* request,
                                      viam::common::v1::DoCommandResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Base::DoCommand] without a request");
     };
 
     std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
-    if (rb == nullptr) {
+    if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
 

--- a/src/viam/sdk/components/base/server.cpp
+++ b/src/viam/sdk/components/base/server.cpp
@@ -9,6 +9,9 @@
 namespace viam {
 namespace sdk {
 
+BaseServer::BaseServer() : ResourceServerBase(std::make_shared<ResourceManager>()){};
+BaseServer::BaseServer(std::shared_ptr<ResourceManager> manager) : ResourceServerBase(manager){};
+
 ::grpc::Status BaseServer::MoveStraight(
     ::grpc::ServerContext* context,
     const ::viam::component::base::v1::MoveStraightRequest* request,

--- a/src/viam/sdk/components/base/server.cpp
+++ b/src/viam/sdk/components/base/server.cpp
@@ -18,7 +18,7 @@ namespace sdk {
                               "Called [Base::MoveStraight] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
+    auto rb = get_sub_svc()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -38,7 +38,7 @@ namespace sdk {
                               "Called [Base::Spin] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
+    auto rb = get_sub_svc()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -58,7 +58,7 @@ namespace sdk {
                               "Called [Base::SetPower] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
+    auto rb = get_sub_svc()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -81,7 +81,7 @@ namespace sdk {
                               "Called [Base::SetVelocity] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
+    auto rb = get_sub_svc()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -103,7 +103,7 @@ namespace sdk {
                               "Called [Base::Stop] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
+    auto rb = get_sub_svc()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -123,7 +123,7 @@ namespace sdk {
                               "Called [Base::IsMoving] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
+    auto rb = get_sub_svc()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -144,7 +144,7 @@ namespace sdk {
                               "Called [Base::DoCommand] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
+    auto rb = get_sub_svc()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }

--- a/src/viam/sdk/components/base/server.cpp
+++ b/src/viam/sdk/components/base/server.cpp
@@ -1,5 +1,6 @@
 #include <viam/sdk/components/base/server.hpp>
 
+#include <viam/sdk/common/linear_algebra.hpp>
 #include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/components/base/base.hpp>
 #include <viam/sdk/config/resource.hpp>
@@ -64,10 +65,8 @@ namespace sdk {
 
     std::shared_ptr<Base> base = std::dynamic_pointer_cast<Base>(rb);
 
-    std::array<double, 3> linear = {
-        request->linear().x(), request->linear().y(), request->linear().z()};
-    std::array<double, 3> angular = {
-        request->angular().x(), request->angular().y(), request->angular().z()};
+    Vector3 linear = {request->linear().x(), request->linear().y(), request->linear().z()};
+    Vector3 angular = {request->angular().x(), request->angular().y(), request->angular().z()};
     base->set_power(linear, angular);
 
     return ::grpc::Status();
@@ -89,10 +88,8 @@ namespace sdk {
 
     std::shared_ptr<Base> base = std::dynamic_pointer_cast<Base>(rb);
 
-    std::array<double, 3> linear = {
-        request->linear().x(), request->linear().y(), request->linear().z()};
-    std::array<double, 3> angular = {
-        request->angular().x(), request->angular().y(), request->angular().z()};
+    Vector3 linear = {request->linear().x(), request->linear().y(), request->linear().z()};
+    Vector3 angular = {request->angular().x(), request->angular().y(), request->angular().z()};
     base->set_velocity(linear, angular);
 
     return ::grpc::Status();

--- a/src/viam/sdk/components/base/server.cpp
+++ b/src/viam/sdk/components/base/server.cpp
@@ -65,8 +65,9 @@ namespace sdk {
 
     std::shared_ptr<Base> base = std::dynamic_pointer_cast<Base>(rb);
 
-    Vector3 linear = {request->linear().x(), request->linear().y(), request->linear().z()};
-    Vector3 angular = {request->angular().x(), request->angular().y(), request->angular().z()};
+    auto linear = Vector3::from_proto(request->linear());
+    auto angular = Vector3::from_proto(request->angular());
+
     base->set_power(linear, angular);
 
     return ::grpc::Status();
@@ -88,8 +89,9 @@ namespace sdk {
 
     std::shared_ptr<Base> base = std::dynamic_pointer_cast<Base>(rb);
 
-    Vector3 linear = {request->linear().x(), request->linear().y(), request->linear().z()};
-    Vector3 angular = {request->angular().x(), request->angular().y(), request->angular().z()};
+    auto linear = Vector3::from_proto(request->linear());
+    auto angular = Vector3::from_proto(request->angular());
+
     base->set_velocity(linear, angular);
 
     return ::grpc::Status();

--- a/src/viam/sdk/components/base/server.cpp
+++ b/src/viam/sdk/components/base/server.cpp
@@ -1,0 +1,174 @@
+#include <viam/sdk/components/base/server.hpp>
+
+#include <viam/sdk/common/utils.hpp>
+#include <viam/sdk/components/base/base.hpp>
+#include <viam/sdk/config/resource.hpp>
+#include <viam/sdk/rpc/server.hpp>
+
+namespace viam {
+namespace sdk {
+
+::grpc::Status BaseServer::MoveStraight(
+    ::grpc::ServerContext* context,
+    const ::viam::component::base::v1::MoveStraightRequest* request,
+    ::viam::component::base::v1::MoveStraightResponse* response) {
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Base::MoveStraight] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+
+    std::shared_ptr<Base> base = std::dynamic_pointer_cast<Base>(rb);
+
+    base->move_straight(request->distance_mm(), request->mm_per_sec());
+
+    return ::grpc::Status();
+}
+
+::grpc::Status BaseServer::Spin(::grpc::ServerContext* context,
+                                const ::viam::component::base::v1::SpinRequest* request,
+                                ::viam::component::base::v1::SpinResponse* response) {
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Base::Spin] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+
+    std::shared_ptr<Base> base = std::dynamic_pointer_cast<Base>(rb);
+
+    base->spin(request->angle_deg(), request->degs_per_sec());
+
+    return ::grpc::Status();
+}
+
+::grpc::Status BaseServer::SetPower(::grpc::ServerContext* context,
+                                    const ::viam::component::base::v1::SetPowerRequest* request,
+                                    ::viam::component::base::v1::SetPowerResponse* response) {
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Base::SetPower] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+
+    std::shared_ptr<Base> base = std::dynamic_pointer_cast<Base>(rb);
+
+    std::array<double, 3> linear = {
+        request->linear().x(), request->linear().y(), request->linear().z()};
+    std::array<double, 3> angular = {
+        request->angular().x(), request->angular().y(), request->angular().z()};
+    base->set_power(linear, angular);
+
+    return ::grpc::Status();
+}
+
+::grpc::Status BaseServer::SetVelocity(
+    ::grpc::ServerContext* context,
+    const ::viam::component::base::v1::SetVelocityRequest* request,
+    ::viam::component::base::v1::SetVelocityResponse* response) {
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Base::SetVelocity] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+
+    std::shared_ptr<Base> base = std::dynamic_pointer_cast<Base>(rb);
+
+    std::array<double, 3> linear = {
+        request->linear().x(), request->linear().y(), request->linear().z()};
+    std::array<double, 3> angular = {
+        request->angular().x(), request->angular().y(), request->angular().z()};
+    base->set_velocity(linear, angular);
+
+    return ::grpc::Status();
+}
+
+::grpc::Status BaseServer::Stop(::grpc::ServerContext* context,
+                                const ::viam::component::base::v1::StopRequest* request,
+                                ::viam::component::base::v1::StopResponse* response) {
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Base::Stop] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+
+    std::shared_ptr<Base> base = std::dynamic_pointer_cast<Base>(rb);
+
+    base->stop();
+
+    return ::grpc::Status();
+}
+
+::grpc::Status BaseServer::IsMoving(::grpc::ServerContext* context,
+                                    const ::viam::component::base::v1::IsMovingRequest* request,
+                                    ::viam::component::base::v1::IsMovingResponse* response) {
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Base::IsMoving] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = get_sub_svc()->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+
+    std::shared_ptr<Base> base = std::dynamic_pointer_cast<Base>(rb);
+
+    bool result = base->is_moving();
+    response->set_is_moving(result);
+
+    return ::grpc::Status();
+}
+
+::grpc::Status BaseServer::DoCommand(grpc::ServerContext* context,
+                                     const viam::common::v1::DoCommandRequest* request,
+                                     viam::common::v1::DoCommandResponse* response) {
+    if (request == nullptr) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Base::DoCommand] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc->resource(request->name());
+    if (rb == nullptr) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+
+    std::shared_ptr<Base> motor = std::dynamic_pointer_cast<Base>(rb);
+    AttributeMap result = motor->do_command(struct_to_map(request->command()));
+
+    *response->mutable_result() = map_to_struct(result);
+
+    return ::grpc::Status();
+}
+
+void BaseServer::register_server(std::shared_ptr<Server> server) {
+    viam::component::base::v1::BaseService::Service* base =
+        static_cast<viam::component::base::v1::BaseService::Service*>(this);
+    server->register_service(base);
+}
+
+std::shared_ptr<SubtypeService> BaseServer::get_sub_svc() {
+    return sub_svc;
+}
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/base/server.hpp
+++ b/src/viam/sdk/components/base/server.hpp
@@ -6,8 +6,8 @@
 #include <viam/api/common/v1/common.pb.h>
 #include <viam/api/component/base/v1/base.grpc.pb.h>
 
+#include <viam/sdk/resource/resource_manager.hpp>
 #include <viam/sdk/resource/resource_server_base.hpp>
-#include <viam/sdk/subtype/subtype.hpp>
 
 namespace viam {
 namespace sdk {
@@ -49,13 +49,8 @@ class BaseServer : public ResourceServerBase,
 
     void register_server(std::shared_ptr<Server> server) override;
 
-    std::shared_ptr<SubtypeService> get_sub_svc();
-
-    BaseServer() : sub_svc(std::make_shared<SubtypeService>()){};
-    BaseServer(std::shared_ptr<SubtypeService> sub_svc) : sub_svc(sub_svc){};
-
-   private:
-    std::shared_ptr<SubtypeService> sub_svc;
+    BaseServer() : ResourceServerBase(std::make_shared<ResourceManager>()){};
+    BaseServer(std::shared_ptr<ResourceManager> manager) : ResourceServerBase(manager){};
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/base/server.hpp
+++ b/src/viam/sdk/components/base/server.hpp
@@ -1,0 +1,62 @@
+/// @file components/base/server.hpp
+///
+/// @brief Implements a gRPC server for the `Base` component.
+#pragma once
+
+#include <viam/api/common/v1/common.pb.h>
+#include <viam/api/component/base/v1/base.grpc.pb.h>
+
+#include <viam/sdk/resource/resource_server_base.hpp>
+#include <viam/sdk/subtype/subtype.hpp>
+
+namespace viam {
+namespace sdk {
+
+/// @class BaseServer
+/// @brief gRPC server implementation of a `Base` component.
+/// @ingroup Base
+class BaseServer : public ResourceServerBase,
+                   public viam::component::base::v1::BaseService::Service {
+   public:
+    ::grpc::Status MoveStraight(
+        ::grpc::ServerContext* context,
+        const ::viam::component::base::v1::MoveStraightRequest* request,
+        ::viam::component::base::v1::MoveStraightResponse* response) override;
+
+    ::grpc::Status Spin(::grpc::ServerContext* context,
+                        const ::viam::component::base::v1::SpinRequest* request,
+                        ::viam::component::base::v1::SpinResponse* response) override;
+
+    ::grpc::Status SetPower(::grpc::ServerContext* context,
+                            const ::viam::component::base::v1::SetPowerRequest* request,
+                            ::viam::component::base::v1::SetPowerResponse* response) override;
+
+    ::grpc::Status SetVelocity(::grpc::ServerContext* context,
+                               const ::viam::component::base::v1::SetVelocityRequest* request,
+                               ::viam::component::base::v1::SetVelocityResponse* response) override;
+
+    ::grpc::Status Stop(::grpc::ServerContext* context,
+                        const ::viam::component::base::v1::StopRequest* request,
+                        ::viam::component::base::v1::StopResponse* response) override;
+
+    ::grpc::Status IsMoving(::grpc::ServerContext* context,
+                            const ::viam::component::base::v1::IsMovingRequest* request,
+                            ::viam::component::base::v1::IsMovingResponse* response) override;
+
+    ::grpc::Status DoCommand(grpc::ServerContext* context,
+                             const viam::common::v1::DoCommandRequest* request,
+                             viam::common::v1::DoCommandResponse* response) override;
+
+    void register_server(std::shared_ptr<Server> server) override;
+
+    std::shared_ptr<SubtypeService> get_sub_svc();
+
+    BaseServer() : sub_svc(std::make_shared<SubtypeService>()){};
+    BaseServer(std::shared_ptr<SubtypeService> sub_svc) : sub_svc(sub_svc){};
+
+   private:
+    std::shared_ptr<SubtypeService> sub_svc;
+};
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/base/server.hpp
+++ b/src/viam/sdk/components/base/server.hpp
@@ -18,6 +18,9 @@ namespace sdk {
 class BaseServer : public ResourceServerBase,
                    public viam::component::base::v1::BaseService::Service {
    public:
+    BaseServer();
+    BaseServer(std::shared_ptr<ResourceManager> manager);
+
     ::grpc::Status MoveStraight(
         ::grpc::ServerContext* context,
         const ::viam::component::base::v1::MoveStraightRequest* request,
@@ -48,9 +51,6 @@ class BaseServer : public ResourceServerBase,
                              viam::common::v1::DoCommandResponse* response) override;
 
     void register_server(std::shared_ptr<Server> server) override;
-
-    BaseServer() : ResourceServerBase(std::make_shared<ResourceManager>()){};
-    BaseServer(std::shared_ptr<ResourceManager> manager) : ResourceServerBase(manager){};
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/tests/CMakeLists.txt
+++ b/src/viam/sdk/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 enable_testing()
 include(viamcppsdk_utils)
 viamcppsdk_add_boost_test(test_generic_component.cpp)
+viamcppsdk_add_boost_test(test_base.cpp)
 viamcppsdk_add_boost_test(test_motor.cpp)
 viamcppsdk_add_boost_test(test_camera.cpp)
 viamcppsdk_add_boost_test(test_encoder.cpp)

--- a/src/viam/sdk/tests/mocks/mock_base.cpp
+++ b/src/viam/sdk/tests/mocks/mock_base.cpp
@@ -1,0 +1,57 @@
+#include <viam/sdk/tests/mocks/mock_base.hpp>
+
+#include <viam/api/common/v1/common.pb.h>
+#include <viam/api/component/base/v1/base.grpc.pb.h>
+#include <viam/api/component/base/v1/base.pb.h>
+
+#include <viam/sdk/components/base/base.hpp>
+#include <viam/sdk/components/base/server.hpp>
+#include <viam/sdk/tests/test_utils.hpp>
+
+namespace viam {
+namespace sdktests {
+namespace base {
+
+using namespace viam::sdk;
+
+void MockBase::move_straight(int64_t distance_mm, double mm_per_sec) {
+    this->peek_move_straight_distance_mm = distance_mm;
+    this->peek_move_straight_mm_per_sec = mm_per_sec;
+    return;
+};
+void MockBase::spin(double angle_deg, double degs_per_sec) {
+    this->peek_spin_angle_deg = angle_deg;
+    this->peek_spin_degs_per_sec = degs_per_sec;
+    return;
+};
+void MockBase::set_power(std::array<double, 3> linear, std::array<double, 3> angular) {
+    this->peek_set_power_linear = linear;
+    this->peek_set_power_angular = angular;
+    return;
+};
+void MockBase::set_velocity(std::array<double, 3> linear, std::array<double, 3> angular) {
+    this->peek_set_velocity_linear = linear;
+    this->peek_set_velocity_angular = angular;
+    return;
+};
+grpc::StatusCode MockBase::stop() {
+    this->peek_stop_called = true;
+    return grpc::StatusCode::OK;
+};
+bool MockBase::is_moving() {
+    return false;
+};
+
+std::shared_ptr<MockBase> MockBase::get_mock_base() {
+    auto base = std::make_shared<MockBase>("mock_base");
+
+    return base;
+}
+AttributeMap MockBase::do_command(AttributeMap command) {
+    this->peek_do_command_command = command;
+    return command;
+};
+
+}  // namespace base
+}  // namespace sdktests
+}  // namespace viam

--- a/src/viam/sdk/tests/mocks/mock_base.cpp
+++ b/src/viam/sdk/tests/mocks/mock_base.cpp
@@ -23,11 +23,11 @@ void MockBase::spin(double angle_deg, double degs_per_sec) {
     this->peek_spin_angle_deg = angle_deg;
     this->peek_spin_degs_per_sec = degs_per_sec;
 };
-void MockBase::set_power(Vector3 linear, Vector3 angular) {
+void MockBase::set_power(const Vector3& linear, const Vector3& angular) {
     this->peek_set_power_linear = linear;
     this->peek_set_power_angular = angular;
 };
-void MockBase::set_velocity(Vector3 linear, Vector3 angular) {
+void MockBase::set_velocity(const Vector3& linear, const Vector3& angular) {
     this->peek_set_velocity_linear = linear;
     this->peek_set_velocity_angular = angular;
 };

--- a/src/viam/sdk/tests/mocks/mock_base.cpp
+++ b/src/viam/sdk/tests/mocks/mock_base.cpp
@@ -4,6 +4,7 @@
 #include <viam/api/component/base/v1/base.grpc.pb.h>
 #include <viam/api/component/base/v1/base.pb.h>
 
+#include <viam/sdk/common/linear_algebra.hpp>
 #include <viam/sdk/components/base/base.hpp>
 #include <viam/sdk/components/base/server.hpp>
 #include <viam/sdk/tests/test_utils.hpp>
@@ -17,22 +18,18 @@ using namespace viam::sdk;
 void MockBase::move_straight(int64_t distance_mm, double mm_per_sec) {
     this->peek_move_straight_distance_mm = distance_mm;
     this->peek_move_straight_mm_per_sec = mm_per_sec;
-    return;
 };
 void MockBase::spin(double angle_deg, double degs_per_sec) {
     this->peek_spin_angle_deg = angle_deg;
     this->peek_spin_degs_per_sec = degs_per_sec;
-    return;
 };
-void MockBase::set_power(std::array<double, 3> linear, std::array<double, 3> angular) {
+void MockBase::set_power(Vector3 linear, Vector3 angular) {
     this->peek_set_power_linear = linear;
     this->peek_set_power_angular = angular;
-    return;
 };
-void MockBase::set_velocity(std::array<double, 3> linear, std::array<double, 3> angular) {
+void MockBase::set_velocity(Vector3 linear, Vector3 angular) {
     this->peek_set_velocity_linear = linear;
     this->peek_set_velocity_angular = angular;
-    return;
 };
 grpc::StatusCode MockBase::stop() {
     this->peek_stop_called = true;
@@ -43,9 +40,7 @@ bool MockBase::is_moving() {
 };
 
 std::shared_ptr<MockBase> MockBase::get_mock_base() {
-    auto base = std::make_shared<MockBase>("mock_base");
-
-    return base;
+    return std::make_shared<MockBase>("mock_base");
 }
 AttributeMap MockBase::do_command(AttributeMap command) {
     this->peek_do_command_command = command;

--- a/src/viam/sdk/tests/mocks/mock_base.hpp
+++ b/src/viam/sdk/tests/mocks/mock_base.hpp
@@ -35,9 +35,6 @@ class MockBase : public viam::sdk::Base {
     viam::sdk::AttributeMap peek_do_command_command;
 
     MockBase(std::string name) : Base(std::move(name)){};
-
-   private:
-    std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<viam::sdk::ProtoType>>> map;
 };
 
 }  // namespace base

--- a/src/viam/sdk/tests/mocks/mock_base.hpp
+++ b/src/viam/sdk/tests/mocks/mock_base.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <viam/api/common/v1/common.pb.h>
+#include <viam/api/component/base/v1/base.grpc.pb.h>
+#include <viam/api/component/base/v1/base.pb.h>
+
+#include <viam/sdk/components/base/base.hpp>
+#include <viam/sdk/components/base/client.hpp>
+#include <viam/sdk/components/base/server.hpp>
+
+namespace viam {
+namespace sdktests {
+namespace base {
+
+class MockBase : public viam::sdk::Base {
+   public:
+    void move_straight(int64_t distance_mm, double mm_per_sec) override;
+    void spin(double angle_deg, double degs_per_sec) override;
+    void set_power(std::array<double, 3> linear, std::array<double, 3> angular) override;
+    void set_velocity(std::array<double, 3> linear, std::array<double, 3> angular) override;
+    grpc::StatusCode stop() override;
+    bool is_moving() override;
+    viam::sdk::AttributeMap do_command(viam::sdk::AttributeMap command) override;
+    static std::shared_ptr<MockBase> get_mock_base();
+
+    int64_t peek_move_straight_distance_mm;
+    double peek_move_straight_mm_per_sec;
+    double peek_spin_angle_deg, peek_spin_degs_per_sec;
+    std::array<double, 3> peek_set_power_linear, peek_set_power_angular;
+    std::array<double, 3> peek_set_velocity_linear, peek_set_velocity_angular;
+    bool peek_stop_called;
+    viam::sdk::AttributeMap peek_do_command_command;
+
+    MockBase(std::string name) : Base(std::move(name)){};
+
+   private:
+    std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<viam::sdk::ProtoType>>> map;
+};
+
+}  // namespace base
+}  // namespace sdktests
+}  // namespace viam

--- a/src/viam/sdk/tests/mocks/mock_base.hpp
+++ b/src/viam/sdk/tests/mocks/mock_base.hpp
@@ -4,6 +4,7 @@
 #include <viam/api/component/base/v1/base.grpc.pb.h>
 #include <viam/api/component/base/v1/base.pb.h>
 
+#include <viam/sdk/common/linear_algebra.hpp>
 #include <viam/sdk/components/base/base.hpp>
 #include <viam/sdk/components/base/client.hpp>
 #include <viam/sdk/components/base/server.hpp>
@@ -16,18 +17,20 @@ class MockBase : public viam::sdk::Base {
    public:
     void move_straight(int64_t distance_mm, double mm_per_sec) override;
     void spin(double angle_deg, double degs_per_sec) override;
-    void set_power(std::array<double, 3> linear, std::array<double, 3> angular) override;
-    void set_velocity(std::array<double, 3> linear, std::array<double, 3> angular) override;
+    void set_power(viam::sdk::Vector3 linear, viam::sdk::Vector3 angular) override;
+    void set_velocity(viam::sdk::Vector3 linear, viam::sdk::Vector3 angular) override;
     grpc::StatusCode stop() override;
     bool is_moving() override;
     viam::sdk::AttributeMap do_command(viam::sdk::AttributeMap command) override;
     static std::shared_ptr<MockBase> get_mock_base();
 
+    // This variables allow the testing infra to `peek` into the mock
+    // and ensure that the correct values were passed
     int64_t peek_move_straight_distance_mm;
     double peek_move_straight_mm_per_sec;
     double peek_spin_angle_deg, peek_spin_degs_per_sec;
-    std::array<double, 3> peek_set_power_linear, peek_set_power_angular;
-    std::array<double, 3> peek_set_velocity_linear, peek_set_velocity_angular;
+    viam::sdk::Vector3 peek_set_power_linear, peek_set_power_angular;
+    viam::sdk::Vector3 peek_set_velocity_linear, peek_set_velocity_angular;
     bool peek_stop_called;
     viam::sdk::AttributeMap peek_do_command_command;
 

--- a/src/viam/sdk/tests/mocks/mock_base.hpp
+++ b/src/viam/sdk/tests/mocks/mock_base.hpp
@@ -24,7 +24,7 @@ class MockBase : public viam::sdk::Base {
     viam::sdk::AttributeMap do_command(viam::sdk::AttributeMap command) override;
     static std::shared_ptr<MockBase> get_mock_base();
 
-    // This variables allow the testing infra to `peek` into the mock
+    // These variables allow the testing infra to `peek` into the mock
     // and ensure that the correct values were passed
     int64_t peek_move_straight_distance_mm;
     double peek_move_straight_mm_per_sec;

--- a/src/viam/sdk/tests/mocks/mock_base.hpp
+++ b/src/viam/sdk/tests/mocks/mock_base.hpp
@@ -17,8 +17,8 @@ class MockBase : public viam::sdk::Base {
    public:
     void move_straight(int64_t distance_mm, double mm_per_sec) override;
     void spin(double angle_deg, double degs_per_sec) override;
-    void set_power(viam::sdk::Vector3 linear, viam::sdk::Vector3 angular) override;
-    void set_velocity(viam::sdk::Vector3 linear, viam::sdk::Vector3 angular) override;
+    void set_power(const viam::sdk::Vector3& linear, const viam::sdk::Vector3& angular) override;
+    void set_velocity(const viam::sdk::Vector3& linear, const viam::sdk::Vector3& angular) override;
     grpc::StatusCode stop() override;
     bool is_moving() override;
     viam::sdk::AttributeMap do_command(viam::sdk::AttributeMap command) override;

--- a/src/viam/sdk/tests/test_base.cpp
+++ b/src/viam/sdk/tests/test_base.cpp
@@ -10,6 +10,7 @@
 #include <viam/api/component/base/v1/base.grpc.pb.h>
 #include <viam/api/component/base/v1/base.pb.h>
 
+#include <viam/sdk/common/linear_algebra.hpp>
 #include <viam/sdk/common/proto_type.hpp>
 #include <viam/sdk/components/base/base.hpp>
 #include <viam/sdk/components/base/client.hpp>
@@ -84,8 +85,8 @@ BOOST_AUTO_TEST_CASE(test_spin) {
 
 BOOST_AUTO_TEST_CASE(test_set_power) {
     server_to_mock_pipeline([](Base& client, std::shared_ptr<MockBase> mock) -> void {
-        std::array<double, 3> linear = {0.1, -0.1, 1.0};
-        std::array<double, 3> angular = {0.5, -1.0, 1.0};
+        Vector3 linear = {0.1, -0.1, 1.0};
+        Vector3 angular = {0.5, -1.0, 1.0};
         client.set_power(linear, angular);
         BOOST_CHECK(mock->peek_set_power_linear == linear);
         BOOST_CHECK(mock->peek_set_power_angular == angular);
@@ -94,8 +95,8 @@ BOOST_AUTO_TEST_CASE(test_set_power) {
 
 BOOST_AUTO_TEST_CASE(test_set_velocity) {
     server_to_mock_pipeline([](Base& client, std::shared_ptr<MockBase> mock) -> void {
-        std::array<double, 3> linear = {0.1, -0.1, 1.0};
-        std::array<double, 3> angular = {0.5, -1.0, 1.0};
+        Vector3 linear = {0.1, -0.1, 1.0};
+        Vector3 angular = {0.5, -1.0, 1.0};
         client.set_velocity(linear, angular);
         BOOST_CHECK(mock->peek_set_velocity_linear == linear);
         BOOST_CHECK(mock->peek_set_velocity_angular == angular);

--- a/src/viam/sdk/tests/test_base.cpp
+++ b/src/viam/sdk/tests/test_base.cpp
@@ -55,7 +55,7 @@ template <typename Lambda>
 void server_to_mock_pipeline(Lambda&& func) {
     BaseServer base_server;
     std::shared_ptr<MockBase> mock = MockBase::get_mock_base();
-    base_server.get_sub_svc()->add(std::string("mock_base"), mock);
+    base_server.resource_manager()->add(std::string("mock_base"), mock);
 
     grpc::ServerBuilder builder;
     builder.RegisterService(&base_server);

--- a/src/viam/sdk/tests/test_base.cpp
+++ b/src/viam/sdk/tests/test_base.cpp
@@ -1,0 +1,135 @@
+#define BOOST_TEST_MODULE test module test_base
+#include <typeinfo>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <boost/test/included/unit_test.hpp>
+
+#include <viam/api/common/v1/common.pb.h>
+#include <viam/api/component/base/v1/base.grpc.pb.h>
+#include <viam/api/component/base/v1/base.pb.h>
+
+#include <viam/sdk/common/proto_type.hpp>
+#include <viam/sdk/components/base/base.hpp>
+#include <viam/sdk/components/base/client.hpp>
+#include <viam/sdk/components/base/server.hpp>
+#include <viam/sdk/tests/mocks/mock_base.hpp>
+#include <viam/sdk/tests/test_utils.hpp>
+
+namespace viam {
+namespace sdktests {
+
+using namespace base;
+
+using namespace viam::sdk;
+
+BOOST_AUTO_TEST_SUITE(test_base)
+
+// This sets up the following architecture
+// -- MockComponent
+//        /\
+//
+//        | (function calls)
+//
+//        \/
+// -- ComponentServer (Real)
+//        /\
+//
+//        | (grpc InProcessChannel)
+//
+//        \/
+// -- ComponentClient (Real)
+//
+// This is as close to a real setup as we can get
+// without starting another process
+//
+// The passed in lambda function has access to the ComponentClient
+//
+template <typename Lambda>
+void server_to_mock_pipeline(Lambda&& func) {
+    BaseServer base_server;
+    std::shared_ptr<MockBase> mock = MockBase::get_mock_base();
+    base_server.get_sub_svc()->add(std::string("mock_base"), mock);
+
+    grpc::ServerBuilder builder;
+    builder.RegisterService(&base_server);
+
+    std::unique_ptr<grpc::Server> server = builder.BuildAndStart();
+
+    grpc::ChannelArguments args;
+    auto grpc_channel = server->InProcessChannel(args);
+    BaseClient client("mock_base", grpc_channel);
+    // Run the passed test on the created stack
+    std::forward<Lambda>(func)(client, mock);
+    // shutdown afterwards
+    server->Shutdown();
+}
+
+BOOST_AUTO_TEST_CASE(test_move_straight) {
+    server_to_mock_pipeline([](Base& client, std::shared_ptr<MockBase> mock) -> void {
+        client.move_straight(32, 0.75);
+        BOOST_CHECK(mock->peek_move_straight_distance_mm == 32);
+        BOOST_CHECK(mock->peek_move_straight_mm_per_sec == 0.75);
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_spin) {
+    server_to_mock_pipeline([](Base& client, std::shared_ptr<MockBase> mock) -> void {
+        client.spin(57.1, -21.1);
+        BOOST_CHECK(mock->peek_spin_angle_deg == 57.1);
+        BOOST_CHECK(mock->peek_spin_degs_per_sec == -21.1);
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_set_power) {
+    server_to_mock_pipeline([](Base& client, std::shared_ptr<MockBase> mock) -> void {
+        std::array<double, 3> linear = {0.1, -0.1, 1.0};
+        std::array<double, 3> angular = {0.5, -1.0, 1.0};
+        client.set_power(linear, angular);
+        BOOST_CHECK(mock->peek_set_power_linear == linear);
+        BOOST_CHECK(mock->peek_set_power_angular == angular);
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_set_velocity) {
+    server_to_mock_pipeline([](Base& client, std::shared_ptr<MockBase> mock) -> void {
+        std::array<double, 3> linear = {0.1, -0.1, 1.0};
+        std::array<double, 3> angular = {0.5, -1.0, 1.0};
+        client.set_velocity(linear, angular);
+        BOOST_CHECK(mock->peek_set_velocity_linear == linear);
+        BOOST_CHECK(mock->peek_set_velocity_angular == angular);
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_stop) {
+    server_to_mock_pipeline([](Base& client, std::shared_ptr<MockBase> mock) -> void {
+        mock->peek_stop_called = false;
+        client.stop();
+        BOOST_CHECK(mock->peek_stop_called);
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_is_moving) {
+    server_to_mock_pipeline([](Base& client, std::shared_ptr<MockBase> mock) -> void {
+        BOOST_CHECK(!client.is_moving());
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_do_command) {
+    server_to_mock_pipeline([](Base& client, std::shared_ptr<MockBase> mock) -> void {
+        AttributeMap expected = fake_map();
+
+        AttributeMap command = fake_map();
+        AttributeMap result_map = client.do_command(command);
+
+        ProtoType expected_pt = *(expected->at(std::string("test")));
+        ProtoType result_pt = *(result_map->at(std::string("test")));
+        BOOST_CHECK(result_pt == expected_pt);
+    });
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace sdktests
+}  // namespace viam

--- a/src/viam/sdk/tests/test_base.cpp
+++ b/src/viam/sdk/tests/test_base.cpp
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include <boost/qvm/all.hpp>
 #include <boost/test/included/unit_test.hpp>
 
 #include <viam/api/common/v1/common.pb.h>
@@ -24,6 +25,9 @@ namespace sdktests {
 using namespace base;
 
 using namespace viam::sdk;
+
+using boost::qvm::operator-;
+using boost::qvm::mag;
 
 BOOST_AUTO_TEST_SUITE(test_base)
 
@@ -70,16 +74,16 @@ void server_to_mock_pipeline(Lambda&& func) {
 BOOST_AUTO_TEST_CASE(test_move_straight) {
     server_to_mock_pipeline([](Base& client, std::shared_ptr<MockBase> mock) -> void {
         client.move_straight(32, 0.75);
-        BOOST_CHECK(mock->peek_move_straight_distance_mm == 32);
-        BOOST_CHECK(mock->peek_move_straight_mm_per_sec == 0.75);
+        BOOST_CHECK_EQUAL(mock->peek_move_straight_distance_mm, 32);
+        BOOST_CHECK_EQUAL(mock->peek_move_straight_mm_per_sec, 0.75);
     });
 }
 
 BOOST_AUTO_TEST_CASE(test_spin) {
     server_to_mock_pipeline([](Base& client, std::shared_ptr<MockBase> mock) -> void {
         client.spin(57.1, -21.1);
-        BOOST_CHECK(mock->peek_spin_angle_deg == 57.1);
-        BOOST_CHECK(mock->peek_spin_degs_per_sec == -21.1);
+        BOOST_CHECK_EQUAL(mock->peek_spin_angle_deg, 57.1);
+        BOOST_CHECK_EQUAL(mock->peek_spin_degs_per_sec, -21.1);
     });
 }
 
@@ -88,8 +92,9 @@ BOOST_AUTO_TEST_CASE(test_set_power) {
         Vector3 linear = {0.1, -0.1, 1.0};
         Vector3 angular = {0.5, -1.0, 1.0};
         client.set_power(linear, angular);
-        BOOST_CHECK(mock->peek_set_power_linear == linear);
-        BOOST_CHECK(mock->peek_set_power_angular == angular);
+
+        BOOST_CHECK_SMALL(mag(mock->peek_set_power_linear - linear), 0.01);
+        BOOST_CHECK_SMALL(mag(mock->peek_set_power_angular - angular), 0.01);
     });
 }
 
@@ -98,8 +103,9 @@ BOOST_AUTO_TEST_CASE(test_set_velocity) {
         Vector3 linear = {0.1, -0.1, 1.0};
         Vector3 angular = {0.5, -1.0, 1.0};
         client.set_velocity(linear, angular);
-        BOOST_CHECK(mock->peek_set_velocity_linear == linear);
-        BOOST_CHECK(mock->peek_set_velocity_angular == angular);
+
+        BOOST_CHECK_SMALL(mag(mock->peek_set_velocity_linear - linear), 0.01);
+        BOOST_CHECK_SMALL(mag(mock->peek_set_velocity_angular - angular), 0.01);
     });
 }
 


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-797

Important decisions: 
1) For now I replaced common.v1.Vector3 with `typedef std::array<double, 3> Vector3` in `common/linear_algebra.hpp`. I am dubious about this for two reasons:
    - If we expose an Vector3, it should be a useful one. I am leaning towards the `boost::numeric::ublas` types
    - If we are following the proto file hierarchy, this should be defined in `common/common.hpp` however, that file doesn't exist, and we have instead chosen to create files like `common/utils.hpp` and `common/proto_type.hpp`
2) For testing, I have done a peeking-based testing architecture rather than the current behavior-based mocks. That was done because `base` has no good getter methods to test functionality. 
3) This does not have an example because I don't think there is any interesting behavior that is not already captured by the existing examples. Happy to add one if others think it would be useful.

EDIT: I have decided to move forward with the `boost::qvm::vec` trait applied to our custom simple Vector3 class.

Pre-merge:
Bring in refactoring changes. Right now there is so much changing that it would be a waste of time to try and keep up before it is stable