### PR TITLE
RSDK-2484 Add encoder wrapper

### DIFF
--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -93,6 +93,10 @@ if (VIAMCPPSDK_USE_DYNAMIC_PROTOS)
     ${PROTO_GEN_DIR}/component/camera/v1/camera.grpc.pb.h
     ${PROTO_GEN_DIR}/component/camera/v1/camera.pb.cc
     ${PROTO_GEN_DIR}/component/camera/v1/camera.pb.h
+    ${PROTO_GEN_DIR}/component/encoder/v1/encoder.grpc.pb.cc
+    ${PROTO_GEN_DIR}/component/encoder/v1/encoder.grpc.pb.h
+    ${PROTO_GEN_DIR}/component/encoder/v1/encoder.pb.cc
+    ${PROTO_GEN_DIR}/component/encoder/v1/encoder.pb.h
     ${PROTO_GEN_DIR}/component/generic/v1/generic.grpc.pb.cc
     ${PROTO_GEN_DIR}/component/generic/v1/generic.grpc.pb.h
     ${PROTO_GEN_DIR}/component/generic/v1/generic.pb.cc
@@ -170,6 +174,8 @@ target_sources(viamapi
     ${PROTO_GEN_DIR}/common/v1/common.pb.cc
     ${PROTO_GEN_DIR}/component/camera/v1/camera.grpc.pb.cc
     ${PROTO_GEN_DIR}/component/camera/v1/camera.pb.cc
+    ${PROTO_GEN_DIR}/component/encoder/v1/encoder.grpc.pb.cc
+    ${PROTO_GEN_DIR}/component/encoder/v1/encoder.pb.cc
     ${PROTO_GEN_DIR}/component/generic/v1/generic.grpc.pb.cc
     ${PROTO_GEN_DIR}/component/generic/v1/generic.pb.cc
     ${PROTO_GEN_DIR}/component/motor/v1/motor.grpc.pb.cc
@@ -195,6 +201,8 @@ target_sources(viamapi
       ${PROTO_GEN_DIR}/../../viam/api/common/v1/common.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/camera/v1/camera.grpc.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/camera/v1/camera.pb.h
+      ${PROTO_GEN_DIR}/../../viam/api/component/encoder/v1/encoder.grpc.pb.h
+      ${PROTO_GEN_DIR}/../../viam/api/component/encoder/v1/encoder.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/generic/v1/generic.grpc.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/generic/v1/generic.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/motor/v1/motor.grpc.pb.h

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -44,8 +44,8 @@ target_sources(viamsdk
     components/camera/camera.cpp
     components/camera/client.cpp
     components/camera/server.cpp
-    components/encoder/encoder.cpp
     components/encoder/client.cpp
+    components/encoder/encoder.cpp
     components/encoder/server.cpp
     components/component_base.cpp
     components/generic/client.cpp
@@ -86,8 +86,8 @@ target_sources(viamsdk
       ../../viam/sdk/components/camera/camera.hpp
       ../../viam/sdk/components/camera/client.hpp
       ../../viam/sdk/components/camera/server.hpp
-      ../../viam/sdk/components/encoder/encoder.hpp
       ../../viam/sdk/components/encoder/client.hpp
+      ../../viam/sdk/components/encoder/encoder.hpp
       ../../viam/sdk/components/encoder/server.hpp
       ../../viam/sdk/components/component_base.hpp
       ../../viam/sdk/components/generic/client.hpp

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -44,6 +44,9 @@ target_sources(viamsdk
     components/camera/camera.cpp
     components/camera/client.cpp
     components/camera/server.cpp
+    components/encoder/encoder.cpp
+    components/encoder/client.cpp
+    components/encoder/server.cpp
     components/component_base.cpp
     components/generic/client.cpp
     components/generic/generic.cpp
@@ -72,6 +75,7 @@ target_sources(viamsdk
     tests/test_utils.cpp
     tests/mocks/camera_mocks.cpp
     tests/mocks/generic_mocks.cpp
+    tests/mocks/mock_encoder.cpp
     tests/mocks/mock_motor.cpp
   PUBLIC FILE_SET viamsdk_public_includes TYPE HEADERS
     BASE_DIRS
@@ -82,6 +86,9 @@ target_sources(viamsdk
       ../../viam/sdk/components/camera/camera.hpp
       ../../viam/sdk/components/camera/client.hpp
       ../../viam/sdk/components/camera/server.hpp
+      ../../viam/sdk/components/encoder/encoder.hpp
+      ../../viam/sdk/components/encoder/client.hpp
+      ../../viam/sdk/components/encoder/server.hpp
       ../../viam/sdk/components/component_base.hpp
       ../../viam/sdk/components/generic/client.hpp
       ../../viam/sdk/components/generic/generic.hpp
@@ -111,6 +118,7 @@ target_sources(viamsdk
       ../../viam/sdk/tests/test_utils.hpp
       ../../viam/sdk/tests/mocks/camera_mocks.hpp
       ../../viam/sdk/tests/mocks/generic_mocks.hpp
+      ../../viam/sdk/tests/mocks/mock_encoder.hpp
       ../../viam/sdk/tests/mocks/mock_motor.hpp
 )
 

--- a/src/viam/sdk/components/encoder/client.cpp
+++ b/src/viam/sdk/components/encoder/client.cpp
@@ -17,6 +17,11 @@
 namespace viam {
 namespace sdk {
 
+EncoderClient::EncoderClient(std::string name, std::shared_ptr<grpc::Channel> channel)
+    : Encoder(std::move(name)),
+      stub_(viam::component::encoder::v1::EncoderService::NewStub(channel)),
+      channel_(std::move(channel)){};
+
 Encoder::position EncoderClient::get_position(position_type position_type) {
     viam::component::encoder::v1::GetPositionRequest request;
     viam::component::encoder::v1::GetPositionResponse response;

--- a/src/viam/sdk/components/encoder/client.cpp
+++ b/src/viam/sdk/components/encoder/client.cpp
@@ -17,7 +17,6 @@
 namespace viam {
 namespace sdk {
 
-
 Encoder::position EncoderClient::get_position(position_type position_type) {
     viam::component::encoder::v1::GetPositionRequest request;
     viam::component::encoder::v1::GetPositionResponse response;
@@ -25,14 +24,13 @@ Encoder::position EncoderClient::get_position(position_type position_type) {
     grpc::ClientContext ctx;
 
     *request.mutable_name() = this->name();
-    request.set_position_type(position_type);
+    request.set_position_type(to_proto(position_type));
 
     grpc::Status status = stub_->GetPosition(&ctx, request, &response);
     if (!status.ok()) {
         throw std::runtime_error(status.error_message());
     }
     return from_proto(response);
-    
 }
 
 void EncoderClient::reset_position() {
@@ -62,26 +60,24 @@ Encoder::properties EncoderClient::get_properties() {
         throw std::runtime_error(status.error_message());
     }
     return from_proto(response);
-    
 }
 
-AttributeMap EncoderClient::do_command(ERROR TODO) {
-    viam::component::encoder::v1::common.v1.DoCommandRequest request;
-    viam::component::encoder::v1::common.v1.DoCommandResponse response;
+AttributeMap EncoderClient::do_command(AttributeMap command) {
+    viam::common::v1::DoCommandRequest request;
+    viam::common::v1::DoCommandResponse response;
 
     grpc::ClientContext ctx;
 
+    google::protobuf::Struct proto_command = map_to_struct(command);
+    *request.mutable_command() = proto_command;
     *request.mutable_name() = this->name();
-    request.set_TODO(TODO);
 
     grpc::Status status = stub_->DoCommand(&ctx, request, &response);
     if (!status.ok()) {
         throw std::runtime_error(status.error_message());
     }
-    return from_proto(response);
-    
+    return struct_to_map(response.result());
 }
-
 
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/encoder/client.cpp
+++ b/src/viam/sdk/components/encoder/client.cpp
@@ -1,0 +1,87 @@
+#include <viam/sdk/components/encoder/client.hpp>
+
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include <viam/api/common/v1/common.pb.h>
+#include <viam/api/component/encoder/v1/encoder.grpc.pb.h>
+
+#include <viam/sdk/common/utils.hpp>
+#include <viam/sdk/components/encoder/encoder.hpp>
+#include <viam/sdk/config/resource.hpp>
+#include <viam/sdk/robot/client.hpp>
+
+namespace viam {
+namespace sdk {
+
+
+Encoder::position EncoderClient::get_position(position_type position_type) {
+    viam::component::encoder::v1::GetPositionRequest request;
+    viam::component::encoder::v1::GetPositionResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+    request.set_position_type(position_type);
+
+    grpc::Status status = stub_->GetPosition(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
+    return from_proto(response);
+    
+}
+
+void EncoderClient::reset_position() {
+    viam::component::encoder::v1::ResetPositionRequest request;
+    viam::component::encoder::v1::ResetPositionResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+
+    grpc::Status status = stub_->ResetPosition(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
+}
+
+Encoder::properties EncoderClient::get_properties() {
+    viam::component::encoder::v1::GetPropertiesRequest request;
+    viam::component::encoder::v1::GetPropertiesResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+
+    grpc::Status status = stub_->GetProperties(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
+    return from_proto(response);
+    
+}
+
+AttributeMap EncoderClient::do_command(ERROR TODO) {
+    viam::component::encoder::v1::common.v1.DoCommandRequest request;
+    viam::component::encoder::v1::common.v1.DoCommandResponse response;
+
+    grpc::ClientContext ctx;
+
+    *request.mutable_name() = this->name();
+    request.set_TODO(TODO);
+
+    grpc::Status status = stub_->DoCommand(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
+    return from_proto(response);
+    
+}
+
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/encoder/client.hpp
+++ b/src/viam/sdk/components/encoder/client.hpp
@@ -1,0 +1,38 @@
+/// @file components/encoder/client.hpp
+///
+/// @brief Implements a gRPC client for the `Encoder` component.
+#pragma once
+
+#include <grpcpp/channel.h>
+
+#include <viam/api/component/encoder/v1/encoder.grpc.pb.h>
+
+#include <viam/sdk/components/encoder/encoder.hpp>
+#include <viam/sdk/components/encoder/server.hpp>
+#include <viam/sdk/config/resource.hpp>
+#include <viam/sdk/robot/client.hpp>
+
+namespace viam {
+namespace sdk {
+
+/// @class EncoderClient
+/// @brief gRPC client implementation of a `Encoder` component.
+/// @ingroup Encoder
+class EncoderClient : public Encoder {
+   public:
+   position get_position(position_type position_type) override;
+   void reset_position() override;
+   properties get_properties() override;
+   AttributeMap do_command(ERROR TODO) override;
+    EncoderClient(std::string name, std::shared_ptr<grpc::Channel> channel)
+        : Encoder(std::move(name)),
+          stub_(viam::component::encoder::v1::EncoderService::NewStub(channel)),
+          channel_(std::move(channel)){};
+
+   private:
+    std::unique_ptr<viam::component::encoder::v1::EncoderService::StubInterface> stub_;
+    std::shared_ptr<grpc::Channel> channel_;
+};
+
+}  // namespace sdk 
+}  // namespace viam

--- a/src/viam/sdk/components/encoder/client.hpp
+++ b/src/viam/sdk/components/encoder/client.hpp
@@ -20,14 +20,12 @@ namespace sdk {
 /// @ingroup Encoder
 class EncoderClient : public Encoder {
    public:
+    EncoderClient(std::string name, std::shared_ptr<grpc::Channel> channel);
+
     position get_position(position_type position_type) override;
     void reset_position() override;
     properties get_properties() override;
     AttributeMap do_command(AttributeMap command) override;
-    EncoderClient(std::string name, std::shared_ptr<grpc::Channel> channel)
-        : Encoder(std::move(name)),
-          stub_(viam::component::encoder::v1::EncoderService::NewStub(channel)),
-          channel_(std::move(channel)){};
 
    private:
     std::unique_ptr<viam::component::encoder::v1::EncoderService::StubInterface> stub_;

--- a/src/viam/sdk/components/encoder/client.hpp
+++ b/src/viam/sdk/components/encoder/client.hpp
@@ -20,10 +20,10 @@ namespace sdk {
 /// @ingroup Encoder
 class EncoderClient : public Encoder {
    public:
-   position get_position(position_type position_type) override;
-   void reset_position() override;
-   properties get_properties() override;
-   AttributeMap do_command(ERROR TODO) override;
+    position get_position(position_type position_type) override;
+    void reset_position() override;
+    properties get_properties() override;
+    AttributeMap do_command(AttributeMap command) override;
     EncoderClient(std::string name, std::shared_ptr<grpc::Channel> channel)
         : Encoder(std::move(name)),
           stub_(viam::component::encoder::v1::EncoderService::NewStub(channel)),
@@ -34,5 +34,5 @@ class EncoderClient : public Encoder {
     std::shared_ptr<grpc::Channel> channel_;
 };
 
-}  // namespace sdk 
+}  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/encoder/encoder.cpp
+++ b/src/viam/sdk/components/encoder/encoder.cpp
@@ -38,58 +38,46 @@ Subtype Encoder::subtype() {
     return Subtype(RDK, COMPONENT, "encoder");
 }
 
-
-Encoder::position Encoder::from_proto(viam::component::encoder::v1::GetPositionResponse proto){
+Encoder::position Encoder::from_proto(viam::component::encoder::v1::GetPositionResponse proto) {
     Encoder::position position;
     position.value = proto.value();
-    
-    position.position_type = proto.position_type();
+
+    position.type = proto.position_type();
     return position;
 }
 
-Encoder::properties Encoder::from_proto(viam::component::encoder::v1::GetPropertiesResponse proto){
+Encoder::properties Encoder::from_proto(viam::component::encoder::v1::GetPropertiesResponse proto) {
     Encoder::properties properties;
     properties.ticks_count_supported = proto.ticks_count_supported();
-    
+
     properties.angle_degrees_supported = proto.angle_degrees_supported();
     return properties;
 }
 
-
-
-
-viam::component::encoder::v1::GetPositionResponse Encoder::to_proto( position position) {
+viam::component::encoder::v1::GetPositionResponse Encoder::to_proto(position position) {
     viam::component::encoder::v1::GetPositionResponse proto;
     proto.set_value(position.value);
-    
+
     proto.set_position_type(position.position_type);
     return proto;
 }
 
-
-viam::component::encoder::v1::GetPropertiesResponse Encoder::to_proto( properties properties) {
+viam::component::encoder::v1::GetPropertiesResponse Encoder::to_proto(properties properties) {
     viam::component::encoder::v1::GetPropertiesResponse proto;
     proto.set_ticks_count_supported(properties.ticks_count_supported);
-    
+
     proto.set_angle_degrees_supported(properties.angle_degrees_supported);
     return proto;
 }
 
-
-
 bool operator==(const Encoder::position& lhs, const Encoder::position& rhs) {
-    return (
-        lhs.value == rhs.value && 
-        lhs.position_type == rhs.position_type);
+    return (lhs.value == rhs.value && lhs.position_type == rhs.position_type);
 }
 
 bool operator==(const Encoder::properties& lhs, const Encoder::properties& rhs) {
-    return (
-        lhs.ticks_count_supported == rhs.ticks_count_supported && 
-        lhs.angle_degrees_supported == rhs.angle_degrees_supported);
+    return (lhs.ticks_count_supported == rhs.ticks_count_supported &&
+            lhs.angle_degrees_supported == rhs.angle_degrees_supported);
 }
-
-
 
 namespace {
 bool init() {

--- a/src/viam/sdk/components/encoder/encoder.cpp
+++ b/src/viam/sdk/components/encoder/encoder.cpp
@@ -1,0 +1,104 @@
+#include <viam/sdk/components/encoder/encoder.hpp>
+
+#include <google/protobuf/descriptor.h>
+
+#include <viam/api/component/encoder/v1/encoder.grpc.pb.h>
+#include <viam/api/component/encoder/v1/encoder.pb.h>
+
+#include <viam/sdk/common/utils.hpp>
+#include <viam/sdk/components/encoder/client.hpp>
+#include <viam/sdk/components/encoder/server.hpp>
+#include <viam/sdk/registry/registry.hpp>
+#include <viam/sdk/resource/resource.hpp>
+
+namespace viam {
+namespace sdk {
+
+std::shared_ptr<ResourceServerBase> EncoderSubtype::create_resource_server(
+    std::shared_ptr<SubtypeService> svc) {
+    return std::make_shared<EncoderServer>(svc);
+};
+
+std::shared_ptr<ResourceBase> EncoderSubtype::create_rpc_client(
+    std::string name, std::shared_ptr<grpc::Channel> chan) {
+    return std::make_shared<EncoderClient>(std::move(name), std::move(chan));
+};
+
+std::shared_ptr<ResourceSubtype> Encoder::resource_subtype() {
+    const google::protobuf::DescriptorPool* p = google::protobuf::DescriptorPool::generated_pool();
+    const google::protobuf::ServiceDescriptor* sd =
+        p->FindServiceByName(viam::component::encoder::v1::EncoderService::service_full_name());
+    if (sd == nullptr) {
+        throw std::runtime_error("Unable to get service descriptor for the encoder service");
+    }
+    return std::make_shared<EncoderSubtype>(sd);
+}
+
+Subtype Encoder::subtype() {
+    return Subtype(RDK, COMPONENT, "encoder");
+}
+
+
+Encoder::position Encoder::from_proto(viam::component::encoder::v1::GetPositionResponse proto){
+    Encoder::position position;
+    position.value = proto.value();
+    
+    position.position_type = proto.position_type();
+    return position;
+}
+
+Encoder::properties Encoder::from_proto(viam::component::encoder::v1::GetPropertiesResponse proto){
+    Encoder::properties properties;
+    properties.ticks_count_supported = proto.ticks_count_supported();
+    
+    properties.angle_degrees_supported = proto.angle_degrees_supported();
+    return properties;
+}
+
+
+
+
+viam::component::encoder::v1::GetPositionResponse Encoder::to_proto( position position) {
+    viam::component::encoder::v1::GetPositionResponse proto;
+    proto.set_value(position.value);
+    
+    proto.set_position_type(position.position_type);
+    return proto;
+}
+
+
+viam::component::encoder::v1::GetPropertiesResponse Encoder::to_proto( properties properties) {
+    viam::component::encoder::v1::GetPropertiesResponse proto;
+    proto.set_ticks_count_supported(properties.ticks_count_supported);
+    
+    proto.set_angle_degrees_supported(properties.angle_degrees_supported);
+    return proto;
+}
+
+
+
+bool operator==(const Encoder::position& lhs, const Encoder::position& rhs) {
+    return (
+        lhs.value == rhs.value && 
+        lhs.position_type == rhs.position_type);
+}
+
+bool operator==(const Encoder::properties& lhs, const Encoder::properties& rhs) {
+    return (
+        lhs.ticks_count_supported == rhs.ticks_count_supported && 
+        lhs.angle_degrees_supported == rhs.angle_degrees_supported);
+}
+
+
+
+namespace {
+bool init() {
+    Registry::register_subtype(Encoder::subtype(), Encoder::resource_subtype());
+    return true;
+};
+
+bool inited = init();
+}  // namespace
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/encoder/encoder.cpp
+++ b/src/viam/sdk/components/encoder/encoder.cpp
@@ -41,13 +41,13 @@ Subtype Encoder::subtype() {
 Encoder::position_type Encoder::from_proto(viam::component::encoder::v1::PositionType proto) {
     switch (proto) {
         case viam::component::encoder::v1::POSITION_TYPE_UNSPECIFIED: {
-            return Encoder::position_type::UNSPECIFIED;
+            return Encoder::position_type::unspecified;
         }
         case viam::component::encoder::v1::POSITION_TYPE_ANGLE_DEGREES: {
-            return Encoder::position_type::ANGLE_DEGREES;
+            return Encoder::position_type::angle_degrees;
         }
         case viam::component::encoder::v1::POSITION_TYPE_TICKS_COUNT: {
-            return Encoder::position_type::TICKS_COUNT;
+            return Encoder::position_type::ticks_count;
         }
         default: {
             throw std::runtime_error("Invalid proto encoder type to decode");
@@ -73,12 +73,13 @@ Encoder::properties Encoder::from_proto(viam::component::encoder::v1::GetPropert
 
 viam::component::encoder::v1::PositionType Encoder::to_proto(position_type position_type) {
     switch (position_type) {
-        case Encoder::position_type::UNSPECIFIED: {
+        case Encoder::position_type::unspecified: {
+            return viam::component::encoder::v1::PositionType::POSITION_TYPE_UNSPECIFIED;
         }
-        case Encoder::position_type::ANGLE_DEGREES: {
+        case Encoder::position_type::angle_degrees: {
             return viam::component::encoder::v1::POSITION_TYPE_ANGLE_DEGREES;
         }
-        case Encoder::position_type::TICKS_COUNT: {
+        case Encoder::position_type::ticks_count: {
             return viam::component::encoder::v1::POSITION_TYPE_TICKS_COUNT;
         }
         default: {
@@ -103,6 +104,8 @@ viam::component::encoder::v1::GetPropertiesResponse Encoder::to_proto(properties
     return proto;
 }
 
+Encoder::Encoder(std::string name) : ComponentBase(std::move(name)){};
+
 bool operator==(const Encoder::position& lhs, const Encoder::position& rhs) {
     return (lhs.value == rhs.value && lhs.type == rhs.type);
 }
@@ -118,7 +121,7 @@ bool init() {
     return true;
 };
 
-bool inited = init();
+const bool inited = init();
 }  // namespace
 
 }  // namespace sdk

--- a/src/viam/sdk/components/encoder/encoder.cpp
+++ b/src/viam/sdk/components/encoder/encoder.cpp
@@ -38,11 +38,28 @@ Subtype Encoder::subtype() {
     return Subtype(RDK, COMPONENT, "encoder");
 }
 
+Encoder::position_type Encoder::from_proto(viam::component::encoder::v1::PositionType proto) {
+    switch (proto) {
+        case viam::component::encoder::v1::POSITION_TYPE_UNSPECIFIED: {
+            return Encoder::position_type::UNSPECIFIED;
+        }
+        case viam::component::encoder::v1::POSITION_TYPE_ANGLE_DEGREES: {
+            return Encoder::position_type::ANGLE_DEGREES;
+        }
+        case viam::component::encoder::v1::POSITION_TYPE_TICKS_COUNT: {
+            return Encoder::position_type::TICKS_COUNT;
+        }
+        default: {
+            throw std::runtime_error("Invalid proto encoder type to decode");
+        }
+    }
+}
+
 Encoder::position Encoder::from_proto(viam::component::encoder::v1::GetPositionResponse proto) {
     Encoder::position position;
     position.value = proto.value();
 
-    position.type = proto.position_type();
+    position.type = from_proto(proto.position_type());
     return position;
 }
 
@@ -54,11 +71,27 @@ Encoder::properties Encoder::from_proto(viam::component::encoder::v1::GetPropert
     return properties;
 }
 
+viam::component::encoder::v1::PositionType Encoder::to_proto(position_type position_type) {
+    switch (position_type) {
+        case Encoder::position_type::UNSPECIFIED: {
+        }
+        case Encoder::position_type::ANGLE_DEGREES: {
+            return viam::component::encoder::v1::POSITION_TYPE_ANGLE_DEGREES;
+        }
+        case Encoder::position_type::TICKS_COUNT: {
+            return viam::component::encoder::v1::POSITION_TYPE_TICKS_COUNT;
+        }
+        default: {
+            throw std::runtime_error("Invalid proto encoder type to encode");
+        }
+    }
+}
+
 viam::component::encoder::v1::GetPositionResponse Encoder::to_proto(position position) {
     viam::component::encoder::v1::GetPositionResponse proto;
     proto.set_value(position.value);
 
-    proto.set_position_type(position.position_type);
+    proto.set_position_type(to_proto(position.type));
     return proto;
 }
 
@@ -71,7 +104,7 @@ viam::component::encoder::v1::GetPropertiesResponse Encoder::to_proto(properties
 }
 
 bool operator==(const Encoder::position& lhs, const Encoder::position& rhs) {
-    return (lhs.value == rhs.value && lhs.position_type == rhs.position_type);
+    return (lhs.value == rhs.value && lhs.type == rhs.type);
 }
 
 bool operator==(const Encoder::properties& lhs, const Encoder::properties& rhs) {

--- a/src/viam/sdk/components/encoder/encoder.cpp
+++ b/src/viam/sdk/components/encoder/encoder.cpp
@@ -15,8 +15,8 @@ namespace viam {
 namespace sdk {
 
 std::shared_ptr<ResourceServerBase> EncoderSubtype::create_resource_server(
-    std::shared_ptr<SubtypeService> svc) {
-    return std::make_shared<EncoderServer>(svc);
+    std::shared_ptr<ResourceManager> manager) {
+    return std::make_shared<EncoderServer>(manager);
 };
 
 std::shared_ptr<ResourceBase> EncoderSubtype::create_rpc_client(
@@ -28,7 +28,7 @@ std::shared_ptr<ResourceSubtype> Encoder::resource_subtype() {
     const google::protobuf::DescriptorPool* p = google::protobuf::DescriptorPool::generated_pool();
     const google::protobuf::ServiceDescriptor* sd =
         p->FindServiceByName(viam::component::encoder::v1::EncoderService::service_full_name());
-    if (sd == nullptr) {
+    if (!sd) {
         throw std::runtime_error("Unable to get service descriptor for the encoder service");
     }
     return std::make_shared<EncoderSubtype>(sd);

--- a/src/viam/sdk/components/encoder/encoder.hpp
+++ b/src/viam/sdk/components/encoder/encoder.hpp
@@ -40,13 +40,13 @@ class EncoderSubtype : public ResourceSubtype {
 class Encoder : public ComponentBase {
    public:
     /// @enum position_type
-    enum position_type {
+    enum class position_type : uint8_t {
         // Unspecified position type
-        UNSPECIFIED,
+        unspecified = 0,
         // Provided by incremental encoders
-        TICKS_COUNT,
+        ticks_count = 1,
         // Provided by absolute encoders
-        ANGLE_DEGREES
+        angle_degrees = 2
     };
 
     /// @struct position
@@ -67,7 +67,7 @@ class Encoder : public ComponentBase {
     static std::shared_ptr<ResourceSubtype> resource_subtype();
     static Subtype subtype();
 
-    /// @brief Creates a `properties` struct from its proto representation.
+    /// @brief Creates a `position_type` struct from its proto representation.
     static position_type from_proto(viam::component::encoder::v1::PositionType proto);
 
     /// @brief Creates a `position` struct from its proto representation.
@@ -76,7 +76,7 @@ class Encoder : public ComponentBase {
     /// @brief Creates a `properties` struct from its proto representation.
     static properties from_proto(viam::component::encoder::v1::GetPropertiesResponse proto);
 
-    /// @brief Converts a `position` struct to its proto representation.
+    /// @brief Converts a `position_type` struct to its proto representation.
     static viam::component::encoder::v1::PositionType to_proto(position_type position_type);
 
     /// @brief Converts a `position` struct to its proto representation.
@@ -87,10 +87,10 @@ class Encoder : public ComponentBase {
 
     /// @brief Returns position of the encoder which can either be ticks since last zeroing for an
     /// incremental encoder or degrees for an absolute encoder.
-    /// @param position_type If supplied, the response will return the specified position type. If
-    /// the driver does not implement the requested type, this call will return an error. If
-    /// position type is UNSPECIFIED, the response will return a default according to the driver.
-    virtual position get_position(position_type position_type) = 0;
+    /// @param position_type The type of position you are requesting. If  the driver does not
+    /// implement the requested type, this call will return an error. If position type is
+    /// `unspecified`, the response will return a default according to the driver.
+    virtual position get_position(position_type position_type = position_type::unspecified) = 0;
 
     /// @brief Reset the value of the position
     virtual void reset_position() = 0;
@@ -104,7 +104,7 @@ class Encoder : public ComponentBase {
     virtual AttributeMap do_command(AttributeMap command) = 0;
 
    protected:
-    explicit Encoder(std::string name) : ComponentBase(std::move(name)){};
+    explicit Encoder(std::string name);
 };
 
 bool operator==(const Encoder::position& lhs, const Encoder::position& rhs);

--- a/src/viam/sdk/components/encoder/encoder.hpp
+++ b/src/viam/sdk/components/encoder/encoder.hpp
@@ -22,13 +22,13 @@ namespace sdk {
 /// @brief Defines a `ResourceSubtype` for the `Encoder` component.
 /// @ingroup Encoder
 class EncoderSubtype : public ResourceSubtype {
-public:
-  std::shared_ptr<ResourceServerBase> create_resource_server(
-      std::shared_ptr<SubtypeService> svc) override;
-  std::shared_ptr<ResourceBase> create_rpc_client(
-      std::string name, std::shared_ptr<grpc::Channel> chan) override;
-  EncoderSubtype(const google::protobuf::ServiceDescriptor *service_descriptor)
-      : ResourceSubtype(service_descriptor){};
+   public:
+    std::shared_ptr<ResourceServerBase> create_resource_server(
+        std::shared_ptr<SubtypeService> svc) override;
+    std::shared_ptr<ResourceBase> create_rpc_client(std::string name,
+                                                    std::shared_ptr<grpc::Channel> chan) override;
+    EncoderSubtype(const google::protobuf::ServiceDescriptor* service_descriptor)
+        : ResourceSubtype(service_descriptor){};
 };
 
 /// @class Encoder encoder.hpp "components/encoder/encoder.hpp"
@@ -38,76 +38,65 @@ public:
 /// This acts as an abstract base class to be inherited from by any drivers representing
 /// specific encoder implementations. This class cannot be used on its own.
 class Encoder : public ComponentBase {
-public:
-  
-  /// @struct position
-  /// @brief TODO.
-  struct position {
+   public:
+    /// @enum position_type
+    /// @brief TODO.
+    enum position_type { UNSPECIFIED, TICKS_COUNT, ANGLE_DEGREES };
+
+    /// @struct position
+    /// @brief TODO.
+    struct position {
         /// TODO
         float value;
         /// TODO
-        position_type position_type;
-  };
-  
-  /// @struct properties
-  /// @brief TODO.
-  struct properties {
+        position_type type;
+    };
+
+    /// @struct properties
+    /// @brief TODO.
+    struct properties {
         /// TODO
         bool ticks_count_supported;
         /// TODO
         bool angle_degrees_supported;
-  };
-  
-  
-  /// @enum position_type
-  /// @brief TODO.
-  enum position_type {
-        POSITION_TYPE_UNSPECIFIED, 
-        POSITION_TYPE_TICKS_COUNT, 
-        POSITION_TYPE_ANGLE_DEGREES
-  };
-  
+    };
 
-  // functions shared across all components
-  static std::shared_ptr<ResourceSubtype> resource_subtype();
-  static Subtype subtype();
+    // functions shared across all components
+    static std::shared_ptr<ResourceSubtype> resource_subtype();
+    static Subtype subtype();
 
-  
-  /// @brief Creates a `position` struct from its proto representation.
-  static position from_proto(viam::component::encoder::v1::GetPositionResponse proto);
-    
-  /// @brief Creates a `properties` struct from its proto representation.
-  static properties from_proto(viam::component::encoder::v1::GetPropertiesResponse proto);
-    
+    /// @brief Creates a `position` struct from its proto representation.
+    static position from_proto(viam::component::encoder::v1::GetPositionResponse proto);
 
-  
-  /// @brief Converts a `position` struct to its proto representation.
-  static viam::component::encoder::v1::GetPositionResponse to_proto(position position);
-  
-  /// @brief Converts a `properties` struct to its proto representation.
-  static viam::component::encoder::v1::GetPropertiesResponse to_proto(properties properties);
-  
+    /// @brief Creates a `properties` struct from its proto representation.
+    static properties from_proto(viam::component::encoder::v1::GetPropertiesResponse proto);
 
-  
-  /// @brief Returns position of the encoder which can either be ticks since last zeroing for an incremental encoder or degrees for an absolute encoder.
-  /// @param position_type If supplied, the response will return the specified position type. If the driver does not implement the requested type, this call will return an error. If position type is not specified, the response will return a default according to the driver.
-  virtual position get_position(position_type position_type) = 0;
-  
-  /// @brief TODO
-  virtual void reset_position() = 0;
-  
-  /// @brief Returns a list of all the methods that are supported by a given robot.
-  virtual properties get_properties() = 0;
-  
-  /// @brief TODO
-  /// @param TODO TODO
-  virtual AttributeMap do_command(ERROR TODO) = 0;
-  
+    /// @brief Converts a `position` struct to its proto representation.
+    static viam::component::encoder::v1::GetPositionResponse to_proto(position position);
 
-protected:
-  explicit Encoder(std::string name) : ComponentBase(std::move(name)){};
+    /// @brief Converts a `properties` struct to its proto representation.
+    static viam::component::encoder::v1::GetPropertiesResponse to_proto(properties properties);
+
+    /// @brief Returns position of the encoder which can either be ticks since last zeroing for an
+    /// incremental encoder or degrees for an absolute encoder.
+    /// @param position_type If supplied, the response will return the specified position type. If
+    /// the driver does not implement the requested type, this call will return an error. If
+    /// position type is UNSPECIFIED, the response will return a default according to the driver.
+    virtual position get_position(position_type position_type) = 0;
+
+    /// @brief TODO
+    virtual void reset_position() = 0;
+
+    /// @brief Returns a list of all the position_types that are supported by the encoder.
+    virtual properties get_properties() = 0;
+
+    /// @brief TODO
+    /// @param TODO TODO
+    virtual AttributeMap do_command(AttributeMap command) = 0;
+
+   protected:
+    explicit Encoder(std::string name) : ComponentBase(std::move(name)){};
 };
-
 
 bool operator==(const Encoder::position& lhs, const Encoder::position& rhs);
 bool operator==(const Encoder::properties& lhs, const Encoder::properties& rhs);

--- a/src/viam/sdk/components/encoder/encoder.hpp
+++ b/src/viam/sdk/components/encoder/encoder.hpp
@@ -11,7 +11,7 @@
 #include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/config/resource.hpp>
 #include <viam/sdk/registry/registry.hpp>
-#include <viam/sdk/subtype/subtype.hpp>
+#include <viam/sdk/resource/resource_manager.hpp>
 
 namespace viam {
 namespace sdk {
@@ -24,7 +24,7 @@ namespace sdk {
 class EncoderSubtype : public ResourceSubtype {
    public:
     std::shared_ptr<ResourceServerBase> create_resource_server(
-        std::shared_ptr<SubtypeService> svc) override;
+        std::shared_ptr<ResourceManager> manager) override;
     std::shared_ptr<ResourceBase> create_rpc_client(std::string name,
                                                     std::shared_ptr<grpc::Channel> chan) override;
     EncoderSubtype(const google::protobuf::ServiceDescriptor* service_descriptor)

--- a/src/viam/sdk/components/encoder/encoder.hpp
+++ b/src/viam/sdk/components/encoder/encoder.hpp
@@ -32,7 +32,7 @@ class EncoderSubtype : public ResourceSubtype {
 };
 
 /// @class Encoder encoder.hpp "components/encoder/encoder.hpp"
-/// @brief TODO
+/// @brief An encoder is a device that is hooked up to motors to report a position
 /// @ingroup Encoder
 ///
 /// This acts as an abstract base class to be inherited from by any drivers representing
@@ -40,24 +40,26 @@ class EncoderSubtype : public ResourceSubtype {
 class Encoder : public ComponentBase {
    public:
     /// @enum position_type
-    /// @brief TODO.
-    enum position_type { UNSPECIFIED, TICKS_COUNT, ANGLE_DEGREES };
+    enum position_type {
+        // Unspecified position type
+        UNSPECIFIED,
+        // Provided by incremental encoders
+        TICKS_COUNT,
+        // Provided by absolute encoders
+        ANGLE_DEGREES
+    };
 
     /// @struct position
-    /// @brief TODO.
+    /// @brief reported position.
     struct position {
-        /// TODO
         float value;
-        /// TODO
         position_type type;
     };
 
     /// @struct properties
-    /// @brief TODO.
+    /// @brief Encodes the supported modes of this encoder
     struct properties {
-        /// TODO
         bool ticks_count_supported;
-        /// TODO
         bool angle_degrees_supported;
     };
 
@@ -65,11 +67,17 @@ class Encoder : public ComponentBase {
     static std::shared_ptr<ResourceSubtype> resource_subtype();
     static Subtype subtype();
 
+    /// @brief Creates a `properties` struct from its proto representation.
+    static position_type from_proto(viam::component::encoder::v1::PositionType proto);
+
     /// @brief Creates a `position` struct from its proto representation.
     static position from_proto(viam::component::encoder::v1::GetPositionResponse proto);
 
     /// @brief Creates a `properties` struct from its proto representation.
     static properties from_proto(viam::component::encoder::v1::GetPropertiesResponse proto);
+
+    /// @brief Converts a `position` struct to its proto representation.
+    static viam::component::encoder::v1::PositionType to_proto(position_type position_type);
 
     /// @brief Converts a `position` struct to its proto representation.
     static viam::component::encoder::v1::GetPositionResponse to_proto(position position);
@@ -84,14 +92,15 @@ class Encoder : public ComponentBase {
     /// position type is UNSPECIFIED, the response will return a default according to the driver.
     virtual position get_position(position_type position_type) = 0;
 
-    /// @brief TODO
+    /// @brief Reset the value of the position
     virtual void reset_position() = 0;
 
     /// @brief Returns a list of all the position_types that are supported by the encoder.
     virtual properties get_properties() = 0;
 
-    /// @brief TODO
-    /// @param TODO TODO
+    /// @brief Send/receive arbitrary commands to the resource.
+    /// @param Command the command to execute.
+    /// @return The result of the executed command.
     virtual AttributeMap do_command(AttributeMap command) = 0;
 
    protected:

--- a/src/viam/sdk/components/encoder/encoder.hpp
+++ b/src/viam/sdk/components/encoder/encoder.hpp
@@ -1,0 +1,116 @@
+/// @file components/encoder/encoder.hpp
+///
+/// @brief Defines a `Encoder` component.
+#pragma once
+
+#include <string>
+
+#include <viam/api/component/encoder/v1/encoder.pb.h>
+
+#include <viam/sdk/common/proto_type.hpp>
+#include <viam/sdk/common/utils.hpp>
+#include <viam/sdk/config/resource.hpp>
+#include <viam/sdk/registry/registry.hpp>
+#include <viam/sdk/subtype/subtype.hpp>
+
+namespace viam {
+namespace sdk {
+
+/// @defgroup Encoder Classes related to the `Encoder` component.
+
+/// @class EncoderSubtype
+/// @brief Defines a `ResourceSubtype` for the `Encoder` component.
+/// @ingroup Encoder
+class EncoderSubtype : public ResourceSubtype {
+public:
+  std::shared_ptr<ResourceServerBase> create_resource_server(
+      std::shared_ptr<SubtypeService> svc) override;
+  std::shared_ptr<ResourceBase> create_rpc_client(
+      std::string name, std::shared_ptr<grpc::Channel> chan) override;
+  EncoderSubtype(const google::protobuf::ServiceDescriptor *service_descriptor)
+      : ResourceSubtype(service_descriptor){};
+};
+
+/// @class Encoder encoder.hpp "components/encoder/encoder.hpp"
+/// @brief TODO
+/// @ingroup Encoder
+///
+/// This acts as an abstract base class to be inherited from by any drivers representing
+/// specific encoder implementations. This class cannot be used on its own.
+class Encoder : public ComponentBase {
+public:
+  
+  /// @struct position
+  /// @brief TODO.
+  struct position {
+        /// TODO
+        float value;
+        /// TODO
+        position_type position_type;
+  };
+  
+  /// @struct properties
+  /// @brief TODO.
+  struct properties {
+        /// TODO
+        bool ticks_count_supported;
+        /// TODO
+        bool angle_degrees_supported;
+  };
+  
+  
+  /// @enum position_type
+  /// @brief TODO.
+  enum position_type {
+        POSITION_TYPE_UNSPECIFIED, 
+        POSITION_TYPE_TICKS_COUNT, 
+        POSITION_TYPE_ANGLE_DEGREES
+  };
+  
+
+  // functions shared across all components
+  static std::shared_ptr<ResourceSubtype> resource_subtype();
+  static Subtype subtype();
+
+  
+  /// @brief Creates a `position` struct from its proto representation.
+  static position from_proto(viam::component::encoder::v1::GetPositionResponse proto);
+    
+  /// @brief Creates a `properties` struct from its proto representation.
+  static properties from_proto(viam::component::encoder::v1::GetPropertiesResponse proto);
+    
+
+  
+  /// @brief Converts a `position` struct to its proto representation.
+  static viam::component::encoder::v1::GetPositionResponse to_proto(position position);
+  
+  /// @brief Converts a `properties` struct to its proto representation.
+  static viam::component::encoder::v1::GetPropertiesResponse to_proto(properties properties);
+  
+
+  
+  /// @brief Returns position of the encoder which can either be ticks since last zeroing for an incremental encoder or degrees for an absolute encoder.
+  /// @param position_type If supplied, the response will return the specified position type. If the driver does not implement the requested type, this call will return an error. If position type is not specified, the response will return a default according to the driver.
+  virtual position get_position(position_type position_type) = 0;
+  
+  /// @brief TODO
+  virtual void reset_position() = 0;
+  
+  /// @brief Returns a list of all the methods that are supported by a given robot.
+  virtual properties get_properties() = 0;
+  
+  /// @brief TODO
+  /// @param TODO TODO
+  virtual AttributeMap do_command(ERROR TODO) = 0;
+  
+
+protected:
+  explicit Encoder(std::string name) : ComponentBase(std::move(name)){};
+};
+
+
+bool operator==(const Encoder::position& lhs, const Encoder::position& rhs);
+bool operator==(const Encoder::properties& lhs, const Encoder::properties& rhs);
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/encoder/server.cpp
+++ b/src/viam/sdk/components/encoder/server.cpp
@@ -8,6 +8,10 @@
 namespace viam {
 namespace sdk {
 
+EncoderServer::EncoderServer() : ResourceServerBase(std::make_shared<ResourceManager>()){};
+EncoderServer::EncoderServer(std::shared_ptr<ResourceManager> manager)
+    : ResourceServerBase(manager){};
+
 ::grpc::Status EncoderServer::GetPosition(
     ::grpc::ServerContext* context,
     const ::viam::component::encoder::v1::GetPositionRequest* request,

--- a/src/viam/sdk/components/encoder/server.cpp
+++ b/src/viam/sdk/components/encoder/server.cpp
@@ -8,67 +8,66 @@
 namespace viam {
 namespace sdk {
 
-
-::grpc::Status EncoderServer::GetPosition(::grpc::ServerContext* context,
-                        const ::viam::component::encoder::v1::GetPositionRequest* request,
-                        ::viam::component::encoder::v1::GetPositionResponse* response) {
-    
+::grpc::Status EncoderServer::GetPosition(
+    ::grpc::ServerContext* context,
+    const ::viam::component::encoder::v1::GetPositionRequest* request,
+    ::viam::component::encoder::v1::GetPositionResponse* response) {
     if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Encoder::GetPosition] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = sub_svc()->resource(request->name());
+    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
-    
+
     std::shared_ptr<Encoder> encoder = std::dynamic_pointer_cast<Encoder>(rb);
-    
-    Encoder::position result = encoder->get_position(request->position_type());
+
+    Encoder::position result = encoder->get_position(Encoder::from_proto(request->position_type()));
     response->set_value(result.value);
-    response->set_position_type(result.position_type);
+    response->set_position_type(Encoder::to_proto(result.type));
 
     return ::grpc::Status();
 }
 
-::grpc::Status EncoderServer::ResetPosition(::grpc::ServerContext* context,
-                        const ::viam::component::encoder::v1::ResetPositionRequest* request,
-                        ::viam::component::encoder::v1::ResetPositionResponse* response) {
-    
+::grpc::Status EncoderServer::ResetPosition(
+    ::grpc::ServerContext* context,
+    const ::viam::component::encoder::v1::ResetPositionRequest* request,
+    ::viam::component::encoder::v1::ResetPositionResponse* response) {
     if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Encoder::ResetPosition] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = sub_svc()->resource(request->name());
+    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
-    
+
     std::shared_ptr<Encoder> encoder = std::dynamic_pointer_cast<Encoder>(rb);
-    
+
     encoder->reset_position();
 
     return ::grpc::Status();
 }
 
-::grpc::Status EncoderServer::GetProperties(::grpc::ServerContext* context,
-                        const ::viam::component::encoder::v1::GetPropertiesRequest* request,
-                        ::viam::component::encoder::v1::GetPropertiesResponse* response) {
-    
+::grpc::Status EncoderServer::GetProperties(
+    ::grpc::ServerContext* context,
+    const ::viam::component::encoder::v1::GetPropertiesRequest* request,
+    ::viam::component::encoder::v1::GetPropertiesResponse* response) {
     if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Encoder::GetProperties] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = sub_svc()->resource(request->name());
+    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
-    
+
     std::shared_ptr<Encoder> encoder = std::dynamic_pointer_cast<Encoder>(rb);
-    
+
     Encoder::properties result = encoder->get_properties();
     response->set_ticks_count_supported(result.ticks_count_supported);
     response->set_angle_degrees_supported(result.angle_degrees_supported);
@@ -76,27 +75,26 @@ namespace sdk {
     return ::grpc::Status();
 }
 
-::grpc::Status EncoderServer::DoCommand(::grpc::ServerContext* context,
-                        const ::viam::component::encoder::v1::common.v1.DoCommandRequest* request,
-                        ::viam::component::encoder::v1::common.v1.DoCommandResponse* response) {
-    
-    if (!request) {
+::grpc::Status EncoderServer::DoCommand(grpc::ServerContext* context,
+                                        const viam::common::v1::DoCommandRequest* request,
+                                        viam::common::v1::DoCommandResponse* response) {
+    if (request == nullptr) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Encoder::DoCommand] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = sub_svc()->resource(request->name());
-    if (!rb) {
+    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    if (rb == nullptr) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
-    
+
     std::shared_ptr<Encoder> encoder = std::dynamic_pointer_cast<Encoder>(rb);
-    
-    AttributeMap result = encoder->do_command(request->TODO());
+    AttributeMap result = encoder->do_command(struct_to_map(request->command()));
+
+    *response->mutable_result() = map_to_struct(result);
 
     return ::grpc::Status();
 }
-
 
 void EncoderServer::register_server(std::shared_ptr<Server> server) {
     viam::component::encoder::v1::EncoderService::Service* encoder =
@@ -104,7 +102,7 @@ void EncoderServer::register_server(std::shared_ptr<Server> server) {
     server->register_service(encoder);
 }
 
-std::shared_ptr<SubtypeService> EncoderServer::sub_svc() {
+std::shared_ptr<SubtypeService> EncoderServer::resource_manager() {
     return sub_svc;
 }
 

--- a/src/viam/sdk/components/encoder/server.cpp
+++ b/src/viam/sdk/components/encoder/server.cpp
@@ -78,13 +78,13 @@ namespace sdk {
 ::grpc::Status EncoderServer::DoCommand(grpc::ServerContext* context,
                                         const viam::common::v1::DoCommandRequest* request,
                                         viam::common::v1::DoCommandResponse* response) {
-    if (request == nullptr) {
+    if (!request) {
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Called [Encoder::DoCommand] without a request");
     };
 
     std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
-    if (rb == nullptr) {
+    if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
 
@@ -97,13 +97,7 @@ namespace sdk {
 }
 
 void EncoderServer::register_server(std::shared_ptr<Server> server) {
-    viam::component::encoder::v1::EncoderService::Service* encoder =
-        static_cast<viam::component::encoder::v1::EncoderService::Service*>(this);
-    server->register_service(encoder);
-}
-
-std::shared_ptr<SubtypeService> EncoderServer::resource_manager() {
-    return sub_svc;
+    server->register_service(this);
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/components/encoder/server.cpp
+++ b/src/viam/sdk/components/encoder/server.cpp
@@ -1,0 +1,112 @@
+#include <viam/sdk/components/encoder/server.hpp>
+
+#include <viam/sdk/common/utils.hpp>
+#include <viam/sdk/components/encoder/encoder.hpp>
+#include <viam/sdk/config/resource.hpp>
+#include <viam/sdk/rpc/server.hpp>
+
+namespace viam {
+namespace sdk {
+
+
+::grpc::Status EncoderServer::GetPosition(::grpc::ServerContext* context,
+                        const ::viam::component::encoder::v1::GetPositionRequest* request,
+                        ::viam::component::encoder::v1::GetPositionResponse* response) {
+    
+    if (!request) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Encoder::GetPosition] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc()->resource(request->name());
+    if (!rb) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+    
+    std::shared_ptr<Encoder> encoder = std::dynamic_pointer_cast<Encoder>(rb);
+    
+    Encoder::position result = encoder->get_position(request->position_type());
+    response->set_value(result.value);
+    response->set_position_type(result.position_type);
+
+    return ::grpc::Status();
+}
+
+::grpc::Status EncoderServer::ResetPosition(::grpc::ServerContext* context,
+                        const ::viam::component::encoder::v1::ResetPositionRequest* request,
+                        ::viam::component::encoder::v1::ResetPositionResponse* response) {
+    
+    if (!request) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Encoder::ResetPosition] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc()->resource(request->name());
+    if (!rb) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+    
+    std::shared_ptr<Encoder> encoder = std::dynamic_pointer_cast<Encoder>(rb);
+    
+    encoder->reset_position();
+
+    return ::grpc::Status();
+}
+
+::grpc::Status EncoderServer::GetProperties(::grpc::ServerContext* context,
+                        const ::viam::component::encoder::v1::GetPropertiesRequest* request,
+                        ::viam::component::encoder::v1::GetPropertiesResponse* response) {
+    
+    if (!request) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Encoder::GetProperties] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc()->resource(request->name());
+    if (!rb) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+    
+    std::shared_ptr<Encoder> encoder = std::dynamic_pointer_cast<Encoder>(rb);
+    
+    Encoder::properties result = encoder->get_properties();
+    response->set_ticks_count_supported(result.ticks_count_supported);
+    response->set_angle_degrees_supported(result.angle_degrees_supported);
+
+    return ::grpc::Status();
+}
+
+::grpc::Status EncoderServer::DoCommand(::grpc::ServerContext* context,
+                        const ::viam::component::encoder::v1::common.v1.DoCommandRequest* request,
+                        ::viam::component::encoder::v1::common.v1.DoCommandResponse* response) {
+    
+    if (!request) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                              "Called [Encoder::DoCommand] without a request");
+    };
+
+    std::shared_ptr<ResourceBase> rb = sub_svc()->resource(request->name());
+    if (!rb) {
+        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
+    }
+    
+    std::shared_ptr<Encoder> encoder = std::dynamic_pointer_cast<Encoder>(rb);
+    
+    AttributeMap result = encoder->do_command(request->TODO());
+
+    return ::grpc::Status();
+}
+
+
+void EncoderServer::register_server(std::shared_ptr<Server> server) {
+    viam::component::encoder::v1::EncoderService::Service* encoder =
+        static_cast<viam::component::encoder::v1::EncoderService::Service*>(this);
+    server->register_service(encoder);
+}
+
+std::shared_ptr<SubtypeService> EncoderServer::sub_svc() {
+    return sub_svc;
+}
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/encoder/server.hpp
+++ b/src/viam/sdk/components/encoder/server.hpp
@@ -1,0 +1,51 @@
+/// @file components/encoder/server.hpp
+///
+/// @brief Implements a gRPC server for the `Encoder` component.
+#pragma once
+
+#include <viam/api/common/v1/common.pb.h>
+#include <viam/api/component/encoder/v1/encoder.grpc.pb.h>
+
+#include <viam/sdk/resource/resource_server_base.hpp>
+#include <viam/sdk/subtype/subtype.hpp>
+
+namespace viam {
+namespace sdk {
+
+/// @class EncoderServer
+/// @brief gRPC server implementation of a `Encoder` component.
+/// @ingroup Encoder
+class EncoderServer : public ResourceServerBase,
+                     public viam::component::encoder::v1::EncoderService::Service {
+   public:
+   
+    ::grpc::Status GetPosition(::grpc::ServerContext* context,
+                            const ::viam::component::encoder::v1::GetPositionRequest* request,
+                            ::viam::component::encoder::v1::GetPositionResponse* response) override;
+   
+    ::grpc::Status ResetPosition(::grpc::ServerContext* context,
+                            const ::viam::component::encoder::v1::ResetPositionRequest* request,
+                            ::viam::component::encoder::v1::ResetPositionResponse* response) override;
+   
+    ::grpc::Status GetProperties(::grpc::ServerContext* context,
+                            const ::viam::component::encoder::v1::GetPropertiesRequest* request,
+                            ::viam::component::encoder::v1::GetPropertiesResponse* response) override;
+   
+    ::grpc::Status DoCommand(::grpc::ServerContext* context,
+                            const ::viam::component::encoder::v1::common.v1.DoCommandRequest* request,
+                            ::viam::component::encoder::v1::common.v1.DoCommandResponse* response) override;
+   
+
+    void register_server(std::shared_ptr<Server> server) override;
+
+    std::shared_ptr<SubtypeService> get_sub_svc();
+
+    EncoderServer() : sub_svc(std::make_shared<SubtypeService>()){};
+    EncoderServer(std::shared_ptr<SubtypeService> sub_svc) : sub_svc(sub_svc){};
+
+   private:
+    std::shared_ptr<SubtypeService> sub_svc;
+};
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/encoder/server.hpp
+++ b/src/viam/sdk/components/encoder/server.hpp
@@ -6,8 +6,8 @@
 #include <viam/api/common/v1/common.pb.h>
 #include <viam/api/component/encoder/v1/encoder.grpc.pb.h>
 
+#include <viam/sdk/resource/resource_manager.hpp>
 #include <viam/sdk/resource/resource_server_base.hpp>
-#include <viam/sdk/subtype/subtype.hpp>
 
 namespace viam {
 namespace sdk {
@@ -39,13 +39,8 @@ class EncoderServer : public ResourceServerBase,
 
     void register_server(std::shared_ptr<Server> server) override;
 
-    std::shared_ptr<SubtypeService> resource_manager();
-
-    EncoderServer() : sub_svc(std::make_shared<SubtypeService>()){};
-    EncoderServer(std::shared_ptr<SubtypeService> sub_svc) : sub_svc(sub_svc){};
-
-   private:
-    std::shared_ptr<SubtypeService> sub_svc;
+    EncoderServer() : ResourceServerBase(std::make_shared<ResourceManager>()){};
+    EncoderServer(std::shared_ptr<ResourceManager> manager) : ResourceServerBase(manager){};
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/encoder/server.hpp
+++ b/src/viam/sdk/components/encoder/server.hpp
@@ -18,6 +18,9 @@ namespace sdk {
 class EncoderServer : public ResourceServerBase,
                       public viam::component::encoder::v1::EncoderService::Service {
    public:
+    EncoderServer();
+    explicit EncoderServer(std::shared_ptr<ResourceManager> manager);
+
     ::grpc::Status GetPosition(
         ::grpc::ServerContext* context,
         const ::viam::component::encoder::v1::GetPositionRequest* request,
@@ -38,9 +41,6 @@ class EncoderServer : public ResourceServerBase,
                              viam::common::v1::DoCommandResponse* response) override;
 
     void register_server(std::shared_ptr<Server> server) override;
-
-    EncoderServer() : ResourceServerBase(std::make_shared<ResourceManager>()){};
-    EncoderServer(std::shared_ptr<ResourceManager> manager) : ResourceServerBase(manager){};
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/encoder/server.hpp
+++ b/src/viam/sdk/components/encoder/server.hpp
@@ -16,29 +16,30 @@ namespace sdk {
 /// @brief gRPC server implementation of a `Encoder` component.
 /// @ingroup Encoder
 class EncoderServer : public ResourceServerBase,
-                     public viam::component::encoder::v1::EncoderService::Service {
+                      public viam::component::encoder::v1::EncoderService::Service {
    public:
-   
-    ::grpc::Status GetPosition(::grpc::ServerContext* context,
-                            const ::viam::component::encoder::v1::GetPositionRequest* request,
-                            ::viam::component::encoder::v1::GetPositionResponse* response) override;
-   
-    ::grpc::Status ResetPosition(::grpc::ServerContext* context,
-                            const ::viam::component::encoder::v1::ResetPositionRequest* request,
-                            ::viam::component::encoder::v1::ResetPositionResponse* response) override;
-   
-    ::grpc::Status GetProperties(::grpc::ServerContext* context,
-                            const ::viam::component::encoder::v1::GetPropertiesRequest* request,
-                            ::viam::component::encoder::v1::GetPropertiesResponse* response) override;
-   
-    ::grpc::Status DoCommand(::grpc::ServerContext* context,
-                            const ::viam::component::encoder::v1::common.v1.DoCommandRequest* request,
-                            ::viam::component::encoder::v1::common.v1.DoCommandResponse* response) override;
-   
+    ::grpc::Status GetPosition(
+        ::grpc::ServerContext* context,
+        const ::viam::component::encoder::v1::GetPositionRequest* request,
+        ::viam::component::encoder::v1::GetPositionResponse* response) override;
+
+    ::grpc::Status ResetPosition(
+        ::grpc::ServerContext* context,
+        const ::viam::component::encoder::v1::ResetPositionRequest* request,
+        ::viam::component::encoder::v1::ResetPositionResponse* response) override;
+
+    ::grpc::Status GetProperties(
+        ::grpc::ServerContext* context,
+        const ::viam::component::encoder::v1::GetPropertiesRequest* request,
+        ::viam::component::encoder::v1::GetPropertiesResponse* response) override;
+
+    ::grpc::Status DoCommand(grpc::ServerContext* context,
+                             const viam::common::v1::DoCommandRequest* request,
+                             viam::common::v1::DoCommandResponse* response) override;
 
     void register_server(std::shared_ptr<Server> server) override;
 
-    std::shared_ptr<SubtypeService> get_sub_svc();
+    std::shared_ptr<SubtypeService> resource_manager();
 
     EncoderServer() : sub_svc(std::make_shared<SubtypeService>()){};
     EncoderServer(std::shared_ptr<SubtypeService> sub_svc) : sub_svc(sub_svc){};

--- a/src/viam/sdk/tests/CMakeLists.txt
+++ b/src/viam/sdk/tests/CMakeLists.txt
@@ -17,5 +17,6 @@ include(viamcppsdk_utils)
 viamcppsdk_add_boost_test(test_generic_component.cpp)
 viamcppsdk_add_boost_test(test_motor.cpp)
 viamcppsdk_add_boost_test(test_camera.cpp)
+viamcppsdk_add_boost_test(test_encoder.cpp)
 viamcppsdk_add_boost_test(test_types.cpp)
 

--- a/src/viam/sdk/tests/mocks/mock_encoder.cpp
+++ b/src/viam/sdk/tests/mocks/mock_encoder.cpp
@@ -1,0 +1,40 @@
+#include <viam/sdk/tests/mocks/mock_encoder.hpp>
+
+#include <viam/api/common/v1/common.pb.h>
+#include <viam/api/component/encoder/v1/encoder.grpc.pb.h>
+#include <viam/api/component/encoder/v1/encoder.pb.h>
+
+#include <viam/sdk/components/encoder/encoder.hpp>
+#include <viam/sdk/components/encoder/server.hpp>
+#include <viam/sdk/tests/test_utils.hpp>
+
+namespace viam {
+namespace sdktests {
+namespace encoder {
+
+using namespace viam::sdk;
+
+Encoder::position MockEncoder::get_position(position_type position_type) {
+    this->peek_get_position_position_type = position_type;
+    return this->peek_get_position_ret;
+};
+
+void MockEncoder::reset_position() {
+    this->peek_reset_position_called = true;
+};
+
+Encoder::properties MockEncoder::get_properties() {
+    return this->peek_get_properties_ret;
+};
+
+AttributeMap MockEncoder::do_command(AttributeMap command) {
+    return command;
+};
+
+std::shared_ptr<MockEncoder> MockEncoder::get_mock_encoder() {
+    return std::make_shared<MockEncoder>("mock_encoder");
+}
+
+}  // namespace encoder
+}  // namespace sdktests
+}  // namespace viam

--- a/src/viam/sdk/tests/mocks/mock_encoder.hpp
+++ b/src/viam/sdk/tests/mocks/mock_encoder.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <viam/api/common/v1/common.pb.h>
+#include <viam/api/component/encoder/v1/encoder.grpc.pb.h>
+#include <viam/api/component/encoder/v1/encoder.pb.h>
+
+#include <viam/sdk/components/encoder/client.hpp>
+#include <viam/sdk/components/encoder/encoder.hpp>
+#include <viam/sdk/components/encoder/server.hpp>
+
+namespace viam {
+namespace sdktests {
+namespace encoder {
+
+class MockEncoder : public viam::sdk::Encoder {
+   public:
+    Encoder::position get_position(Encoder::position_type position_type) override;
+    void reset_position() override;
+    Encoder::properties get_properties() override;
+    viam::sdk::AttributeMap do_command(viam::sdk::AttributeMap command) override;
+    static std::shared_ptr<MockEncoder> get_mock_encoder();
+
+    MockEncoder(std::string name) : Encoder(std::move(name)){};
+
+    // For testing purposes only.
+    bool peek_reset_position_called;
+    Encoder::properties peek_get_properties_ret;
+    Encoder::position_type peek_get_position_position_type;
+    Encoder::position peek_get_position_ret;
+};
+
+}  // namespace encoder
+}  // namespace sdktests
+}  // namespace viam

--- a/src/viam/sdk/tests/test_encoder.cpp
+++ b/src/viam/sdk/tests/test_encoder.cpp
@@ -1,0 +1,108 @@
+#define BOOST_TEST_MODULE test module test_encoder
+
+#include <typeinfo>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <boost/test/included/unit_test.hpp>
+
+#include <viam/api/common/v1/common.pb.h>
+#include <viam/api/component/encoder/v1/encoder.grpc.pb.h>
+#include <viam/api/component/encoder/v1/encoder.pb.h>
+
+#include <viam/sdk/common/proto_type.hpp>
+#include <viam/sdk/components/encoder/client.hpp>
+#include <viam/sdk/components/encoder/encoder.hpp>
+#include <viam/sdk/components/encoder/server.hpp>
+#include <viam/sdk/tests/mocks/mock_encoder.hpp>
+#include <viam/sdk/tests/test_utils.hpp>
+
+namespace viam {
+namespace sdktests {
+
+using namespace encoder;
+
+using namespace viam::sdk;
+
+BOOST_AUTO_TEST_SUITE(test_encoder)
+// This sets up the following architecture
+// -- MockComponent
+//        /\
+//
+//        | (function calls)
+//
+//        \/
+// -- ComponentServer (Real)
+//        /\
+//
+//        | (grpc InProcessChannel)
+//
+//        \/
+// -- ComponentClient (Real)
+//
+// This is as close to a real setup as we can get
+// without starting another process
+//
+// The passed in lambda function has access to the ComponentClient
+//
+template <typename Lambda>
+void server_to_mock_pipeline(Lambda&& func) {
+    EncoderServer encoder_server;
+    std::shared_ptr<MockEncoder> mock = MockEncoder::get_mock_encoder();
+    encoder_server.resource_manager()->add(std::string("mock_encoder"), mock);
+
+    grpc::ServerBuilder builder;
+    builder.RegisterService(&encoder_server);
+
+    std::unique_ptr<grpc::Server> server = builder.BuildAndStart();
+
+    grpc::ChannelArguments args;
+    auto grpc_channel = server->InProcessChannel(args);
+    EncoderClient client("mock_encoder", grpc_channel);
+    // Run the passed test on the created stack
+    std::forward<Lambda>(func)(client, mock);
+    server->Shutdown();
+}
+
+BOOST_AUTO_TEST_CASE(test_get_position) {
+    server_to_mock_pipeline([](Encoder& client, std::shared_ptr<MockEncoder> mock) -> void {
+        mock->peek_get_position_ret = Encoder::position{1.0, Encoder::position_type::ANGLE_DEGREES};
+        auto returned_position = client.get_position(Encoder::position_type::TICKS_COUNT);
+        BOOST_CHECK(mock->peek_get_position_position_type == Encoder::position_type::TICKS_COUNT);
+        BOOST_CHECK(returned_position == mock->peek_get_position_ret);
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_reset_position) {
+    server_to_mock_pipeline([](Encoder& client, std::shared_ptr<MockEncoder> mock) -> void {
+        mock->peek_reset_position_called = false;
+        client.reset_position();
+        BOOST_CHECK(mock->peek_reset_position_called);
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_get_properties) {
+    server_to_mock_pipeline([](Encoder& client, std::shared_ptr<MockEncoder> mock) -> void {
+        mock->peek_get_properties_ret = Encoder::properties{false, true};
+        auto returned_properties = client.get_properties();
+        BOOST_CHECK(returned_properties == mock->peek_get_properties_ret);
+    });
+}
+BOOST_AUTO_TEST_CASE(test_do_command) {
+    server_to_mock_pipeline([](Encoder& client, std::shared_ptr<MockEncoder> mock) -> void {
+        AttributeMap expected = fake_map();
+
+        AttributeMap command = fake_map();
+        AttributeMap result_map = client.do_command(command);
+
+        ProtoType expected_pt = *(expected->at(std::string("test")));
+        ProtoType result_pt = *(result_map->at(std::string("test")));
+        BOOST_CHECK(result_pt == expected_pt);
+    });
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace sdktests
+}  // namespace viam

--- a/src/viam/sdk/tests/test_encoder.cpp
+++ b/src/viam/sdk/tests/test_encoder.cpp
@@ -67,10 +67,13 @@ void server_to_mock_pipeline(Lambda&& func) {
 
 BOOST_AUTO_TEST_CASE(test_get_position) {
     server_to_mock_pipeline([](Encoder& client, std::shared_ptr<MockEncoder> mock) -> void {
-        mock->peek_get_position_ret = Encoder::position{1.0, Encoder::position_type::ANGLE_DEGREES};
-        auto returned_position = client.get_position(Encoder::position_type::TICKS_COUNT);
-        BOOST_CHECK(mock->peek_get_position_position_type == Encoder::position_type::TICKS_COUNT);
+        mock->peek_get_position_ret = Encoder::position{1.0, Encoder::position_type::angle_degrees};
+        auto returned_position = client.get_position(Encoder::position_type::ticks_count);
+        BOOST_CHECK(mock->peek_get_position_position_type == Encoder::position_type::ticks_count);
         BOOST_CHECK(returned_position == mock->peek_get_position_ret);
+        // Check that an empty get_position() request has unspecified position_type
+        client.get_position();
+        BOOST_CHECK(mock->peek_get_position_position_type == Encoder::position_type::unspecified);
     });
 }
 


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-2484

Important design decisions:
1) Unsure if Encoder::position_type should be a subclass of Encoder::postion
2) I used peeking-based mocks because it would be difficult to do a behavior-based mock for this component.

Pre-merge:
Bring in refactoring changes. Right now there is so much changing that it would be a waste of time to try and keep up before it is stable.