### PR TITLE
RSDK-2971 - refactor `*Base` classes

### DIFF
--- a/src/viam/examples/modules/example_module.cpp
+++ b/src/viam/examples/modules/example_module.cpp
@@ -23,9 +23,9 @@
 using viam::component::generic::v1::GenericService;
 using namespace viam::sdk;
 
-class MyModule : public GenericService::Service, public ComponentBase {
+class MyModule : public GenericService::Service, public Component {
    public:
-    void reconfigure(Dependencies deps, Resource cfg) override {
+    void reconfigure(Dependencies deps, ResourceConfig cfg) override {
         std::cout << "Calling reconfigure on MyModule" << std::endl;
         for (auto& dep : deps) {
             std::cout << "dependency: " << dep.first.to_string() << std::endl;
@@ -39,7 +39,7 @@ class MyModule : public GenericService::Service, public ComponentBase {
         which_ += 1;
     };
 
-    MyModule(Resource cfg) {
+    MyModule(ResourceConfig cfg) {
         name_ = cfg.name();
         std::cout << "Creating module with name " + name_ << std::endl;
         inner_which_ = which_;
@@ -93,12 +93,12 @@ int main(int argc, char** argv) {
         ResourceType("MyModule"),
         generic,
         m,
-        [](Dependencies, Resource cfg) { return std::make_unique<MyModule>(cfg); },
+        [](Dependencies, ResourceConfig cfg) { return std::make_unique<MyModule>(cfg); },
         // Custom validation can be done by specifying a validate function like
         // this one. Validate functions can `throw` error strings that will be
         // returned to the parent through gRPC. Validate functions can also return
         // a vector of strings representing the implicit dependencies of the resource.
-        [](Resource cfg) -> std::vector<std::string> {
+        [](ResourceConfig cfg) -> std::vector<std::string> {
             if (cfg.attributes()->find("invalidattribute") != cfg.attributes()->end()) {
                 throw std::string(
                     "'invalidattribute' attribute not allowed for model 'acme:demo:printer'");

--- a/src/viam/sdk/common/linear_algebra.hpp
+++ b/src/viam/sdk/common/linear_algebra.hpp
@@ -1,4 +1,7 @@
 #pragma once
+
+#include <array>
+
 #include <boost/qvm/vec.hpp>
 #include <boost/qvm/vec_traits.hpp>
 

--- a/src/viam/sdk/common/utils.cpp
+++ b/src/viam/sdk/common/utils.cpp
@@ -19,7 +19,7 @@ namespace sdk {
 
 using viam::common::v1::ResourceName;
 
-std::vector<ResourceName> resource_names_for_resource(std::shared_ptr<ResourceBase> resource) {
+std::vector<ResourceName> resource_names_for_resource(std::shared_ptr<Resource> resource) {
     std::string resource_type;
     std::vector<ResourceName> resource_names;
     for (auto& a : Registry::registered_resources()) {

--- a/src/viam/sdk/common/utils.hpp
+++ b/src/viam/sdk/common/utils.hpp
@@ -23,7 +23,7 @@ const std::string GENERIC = "generic";
 const std::string BUILTIN = "builtin";
 
 std::vector<viam::common::v1::ResourceName> resource_names_for_resource(
-    std::shared_ptr<ResourceBase> resource);
+    std::shared_ptr<Resource> resource);
 
 class ResourceNameHasher {
    public:

--- a/src/viam/sdk/components/base/base.cpp
+++ b/src/viam/sdk/components/base/base.cpp
@@ -25,7 +25,7 @@ std::shared_ptr<ResourceServer> BaseSubtype::create_resource_server(
 };
 
 std::shared_ptr<Resource> BaseSubtype::create_rpc_client(std::string name,
-                                                             std::shared_ptr<grpc::Channel> chan) {
+                                                         std::shared_ptr<grpc::Channel> chan) {
     return std::make_shared<BaseClient>(std::move(name), std::move(chan));
 };
 

--- a/src/viam/sdk/components/base/base.cpp
+++ b/src/viam/sdk/components/base/base.cpp
@@ -19,12 +19,12 @@ BaseClient::BaseClient(std::string name, std::shared_ptr<grpc::Channel> channel)
       stub_(viam::component::base::v1::BaseService::NewStub(channel)),
       channel_(std::move(channel)){};
 
-std::shared_ptr<ResourceServerBase> BaseSubtype::create_resource_server(
+std::shared_ptr<ResourceServer> BaseSubtype::create_resource_server(
     std::shared_ptr<ResourceManager> manager) {
     return std::make_shared<BaseServer>(manager);
 };
 
-std::shared_ptr<ResourceBase> BaseSubtype::create_rpc_client(std::string name,
+std::shared_ptr<Resource> BaseSubtype::create_rpc_client(std::string name,
                                                              std::shared_ptr<grpc::Channel> chan) {
     return std::make_shared<BaseClient>(std::move(name), std::move(chan));
 };
@@ -43,7 +43,7 @@ Subtype Base::subtype() {
     return Subtype(RDK, COMPONENT, "base");
 }
 
-Base::Base(std::string name) : ComponentBase(std::move(name)){};
+Base::Base(std::string name) : Component(std::move(name)){};
 
 namespace {
 bool init() {

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -24,9 +24,9 @@ namespace sdk {
 /// @ingroup Base
 class BaseSubtype : public ResourceSubtype {
    public:
-    std::shared_ptr<ResourceServerBase> create_resource_server(
+    std::shared_ptr<ResourceServer> create_resource_server(
         std::shared_ptr<ResourceManager> manager) override;
-    std::shared_ptr<ResourceBase> create_rpc_client(std::string name,
+    std::shared_ptr<Resource> create_rpc_client(std::string name,
                                                     std::shared_ptr<grpc::Channel> chan) override;
     BaseSubtype(const google::protobuf::ServiceDescriptor* service_descriptor)
         : ResourceSubtype(service_descriptor){};
@@ -38,7 +38,7 @@ class BaseSubtype : public ResourceSubtype {
 ///
 /// This acts as an abstract parent class to be inherited from by any drivers representing
 /// specific base implementations. This class cannot be used on its own.
-class Base : public ComponentBase {
+class Base : public Component {
    public:
     // functions shared across all components
     static std::shared_ptr<ResourceSubtype> resource_subtype();

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -27,7 +27,7 @@ class BaseSubtype : public ResourceSubtype {
     std::shared_ptr<ResourceServer> create_resource_server(
         std::shared_ptr<ResourceManager> manager) override;
     std::shared_ptr<Resource> create_rpc_client(std::string name,
-                                                    std::shared_ptr<grpc::Channel> chan) override;
+                                                std::shared_ptr<grpc::Channel> chan) override;
     BaseSubtype(const google::protobuf::ServiceDescriptor* service_descriptor)
         : ResourceSubtype(service_descriptor){};
 };

--- a/src/viam/sdk/components/base/server.cpp
+++ b/src/viam/sdk/components/base/server.cpp
@@ -9,8 +9,8 @@
 namespace viam {
 namespace sdk {
 
-BaseServer::BaseServer() : ResourceServerBase(std::make_shared<ResourceManager>()){};
-BaseServer::BaseServer(std::shared_ptr<ResourceManager> manager) : ResourceServerBase(manager){};
+BaseServer::BaseServer() : ResourceServer(std::make_shared<ResourceManager>()){};
+BaseServer::BaseServer(std::shared_ptr<ResourceManager> manager) : ResourceServer(manager){};
 
 ::grpc::Status BaseServer::MoveStraight(
     ::grpc::ServerContext* context,

--- a/src/viam/sdk/components/base/server.hpp
+++ b/src/viam/sdk/components/base/server.hpp
@@ -15,7 +15,7 @@ namespace sdk {
 /// @class BaseServer
 /// @brief gRPC server implementation of a `Base` component.
 /// @ingroup Base
-class BaseServer : public ResourceServerBase,
+class BaseServer : public ResourceServer,
                    public viam::component::base::v1::BaseService::Service {
    public:
     BaseServer();

--- a/src/viam/sdk/components/base/server.hpp
+++ b/src/viam/sdk/components/base/server.hpp
@@ -15,8 +15,7 @@ namespace sdk {
 /// @class BaseServer
 /// @brief gRPC server implementation of a `Base` component.
 /// @ingroup Base
-class BaseServer : public ResourceServer,
-                   public viam::component::base::v1::BaseService::Service {
+class BaseServer : public ResourceServer, public viam::component::base::v1::BaseService::Service {
    public:
     BaseServer();
     BaseServer(std::shared_ptr<ResourceManager> manager);

--- a/src/viam/sdk/components/camera/camera.cpp
+++ b/src/viam/sdk/components/camera/camera.cpp
@@ -14,15 +14,13 @@
 namespace viam {
 namespace sdk {
 
-CameraSubtype::~CameraSubtype() = default;
-
-std::shared_ptr<ResourceServerBase> CameraSubtype::create_resource_server(
+std::shared_ptr<ResourceServer> CameraSubtype::create_resource_server(
     std::shared_ptr<ResourceManager> manager) {
     return std::make_shared<CameraServer>(manager);
 };
 
-std::shared_ptr<ResourceBase> CameraSubtype::create_rpc_client(
-    std::string name, std::shared_ptr<grpc::Channel> chan) {
+std::shared_ptr<Resource> CameraSubtype::create_rpc_client(std::string name,
+                                                           std::shared_ptr<grpc::Channel> chan) {
     return std::make_shared<CameraClient>(std::move(name), std::move(chan));
 };
 

--- a/src/viam/sdk/components/camera/camera.hpp
+++ b/src/viam/sdk/components/camera/camera.hpp
@@ -25,11 +25,10 @@ namespace sdk {
 /// @ingroup Camera
 class CameraSubtype : public ResourceSubtype {
    public:
-    virtual ~CameraSubtype();
-    std::shared_ptr<ResourceServerBase> create_resource_server(
+    std::shared_ptr<ResourceServer> create_resource_server(
         std::shared_ptr<ResourceManager> manager) override;
-    std::shared_ptr<ResourceBase> create_rpc_client(std::string name,
-                                                    std::shared_ptr<grpc::Channel> chan) override;
+    std::shared_ptr<Resource> create_rpc_client(std::string name,
+                                                std::shared_ptr<grpc::Channel> chan) override;
     CameraSubtype(const google::protobuf::ServiceDescriptor* service_descriptor)
         : ResourceSubtype(service_descriptor){};
 };
@@ -40,7 +39,7 @@ class CameraSubtype : public ResourceSubtype {
 ///
 /// This acts as an abstract base class to be inherited from by any drivers representing
 /// specific camera implementations. This class cannot be used on its own.
-class Camera : public ComponentBase {
+class Camera : public Component {
    public:
     /// @struct intrinsic parameters
     /// @brief The properties of the camera.
@@ -138,7 +137,7 @@ class Camera : public ComponentBase {
     virtual properties get_properties() = 0;
 
    protected:
-    explicit Camera(std::string name) : ComponentBase(std::move(name)){};
+    explicit Camera(std::string name) : Component(std::move(name)){};
 };
 
 bool operator==(const Camera::raw_image& lhs, const Camera::raw_image& rhs);

--- a/src/viam/sdk/components/camera/client.cpp
+++ b/src/viam/sdk/components/camera/client.cpp
@@ -16,7 +16,6 @@
 namespace viam {
 namespace sdk {
 
-CameraClient::~CameraClient() = default;
 std::string normalize_mime_type(const std::string& str) {
     std::string mime_type = str;
     if (str.size() >= Camera::lazy_suffix.size() &&

--- a/src/viam/sdk/components/camera/client.hpp
+++ b/src/viam/sdk/components/camera/client.hpp
@@ -20,7 +20,6 @@ namespace sdk {
 /// @ingroup Camera
 class CameraClient : public Camera {
    public:
-    virtual ~CameraClient();
     AttributeMap do_command(AttributeMap command) override;
     raw_image get_image(std::string mime_type) override;
     point_cloud get_point_cloud(std::string mime_type) override;

--- a/src/viam/sdk/components/camera/server.cpp
+++ b/src/viam/sdk/components/camera/server.cpp
@@ -16,7 +16,7 @@ namespace sdk {
                               "Called [DoCommand] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -37,7 +37,7 @@ namespace sdk {
                               "Called [GetImage] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -63,7 +63,7 @@ namespace sdk {
                               "Called [RenderFrame] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -87,7 +87,7 @@ namespace sdk {
                               "Called [GetPointCloud] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
 
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
@@ -112,7 +112,7 @@ namespace sdk {
                               "Called [GetProperties] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }

--- a/src/viam/sdk/components/camera/server.hpp
+++ b/src/viam/sdk/components/camera/server.hpp
@@ -15,7 +15,7 @@ namespace sdk {
 /// @class CameraServer
 /// @brief gRPC server implementation of a `Camera` component.
 /// @ingroup Camera
-class CameraServer : public ResourceServerBase,
+class CameraServer : public ResourceServer,
                      public viam::component::camera::v1::CameraService::Service {
    public:
     ::grpc::Status DoCommand(::grpc::ServerContext* context,
@@ -38,8 +38,8 @@ class CameraServer : public ResourceServerBase,
 
     void register_server(std::shared_ptr<Server> server) override;
 
-    CameraServer() : ResourceServerBase(std::make_shared<ResourceManager>()){};
-    CameraServer(std::shared_ptr<ResourceManager> manager) : ResourceServerBase(manager){};
+    CameraServer() : ResourceServer(std::make_shared<ResourceManager>()){};
+    CameraServer(std::shared_ptr<ResourceManager> manager) : ResourceServer(manager){};
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/component_base.cpp
+++ b/src/viam/sdk/components/component_base.cpp
@@ -15,13 +15,13 @@ namespace sdk {
 
 using viam::common::v1::ResourceName;
 
-ResourceName ComponentBase::get_resource_name(std::string name) {
-    auto r = this->ResourceBase::get_resource_name(name);
+ResourceName Component::get_resource_name(std::string name) {
+    auto r = this->Resource::get_resource_name(name);
     *r.mutable_type() = COMPONENT;
     return r;
 }
 
-ResourceType ComponentBase::type() {
+ResourceType Component::type() {
     return {COMPONENT};
 }
 

--- a/src/viam/sdk/components/component_base.hpp
+++ b/src/viam/sdk/components/component_base.hpp
@@ -11,14 +11,14 @@
 namespace viam {
 namespace sdk {
 
-class ComponentBase : public ResourceBase {
+class Component : public Resource {
    public:
     virtual ResourceType type() override;
     viam::common::v1::ResourceName get_resource_name(std::string name) override;
-    ComponentBase() : ResourceBase("component"){};
+    Component() : Resource("component"){};
 
    protected:
-    explicit ComponentBase(std::string name) : ResourceBase(std::move(name)){};
+    explicit Component(std::string name) : Resource(std::move(name)){};
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/encoder/encoder.cpp
+++ b/src/viam/sdk/components/encoder/encoder.cpp
@@ -14,13 +14,13 @@
 namespace viam {
 namespace sdk {
 
-std::shared_ptr<ResourceServerBase> EncoderSubtype::create_resource_server(
+std::shared_ptr<ResourceServer> EncoderSubtype::create_resource_server(
     std::shared_ptr<ResourceManager> manager) {
     return std::make_shared<EncoderServer>(manager);
 };
 
-std::shared_ptr<ResourceBase> EncoderSubtype::create_rpc_client(
-    std::string name, std::shared_ptr<grpc::Channel> chan) {
+std::shared_ptr<Resource> EncoderSubtype::create_rpc_client(std::string name,
+                                                            std::shared_ptr<grpc::Channel> chan) {
     return std::make_shared<EncoderClient>(std::move(name), std::move(chan));
 };
 
@@ -104,7 +104,7 @@ viam::component::encoder::v1::GetPropertiesResponse Encoder::to_proto(properties
     return proto;
 }
 
-Encoder::Encoder(std::string name) : ComponentBase(std::move(name)){};
+Encoder::Encoder(std::string name) : Component(std::move(name)){};
 
 bool operator==(const Encoder::position& lhs, const Encoder::position& rhs) {
     return (lhs.value == rhs.value && lhs.type == rhs.type);

--- a/src/viam/sdk/components/encoder/encoder.hpp
+++ b/src/viam/sdk/components/encoder/encoder.hpp
@@ -23,10 +23,10 @@ namespace sdk {
 /// @ingroup Encoder
 class EncoderSubtype : public ResourceSubtype {
    public:
-    std::shared_ptr<ResourceServerBase> create_resource_server(
+    std::shared_ptr<ResourceServer> create_resource_server(
         std::shared_ptr<ResourceManager> manager) override;
-    std::shared_ptr<ResourceBase> create_rpc_client(std::string name,
-                                                    std::shared_ptr<grpc::Channel> chan) override;
+    std::shared_ptr<Resource> create_rpc_client(std::string name,
+                                                std::shared_ptr<grpc::Channel> chan) override;
     EncoderSubtype(const google::protobuf::ServiceDescriptor* service_descriptor)
         : ResourceSubtype(service_descriptor){};
 };
@@ -37,7 +37,7 @@ class EncoderSubtype : public ResourceSubtype {
 ///
 /// This acts as an abstract base class to be inherited from by any drivers representing
 /// specific encoder implementations. This class cannot be used on its own.
-class Encoder : public ComponentBase {
+class Encoder : public Component {
    public:
     /// @enum position_type
     enum class position_type : uint8_t {

--- a/src/viam/sdk/components/encoder/server.cpp
+++ b/src/viam/sdk/components/encoder/server.cpp
@@ -8,9 +8,9 @@
 namespace viam {
 namespace sdk {
 
-EncoderServer::EncoderServer() : ResourceServerBase(std::make_shared<ResourceManager>()){};
+EncoderServer::EncoderServer() : ResourceServer(std::make_shared<ResourceManager>()){};
 EncoderServer::EncoderServer(std::shared_ptr<ResourceManager> manager)
-    : ResourceServerBase(manager){};
+    : ResourceServer(manager){};
 
 ::grpc::Status EncoderServer::GetPosition(
     ::grpc::ServerContext* context,
@@ -21,7 +21,7 @@ EncoderServer::EncoderServer(std::shared_ptr<ResourceManager> manager)
                               "Called [Encoder::GetPosition] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -44,7 +44,7 @@ EncoderServer::EncoderServer(std::shared_ptr<ResourceManager> manager)
                               "Called [Encoder::ResetPosition] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -65,7 +65,7 @@ EncoderServer::EncoderServer(std::shared_ptr<ResourceManager> manager)
                               "Called [Encoder::GetProperties] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -87,7 +87,7 @@ EncoderServer::EncoderServer(std::shared_ptr<ResourceManager> manager)
                               "Called [Encoder::DoCommand] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }

--- a/src/viam/sdk/components/encoder/server.cpp
+++ b/src/viam/sdk/components/encoder/server.cpp
@@ -9,8 +9,7 @@ namespace viam {
 namespace sdk {
 
 EncoderServer::EncoderServer() : ResourceServer(std::make_shared<ResourceManager>()){};
-EncoderServer::EncoderServer(std::shared_ptr<ResourceManager> manager)
-    : ResourceServer(manager){};
+EncoderServer::EncoderServer(std::shared_ptr<ResourceManager> manager) : ResourceServer(manager){};
 
 ::grpc::Status EncoderServer::GetPosition(
     ::grpc::ServerContext* context,

--- a/src/viam/sdk/components/encoder/server.hpp
+++ b/src/viam/sdk/components/encoder/server.hpp
@@ -15,7 +15,7 @@ namespace sdk {
 /// @class EncoderServer
 /// @brief gRPC server implementation of a `Encoder` component.
 /// @ingroup Encoder
-class EncoderServer : public ResourceServerBase,
+class EncoderServer : public ResourceServer,
                       public viam::component::encoder::v1::EncoderService::Service {
    public:
     EncoderServer();

--- a/src/viam/sdk/components/generic/client.cpp
+++ b/src/viam/sdk/components/generic/client.cpp
@@ -12,7 +12,6 @@
 namespace viam {
 namespace sdk {
 
-GenericClient::~GenericClient() = default;
 AttributeMap GenericClient::do_command(AttributeMap command) {
     viam::common::v1::DoCommandRequest req;
     viam::common::v1::DoCommandResponse resp;

--- a/src/viam/sdk/components/generic/client.hpp
+++ b/src/viam/sdk/components/generic/client.hpp
@@ -18,7 +18,6 @@ namespace sdk {
 /// @ingroup Generic
 class GenericClient : public Generic {
    public:
-    virtual ~GenericClient();
     AttributeMap do_command(AttributeMap command) override;
     GenericClient(std::string name, std::shared_ptr<grpc::Channel> channel)
         : Generic(std::move(name)),

--- a/src/viam/sdk/components/generic/generic.cpp
+++ b/src/viam/sdk/components/generic/generic.cpp
@@ -15,15 +15,13 @@
 namespace viam {
 namespace sdk {
 
-GenericSubtype::~GenericSubtype() = default;
-
-std::shared_ptr<ResourceServerBase> GenericSubtype::create_resource_server(
+std::shared_ptr<ResourceServer> GenericSubtype::create_resource_server(
     std::shared_ptr<ResourceManager> manager) {
     return std::make_shared<GenericServer>(manager);
 };
 
-std::shared_ptr<ResourceBase> GenericSubtype::create_rpc_client(
-    std::string name, std::shared_ptr<grpc::Channel> chan) {
+std::shared_ptr<Resource> GenericSubtype::create_rpc_client(std::string name,
+                                                            std::shared_ptr<grpc::Channel> chan) {
     return std::make_shared<GenericClient>(std::move(name), std::move(chan));
 };
 

--- a/src/viam/sdk/components/generic/generic.hpp
+++ b/src/viam/sdk/components/generic/generic.hpp
@@ -22,11 +22,10 @@ namespace sdk {
 /// @ingroup Generic
 class GenericSubtype : public ResourceSubtype {
    public:
-    virtual ~GenericSubtype();
-    std::shared_ptr<ResourceServerBase> create_resource_server(
+    std::shared_ptr<ResourceServer> create_resource_server(
         std::shared_ptr<ResourceManager> manager) override;
-    std::shared_ptr<ResourceBase> create_rpc_client(std::string name,
-                                                    std::shared_ptr<grpc::Channel> chan) override;
+    std::shared_ptr<Resource> create_rpc_client(std::string name,
+                                                std::shared_ptr<grpc::Channel> chan) override;
     GenericSubtype(const google::protobuf::ServiceDescriptor* service_descriptor)
         : ResourceSubtype(service_descriptor){};
 };
@@ -37,7 +36,7 @@ class GenericSubtype : public ResourceSubtype {
 ///
 /// This acts as an abstract base class to be inherited from by any drivers representing
 /// specific generic implementations. This class cannot be used on its own.
-class Generic : public ComponentBase {
+class Generic : public Component {
    public:
     /// @brief Creates a `ResourceSubtype` for the `Generic` component.
     static std::shared_ptr<ResourceSubtype> resource_subtype();
@@ -51,7 +50,7 @@ class Generic : public ComponentBase {
     virtual AttributeMap do_command(AttributeMap command) = 0;
 
    protected:
-    explicit Generic(std::string name) : ComponentBase(std::move(name)){};
+    explicit Generic(std::string name) : Component(std::move(name)){};
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/generic/server.cpp
+++ b/src/viam/sdk/components/generic/server.cpp
@@ -14,7 +14,7 @@ namespace sdk {
                               "Called [DoCommand] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }

--- a/src/viam/sdk/components/generic/server.hpp
+++ b/src/viam/sdk/components/generic/server.hpp
@@ -15,7 +15,7 @@ namespace sdk {
 /// @class GenericServer
 /// @brief gRPC server implementation of a `Generic` component.
 /// @ingroup Generic
-class GenericServer : public ResourceServerBase,
+class GenericServer : public ResourceServer,
                       public viam::component::generic::v1::GenericService::Service {
    public:
     ::grpc::Status DoCommand(::grpc::ServerContext* context,
@@ -24,8 +24,8 @@ class GenericServer : public ResourceServerBase,
 
     void register_server(std::shared_ptr<Server> server) override;
 
-    GenericServer() : ResourceServerBase(std::make_shared<ResourceManager>()){};
-    GenericServer(std::shared_ptr<ResourceManager> manager) : ResourceServerBase(manager){};
+    GenericServer() : ResourceServer(std::make_shared<ResourceManager>()){};
+    GenericServer(std::shared_ptr<ResourceManager> manager) : ResourceServer(manager){};
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/motor/client.cpp
+++ b/src/viam/sdk/components/motor/client.cpp
@@ -17,8 +17,6 @@
 namespace viam {
 namespace sdk {
 
-MotorClient::~MotorClient() = default;
-
 void MotorClient::set_power(double power_pct) {
     viam::component::motor::v1::SetPowerRequest request;
     viam::component::motor::v1::SetPowerResponse response;

--- a/src/viam/sdk/components/motor/client.hpp
+++ b/src/viam/sdk/components/motor/client.hpp
@@ -20,7 +20,6 @@ namespace sdk {
 /// @ingroup Motor
 class MotorClient : public Motor {
    public:
-    virtual ~MotorClient();
     void set_power(double power_pct) override;
     void go_for(double rpm, double revolutions) override;
     void go_to(double rpm, double position_revolutions) override;

--- a/src/viam/sdk/components/motor/motor.cpp
+++ b/src/viam/sdk/components/motor/motor.cpp
@@ -14,14 +14,13 @@
 namespace viam {
 namespace sdk {
 
-MotorSubtype::~MotorSubtype() = default;
-std::shared_ptr<ResourceServerBase> MotorSubtype::create_resource_server(
+std::shared_ptr<ResourceServer> MotorSubtype::create_resource_server(
     std::shared_ptr<ResourceManager> manager) {
     return std::make_shared<MotorServer>(manager);
 };
 
-std::shared_ptr<ResourceBase> MotorSubtype::create_rpc_client(std::string name,
-                                                              std::shared_ptr<grpc::Channel> chan) {
+std::shared_ptr<Resource> MotorSubtype::create_rpc_client(std::string name,
+                                                          std::shared_ptr<grpc::Channel> chan) {
     return std::make_shared<MotorClient>(std::move(name), std::move(chan));
 };
 

--- a/src/viam/sdk/components/motor/motor.hpp
+++ b/src/viam/sdk/components/motor/motor.hpp
@@ -23,11 +23,10 @@ namespace sdk {
 /// @ingroup Motor
 class MotorSubtype : public ResourceSubtype {
    public:
-    virtual ~MotorSubtype();
-    std::shared_ptr<ResourceServerBase> create_resource_server(
+    std::shared_ptr<ResourceServer> create_resource_server(
         std::shared_ptr<ResourceManager> manager) override;
-    std::shared_ptr<ResourceBase> create_rpc_client(std::string name,
-                                                    std::shared_ptr<grpc::Channel> chan) override;
+    std::shared_ptr<Resource> create_rpc_client(std::string name,
+                                                std::shared_ptr<grpc::Channel> chan) override;
     MotorSubtype(const google::protobuf::ServiceDescriptor* service_descriptor)
         : ResourceSubtype(service_descriptor){};
 };
@@ -38,7 +37,7 @@ class MotorSubtype : public ResourceSubtype {
 ///
 /// This acts as an abstract base class to be inherited from by any drivers representing
 /// specific motor implementations. This class cannot be used on its own.
-class Motor : public ComponentBase {
+class Motor : public Component {
    public:
     /// @struct position
     /// @brief Current position of the motor relative to its home
@@ -131,7 +130,7 @@ class Motor : public ComponentBase {
     virtual AttributeMap do_command(AttributeMap command) = 0;
 
    protected:
-    explicit Motor(std::string name) : ComponentBase(std::move(name)){};
+    explicit Motor(std::string name) : Component(std::move(name)){};
 };
 
 bool operator==(const Motor::power_status& lhs, const Motor::power_status& rhs);

--- a/src/viam/sdk/components/motor/server.cpp
+++ b/src/viam/sdk/components/motor/server.cpp
@@ -16,7 +16,7 @@ namespace sdk {
                               "Called [Motor::SetPower] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -36,7 +36,7 @@ namespace sdk {
                               "Called [Motor::GoFor] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -56,7 +56,7 @@ namespace sdk {
                               "Called [Motor::GoTo] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -77,7 +77,7 @@ namespace sdk {
                               "Called [Motor::ResetZeroPosition] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -98,7 +98,7 @@ namespace sdk {
                               "Called [Motor::GetPosition] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -120,7 +120,7 @@ namespace sdk {
                               "Called [Motor::GetProperties] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -141,7 +141,7 @@ namespace sdk {
                               "Called [Motor::Stop] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -161,7 +161,7 @@ namespace sdk {
                               "Called [Motor::IsPowered] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -183,7 +183,7 @@ namespace sdk {
                               "Called [Motor::IsMoving] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }
@@ -204,7 +204,7 @@ namespace sdk {
                               "Called [Motor::DoCommand] without a request");
     };
 
-    std::shared_ptr<ResourceBase> rb = resource_manager()->resource(request->name());
+    std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
     if (!rb) {
         return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
     }

--- a/src/viam/sdk/components/motor/server.hpp
+++ b/src/viam/sdk/components/motor/server.hpp
@@ -15,7 +15,7 @@ namespace sdk {
 /// @class MotorServer
 /// @brief gRPC server implementation of a `Motor` component.
 /// @ingroup Motor
-class MotorServer : public ResourceServerBase,
+class MotorServer : public ResourceServer,
                     public viam::component::motor::v1::MotorService::Service {
    public:
     ::grpc::Status SetPower(::grpc::ServerContext* context,
@@ -63,8 +63,8 @@ class MotorServer : public ResourceServerBase,
 
     void register_server(std::shared_ptr<Server> server) override;
 
-    MotorServer() : ResourceServerBase(std::make_shared<ResourceManager>()){};
-    MotorServer(std::shared_ptr<ResourceManager> manager) : ResourceServerBase(manager){};
+    MotorServer() : ResourceServer(std::make_shared<ResourceManager>()){};
+    MotorServer(std::shared_ptr<ResourceManager> manager) : ResourceServer(manager){};
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/config/resource.cpp
+++ b/src/viam/sdk/config/resource.cpp
@@ -17,7 +17,7 @@
 namespace viam {
 namespace sdk {
 
-Name Resource::resource_name() {
+Name ResourceConfig::resource_name() {
     try {
         this->fix_api();
     } catch (std::string err) {
@@ -34,35 +34,35 @@ Name Resource::resource_name() {
     return Name(this->api_, "", remotes.at(0));
 }
 
-const Subtype& Resource::api() const {
+const Subtype& ResourceConfig::api() const {
     return api_;
 }
 
-const LinkConfig& Resource::frame() const {
+const LinkConfig& ResourceConfig::frame() const {
     return frame_;
 }
 
-const Model& Resource::model() const {
+const Model& ResourceConfig::model() const {
     return model_;
 }
 
-const std::string& Resource::name() const {
+const std::string& ResourceConfig::name() const {
     return name_;
 }
 
-const std::string& Resource::namespace_() const {
+const std::string& ResourceConfig::namespace_() const {
     return namespace__;
 }
 
-const std::string& Resource::type() const {
+const std::string& ResourceConfig::type() const {
     return type_;
 }
 
-const AttributeMap& Resource::attributes() const {
+const AttributeMap& ResourceConfig::attributes() const {
     return attributes_;
 }
 
-void Resource::fix_api() {
+void ResourceConfig::fix_api() {
     if (this->api_.type_namespace() == "" && this->namespace__ == "") {
         this->namespace__ = RDK;
         this->api_.set_namespace(RDK);
@@ -90,8 +90,8 @@ void Resource::fix_api() {
     }
 }
 
-Resource Resource::from_proto(viam::app::v1::ComponentConfig proto_cfg) {
-    Resource resource(proto_cfg.type());
+ResourceConfig ResourceConfig::from_proto(viam::app::v1::ComponentConfig proto_cfg) {
+    ResourceConfig resource(proto_cfg.type());
     resource.name_ = proto_cfg.name();
     resource.namespace__ = proto_cfg.namespace_();
     resource.type_ = proto_cfg.type();
@@ -115,7 +115,7 @@ Resource Resource::from_proto(viam::app::v1::ComponentConfig proto_cfg) {
     return resource;
 };
 
-viam::app::v1::ComponentConfig Resource::to_proto() const {
+viam::app::v1::ComponentConfig ResourceConfig::to_proto() const {
     viam::app::v1::ComponentConfig proto_cfg;
     google::protobuf::Struct s = map_to_struct(attributes_);
     google::protobuf::RepeatedPtrField<viam::app::v1::ResourceLevelServiceConfig> service_configs;
@@ -142,7 +142,7 @@ viam::app::v1::ComponentConfig Resource::to_proto() const {
     return proto_cfg;
 }
 
-Resource::Resource(std::string type) : api_({RDK, type, ""}), type_(type){};
+ResourceConfig::ResourceConfig(std::string type) : api_({RDK, type, ""}), type_(type){};
 
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/config/resource.hpp
+++ b/src/viam/sdk/config/resource.hpp
@@ -22,11 +22,11 @@ class ResourceLevelServiceConfig {
     ProtoType converted_attributes;
 };
 
-class Resource {
+class ResourceConfig {
    public:
-    static Resource from_proto(viam::app::v1::ComponentConfig proto_cfg);
+    static ResourceConfig from_proto(viam::app::v1::ComponentConfig proto_cfg);
     viam::app::v1::ComponentConfig to_proto() const;
-    Resource(std::string type);
+    ResourceConfig(std::string type);
     Name resource_name();
     const Subtype& api() const;
     const LinkConfig& frame() const;

--- a/src/viam/sdk/module/module.cpp
+++ b/src/viam/sdk/module/module.cpp
@@ -40,10 +40,10 @@ const std::unordered_map<Subtype, std::shared_ptr<ResourceManager>>& Module::ser
 std::unordered_map<Subtype, std::shared_ptr<ResourceManager>>& Module::mutable_services() {
     return services_;
 };
-const std::vector<std::shared_ptr<ResourceServerBase>>& Module::servers() const {
+const std::vector<std::shared_ptr<ResourceServer>>& Module::servers() const {
     return servers_;
 };
-std::vector<std::shared_ptr<ResourceServerBase>>& Module::mutable_servers() {
+std::vector<std::shared_ptr<ResourceServer>>& Module::mutable_servers() {
     return servers_;
 };
 

--- a/src/viam/sdk/module/module.hpp
+++ b/src/viam/sdk/module/module.hpp
@@ -21,8 +21,8 @@ class Module {
     const std::shared_ptr<grpc::Channel>& channel() const;
     const std::unordered_map<Subtype, std::shared_ptr<ResourceManager>>& services() const;
     std::unordered_map<Subtype, std::shared_ptr<ResourceManager>>& mutable_services();
-    const std::vector<std::shared_ptr<ResourceServerBase>>& servers() const;
-    std::vector<std::shared_ptr<ResourceServerBase>>& mutable_servers();
+    const std::vector<std::shared_ptr<ResourceServer>>& servers() const;
+    std::vector<std::shared_ptr<ResourceServer>>& mutable_servers();
 
    private:
     std::string name_;
@@ -31,7 +31,7 @@ class Module {
     HandlerMap_ handles_;
     std::shared_ptr<grpc::Channel> channel_;
     std::unordered_map<Subtype, std::shared_ptr<ResourceManager>> services_;
-    std::vector<std::shared_ptr<ResourceServerBase>> servers_;
+    std::vector<std::shared_ptr<ResourceServer>> servers_;
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/module/service.hpp
+++ b/src/viam/sdk/module/service.hpp
@@ -14,7 +14,7 @@ class ModuleService_ : public viam::module::v1::ModuleService::Service {
    public:
     void start(std::shared_ptr<Server> server);
     void close();
-    std::shared_ptr<ResourceBase> get_parent_resource(Name name);
+    std::shared_ptr<Resource> get_parent_resource(Name name);
 
     void add_api_from_registry(std::shared_ptr<Server> server, Subtype api);
     void add_model_from_registry(std::shared_ptr<Server> server, Subtype api, Model model);

--- a/src/viam/sdk/registry/registry.cpp
+++ b/src/viam/sdk/registry/registry.cpp
@@ -24,6 +24,8 @@ namespace sdk {
 
 using viam::robot::v1::Status;
 
+ResourceSubtype::~ResourceSubtype() = default;
+
 const ResourceType& ModelRegistration::resource_type() const {
     return resource_type_;
 };
@@ -84,7 +86,7 @@ Registry::registered_resources() {
     return registry;
 }
 
-Status ModelRegistration::create_status(std::shared_ptr<ResourceBase> resource) {
+Status ModelRegistration::create_status(std::shared_ptr<Resource> resource) {
     Status status;
     *status.mutable_name() = resource->get_resource_name(resource->name());
     *status.mutable_status() = google::protobuf::Struct();

--- a/src/viam/sdk/registry/registry.hpp
+++ b/src/viam/sdk/registry/registry.hpp
@@ -30,16 +30,17 @@ namespace sdk {
 /// @brief Defines registered `Resource` creation functionality.
 class ResourceSubtype {
    public:
+    virtual ~ResourceSubtype();
     /// @brief Add `Reconfigure` functionality to a resource.
-    std::function<ResourceBase(ResourceBase, Name)> create_reconfigurable;
+    std::function<Resource(Resource, Name)> create_reconfigurable;
 
     // TODO: it doesn't look like we actually use this. Confirm, then remove.
-    std::function<ProtoType(ResourceBase)> create_status;
+    std::function<ProtoType(Resource)> create_status;
 
     /// @brief Create a resource's gRPC server.
     /// @param manager The server's `ResourceManager`.
     /// @return a `shared_ptr` to the gRPC server.
-    virtual std::shared_ptr<ResourceServerBase> create_resource_server(
+    virtual std::shared_ptr<ResourceServer> create_resource_server(
         std::shared_ptr<ResourceManager> manager) = 0;
 
     /// @brief Returns a reference to the `ResourceSubtype`'s service descriptor.
@@ -49,8 +50,8 @@ class ResourceSubtype {
     /// @param name The name of the resource.
     /// @param channel A channel connected to the client.
     /// @return A `shared_ptr` to the resource client.
-    virtual std::shared_ptr<ResourceBase> create_rpc_client(
-        std::string name, std::shared_ptr<grpc::Channel> channel) = 0;
+    virtual std::shared_ptr<Resource> create_rpc_client(std::string name,
+                                                        std::shared_ptr<grpc::Channel> channel) = 0;
 
     ResourceSubtype(const google::protobuf::ServiceDescriptor* service_descriptor)
         : service_descriptor_(service_descriptor){};
@@ -70,7 +71,7 @@ class ModelRegistration {
         ResourceType rt,
         Subtype subtype,
         Model model,
-        std::function<std::shared_ptr<ResourceBase>(Dependencies, Resource)> constructor)
+        std::function<std::shared_ptr<Resource>(Dependencies, ResourceConfig)> constructor)
         : construct_resource(std::move(constructor)),
           validate(default_validator),
           model_(std::move(model)),
@@ -81,8 +82,8 @@ class ModelRegistration {
         ResourceType rt,
         Subtype subtype,
         Model model,
-        std::function<std::shared_ptr<ResourceBase>(Dependencies, Resource)> constructor,
-        std::function<std::vector<std::string>(Resource)> validator)
+        std::function<std::shared_ptr<Resource>(Dependencies, ResourceConfig)> constructor,
+        std::function<std::vector<std::string>(ResourceConfig)> validator)
         : construct_resource(std::move(constructor)),
           validate(std::move(validator)),
           model_(std::move(model)),
@@ -94,13 +95,13 @@ class ModelRegistration {
     const Model& model() const;
 
     /// @brief Constructs a resource from a map of dependencies and a resource config.
-    std::function<std::shared_ptr<ResourceBase>(Dependencies, Resource)> construct_resource;
+    std::function<std::shared_ptr<Resource>(Dependencies, ResourceConfig)> construct_resource;
 
     /// @brief Validates a resource config.
-    std::function<std::vector<std::string>(Resource)> validate;
+    std::function<std::vector<std::string>(ResourceConfig)> validate;
 
     /// @brief Creates a `Status` object for a given resource.
-    viam::robot::v1::Status create_status(std::shared_ptr<ResourceBase> resource);
+    viam::robot::v1::Status create_status(std::shared_ptr<Resource> resource);
 
    private:
     // default_validator is the default validator for all models if no validator
@@ -108,7 +109,7 @@ class ModelRegistration {
     Model model_;
     ResourceType resource_type_;
     Subtype subtype_;
-    static const std::vector<std::string> default_validator(Resource cfg) {
+    static const std::vector<std::string> default_validator(ResourceConfig cfg) {
         return {};
     };
 };

--- a/src/viam/sdk/resource/resource_base.cpp
+++ b/src/viam/sdk/resource/resource_base.cpp
@@ -11,29 +11,31 @@
 namespace viam {
 namespace sdk {
 
-grpc::StatusCode ResourceBase::stop(AttributeMap extra) {
+Resource::~Resource() = default;
+
+grpc::StatusCode Resource::stop(AttributeMap extra) {
     return stop();
 }
 
-grpc::StatusCode ResourceBase::stop() {
+grpc::StatusCode Resource::stop() {
     return grpc::StatusCode::UNIMPLEMENTED;
 }
 
-std::string ResourceBase::name() {
+std::string Resource::name() {
     return name_;
 }
 
-Subtype ResourceBase::subtype() {
-    return {RDK, RESOURCE, "ResourceBase"};
+Subtype Resource::subtype() {
+    return {RDK, RESOURCE, "Resource"};
 }
 
-void ResourceBase::reconfigure(Dependencies deps, Resource cfg){};
+void Resource::reconfigure(Dependencies deps, ResourceConfig cfg){};
 
-ResourceType ResourceBase::type() {
+ResourceType Resource::type() {
     return {RESOURCE};
 }
 
-ResourceName ResourceBase::get_resource_name(std::string name) {
+ResourceName Resource::get_resource_name(std::string name) {
     ResourceName r;
     *r.mutable_namespace_() = RDK;
     *r.mutable_type() = RESOURCE;

--- a/src/viam/sdk/resource/resource_base.hpp
+++ b/src/viam/sdk/resource/resource_base.hpp
@@ -13,16 +13,17 @@
 namespace viam {
 namespace sdk {
 
-class ResourceBase;
-using Dependencies = std::unordered_map<Name, std::shared_ptr<ResourceBase>>;
-class ResourceBase {
+class Resource;
+using Dependencies = std::unordered_map<Name, std::shared_ptr<Resource>>;
+class Resource {
    public:
-    explicit ResourceBase(std::string name) : name_(std::move(name)){};
+    virtual ~Resource();
+    explicit Resource(std::string name) : name_(std::move(name)){};
     static Subtype subtype();
     virtual viam::common::v1::ResourceName get_resource_name(std::string name);
     virtual grpc::StatusCode stop(AttributeMap extra);
     virtual grpc::StatusCode stop();
-    virtual void reconfigure(Dependencies deps, Resource cfg);
+    virtual void reconfigure(Dependencies deps, ResourceConfig cfg);
     virtual std::string name();
     virtual ResourceType type();
 

--- a/src/viam/sdk/resource/resource_manager.cpp
+++ b/src/viam/sdk/resource/resource_manager.cpp
@@ -23,7 +23,7 @@
 namespace viam {
 namespace sdk {
 
-std::shared_ptr<ResourceBase> ResourceManager::resource(std::string name) {
+std::shared_ptr<Resource> ResourceManager::resource(std::string name) {
     std::lock_guard<std::mutex> lock(lock_);
 
     if (resources_.find(name) != resources_.end()) {
@@ -39,9 +39,9 @@ std::shared_ptr<ResourceBase> ResourceManager::resource(std::string name) {
     throw std::runtime_error("Unable to find resource named " + name);
 }
 
-void ResourceManager::replace_all(std::unordered_map<Name, std::shared_ptr<ResourceBase>> new_map) {
+void ResourceManager::replace_all(std::unordered_map<Name, std::shared_ptr<Resource>> new_map) {
     std::lock_guard<std::mutex> lock(lock_);
-    std::unordered_map<std::string, std::shared_ptr<ResourceBase>> new_resources;
+    std::unordered_map<std::string, std::shared_ptr<Resource>> new_resources;
     std::unordered_map<std::string, std::string> new_short_names;
     this->resources_ = new_resources;
     this->short_names_ = new_short_names;
@@ -62,7 +62,7 @@ std::string get_shortcut_name(std::string name) {
     return name_split.at(name_split.size() - 1);
 }
 
-void ResourceManager::do_add(Name name, std::shared_ptr<ResourceBase> resource) {
+void ResourceManager::do_add(Name name, std::shared_ptr<Resource> resource) {
     if (name.name() == "") {
         throw "Empty name used for resource: " + name.to_string();
     }
@@ -71,7 +71,7 @@ void ResourceManager::do_add(Name name, std::shared_ptr<ResourceBase> resource) 
     do_add(short_name, resource);
 }
 
-void ResourceManager::do_add(std::string name, std::shared_ptr<ResourceBase> resource) {
+void ResourceManager::do_add(std::string name, std::shared_ptr<Resource> resource) {
     if (resources_.find(name) != resources_.end()) {
         throw "Attempted to add resource that already existed: " + name;
     }
@@ -88,7 +88,7 @@ void ResourceManager::do_add(std::string name, std::shared_ptr<ResourceBase> res
     }
 }
 
-void ResourceManager::add(Name name, std::shared_ptr<ResourceBase> resource) {
+void ResourceManager::add(Name name, std::shared_ptr<Resource> resource) {
     std::lock_guard<std::mutex> lock(lock_);
     try {
         do_add(name, resource);
@@ -132,7 +132,7 @@ void ResourceManager::remove(Name name) {
     };
 };
 
-void ResourceManager::replace_one(Name name, std::shared_ptr<ResourceBase> resource) {
+void ResourceManager::replace_one(Name name, std::shared_ptr<Resource> resource) {
     std::lock_guard<std::mutex> lock(lock_);
     try {
         do_remove(name);
@@ -143,12 +143,12 @@ void ResourceManager::replace_one(Name name, std::shared_ptr<ResourceBase> resou
     }
 }
 
-const std::unordered_map<std::string, std::shared_ptr<ResourceBase>>& ResourceManager::resources()
+const std::unordered_map<std::string, std::shared_ptr<Resource>>& ResourceManager::resources()
     const {
     return resources_;
 }
 
-void ResourceManager::add(std::string name, std::shared_ptr<ResourceBase> resource) {
+void ResourceManager::add(std::string name, std::shared_ptr<Resource> resource) {
     std::lock_guard<std::mutex> lock(lock_);
     do_add(name, resource);
 }

--- a/src/viam/sdk/resource/resource_manager.hpp
+++ b/src/viam/sdk/resource/resource_manager.hpp
@@ -25,21 +25,21 @@ class ResourceManager {
     /// @brief Returns a resource.
     /// @param name the name of the desired resource.
     /// @throws `std::runtime_error` if the desired resource does not exist.
-    std::shared_ptr<ResourceBase> resource(std::string name);
+    std::shared_ptr<Resource> resource(std::string name);
 
     /// @brief Replaces all resources in the manager.
     /// @param resources The resources to replace with.
-    void replace_all(std::unordered_map<Name, std::shared_ptr<ResourceBase>> resources);
+    void replace_all(std::unordered_map<Name, std::shared_ptr<Resource>> resources);
 
     /// @brief Adds a single resource to the manager.
     /// @param name The name of the resource.
     /// @param resource The resource being added.
-    void add(Name name, std::shared_ptr<ResourceBase> resource);
+    void add(Name name, std::shared_ptr<Resource> resource);
 
     /// @brief Adds a single resource to the manager.
     /// @param name The name of the resource.
     /// @param resource The resource being added.
-    void add(std::string name, std::shared_ptr<ResourceBase> resource);
+    void add(std::string name, std::shared_ptr<Resource> resource);
 
     /// @brief Remodes a single resource from the manager.
     /// @param name The name of the resource to remove.
@@ -48,20 +48,20 @@ class ResourceManager {
     /// @brief Replaces an existing resource. No-op if the named resource does not exist.
     /// @param name The name of the resource to replace.
     /// @param resource The new resource that is replacing the existing one.
-    void replace_one(Name name, std::shared_ptr<ResourceBase> resource);
+    void replace_one(Name name, std::shared_ptr<Resource> resource);
 
     /// @brief Returns a reference to the existing resources within the manager.
-    const std::unordered_map<std::string, std::shared_ptr<ResourceBase>>& resources() const;
+    const std::unordered_map<std::string, std::shared_ptr<Resource>>& resources() const;
 
     ResourceManager(){};
 
    private:
     std::mutex lock_;
-    std::unordered_map<std::string, std::shared_ptr<ResourceBase>> resources_;
+    std::unordered_map<std::string, std::shared_ptr<Resource>> resources_;
     /// @brief `short_names_` is a shortened version of `Name` N of form <remote>:<name>.
     std::unordered_map<std::string, std::string> short_names_;
-    void do_add(Name name, std::shared_ptr<ResourceBase> resource);
-    void do_add(std::string name, std::shared_ptr<ResourceBase> resource);
+    void do_add(Name name, std::shared_ptr<Resource> resource);
+    void do_add(std::string name, std::shared_ptr<Resource> resource);
     void do_remove(Name name);
 };
 

--- a/src/viam/sdk/resource/resource_server_base.cpp
+++ b/src/viam/sdk/resource/resource_server_base.cpp
@@ -2,7 +2,7 @@
 
 namespace viam {
 namespace sdk {
-const std::shared_ptr<ResourceManager>& ResourceServerBase::resource_manager() const {
+const std::shared_ptr<ResourceManager>& ResourceServer::resource_manager() const {
     return manager_;
 };
 

--- a/src/viam/sdk/resource/resource_server_base.hpp
+++ b/src/viam/sdk/resource/resource_server_base.hpp
@@ -6,13 +6,13 @@
 namespace viam {
 namespace sdk {
 
-class ResourceServerBase {
+class ResourceServer {
    public:
     virtual void register_server(std::shared_ptr<Server> server) = 0;
     const std::shared_ptr<ResourceManager>& resource_manager() const;
 
    protected:
-    ResourceServerBase(std::shared_ptr<ResourceManager> manager) : manager_(manager){};
+    ResourceServer(std::shared_ptr<ResourceManager> manager) : manager_(manager){};
 
    private:
     std::shared_ptr<ResourceManager> manager_;

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -155,7 +155,7 @@ void RobotClient::refresh() {
         BOOST_LOG_TRIVIAL(error) << "Error getting resource names: " << response.error_message();
     }
 
-    std::unordered_map<Name, std::shared_ptr<ResourceBase>> new_resources;
+    std::unordered_map<Name, std::shared_ptr<Resource>> new_resources;
     RepeatedPtrField<ResourceName> resources = resp.resources();
 
     std::vector<ResourceName> current_resources;
@@ -177,7 +177,7 @@ void RobotClient::refresh() {
             Registry::lookup_subtype({name.namespace_(), name.type(), name.subtype()});
         if (rs) {
             try {
-                std::shared_ptr<ResourceBase> rpc_client =
+                std::shared_ptr<Resource> rpc_client =
                     rs->create_rpc_client(name.name(), channel_);
                 Name name_({name.namespace_(), name.type(), name.subtype()}, "", name.name());
                 new_resources.emplace(name_, rpc_client);
@@ -346,7 +346,7 @@ std::vector<Discovery> RobotClient::discover_components(std::vector<DiscoveryQue
     return components;
 }
 
-std::shared_ptr<ResourceBase> RobotClient::resource_by_name(const ResourceName& name) {
+std::shared_ptr<Resource> RobotClient::resource_by_name(const ResourceName& name) {
     return resource_manager_.resource(name.name());
 }
 

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -177,8 +177,7 @@ void RobotClient::refresh() {
             Registry::lookup_subtype({name.namespace_(), name.type(), name.subtype()});
         if (rs) {
             try {
-                std::shared_ptr<Resource> rpc_client =
-                    rs->create_rpc_client(name.name(), channel_);
+                std::shared_ptr<Resource> rpc_client = rs->create_rpc_client(name.name(), channel_);
                 Name name_({name.namespace_(), name.type(), name.subtype()}, "", name.name());
                 new_resources.emplace(name_, rpc_client);
             } catch (const std::exception& exc) {

--- a/src/viam/sdk/robot/client.hpp
+++ b/src/viam/sdk/robot/client.hpp
@@ -71,15 +71,15 @@ class RobotClient {
     /// @brief Lookup and return a `shared_ptr` to a resource.
     /// @param name The `ResourceName` of the resource.
     /// @throws `std::runtime_error` if the requested resource doesn't exist or is the wrong type.
-    /// @return a `shared_ptr` to the requested resource as an uncasted `ResourceBase`.
+    /// @return a `shared_ptr` to the requested resource as an uncasted `Resource`.
     ///
     /// This method should not be called directly except in specific cases. The
     /// type-annotated `resource_by_name<T>(name)` overload is the preferred method
     /// for obtaining resources.
     ///
-    /// Because the return type here is a `ResourceBase`, the user will need to manually
+    /// Because the return type here is a `Resource`, the user will need to manually
     /// cast to the desired type.
-    std::shared_ptr<ResourceBase> resource_by_name(const ResourceName& name);
+    std::shared_ptr<Resource> resource_by_name(const ResourceName& name);
 
     template <typename T>
     /// @brief Lookup and return a `shared_ptr` to a resource of the requested type.

--- a/src/viam/sdk/robot/service.cpp
+++ b/src/viam/sdk/robot/service.cpp
@@ -41,7 +41,7 @@ std::vector<ResourceName> RobotService_::generate_metadata() {
 std::vector<Status> RobotService_::generate_status(RepeatedPtrField<ResourceName> resource_names) {
     std::vector<Status> statuses;
     for (auto& cmp : resource_manager()->resources()) {
-        std::shared_ptr<ResourceBase> resource = cmp.second;
+        std::shared_ptr<Resource> resource = cmp.second;
         for (auto& registry : Registry::registered_resources()) {
             std::shared_ptr<ModelRegistration> registration = registry.second;
             if (registration->resource_type() == resource->type()) {
@@ -154,7 +154,7 @@ void RobotService_::stream_status(
         extra.emplace(name, value_map);
 
         for (auto& r : resource_manager()->resources()) {
-            std::shared_ptr<ResourceBase> resource = r.second;
+            std::shared_ptr<Resource> resource = r.second;
             ResourceName rn = resource->get_resource_name(resource->name());
             std::string rn_ = rn.SerializeAsString();
             if (extra.find(rn_) != extra.end()) {
@@ -171,8 +171,8 @@ void RobotService_::stream_status(
     return grpc::Status(status, "");
 }
 
-std::shared_ptr<ResourceBase> RobotService_::resource_by_name(Name name) {
-    std::shared_ptr<ResourceBase> r;
+std::shared_ptr<Resource> RobotService_::resource_by_name(Name name) {
+    std::shared_ptr<Resource> r;
     std::lock_guard<std::mutex> lock(lock_);
     auto resources = resource_manager()->resources();
     if (resources.find(name.name()) != resources.end()) {

--- a/src/viam/sdk/robot/service.hpp
+++ b/src/viam/sdk/robot/service.hpp
@@ -30,12 +30,12 @@ using viam::robot::v1::Status;
 /// @class RobotService_ service.hpp "robot/service.hpp"
 /// @brief a gRPC service for a robot.
 /// @ingroup Robot
-class RobotService_ : public ResourceServerBase, public viam::robot::v1::RobotService::Service {
+class RobotService_ : public ResourceServer, public viam::robot::v1::RobotService::Service {
    public:
-    RobotService_() : ResourceServerBase(std::make_shared<ResourceManager>()){};
-    RobotService_(std::shared_ptr<ResourceManager> manager) : ResourceServerBase(manager){};
+    RobotService_() : ResourceServer(std::make_shared<ResourceManager>()){};
+    RobotService_(std::shared_ptr<ResourceManager> manager) : ResourceServer(manager){};
     static std::shared_ptr<RobotService_> create();
-    std::shared_ptr<ResourceBase> resource_by_name(Name name);
+    std::shared_ptr<Resource> resource_by_name(Name name);
     ::grpc::Status ResourceNames(::grpc::ServerContext* context,
                                  const ::viam::robot::v1::ResourceNamesRequest* request,
                                  ::viam::robot::v1::ResourceNamesResponse* response) override;

--- a/src/viam/sdk/services/service_base.cpp
+++ b/src/viam/sdk/services/service_base.cpp
@@ -10,15 +10,15 @@
 namespace viam {
 namespace sdk {
 
-ResourceName ServiceBase::get_resource_name(std::string name) {
-    auto r = this->ResourceBase::get_resource_name(name);
+ResourceName Service::get_resource_name(std::string name) {
+    auto r = this->Resource::get_resource_name(name);
     *r.mutable_type() = SERVICE;
     return r;
 }
 
-ServiceBase::ServiceBase() : ResourceBase("service"){};
+Service::Service() : Resource("service"){};
 
-ResourceType ServiceBase::type() {
+ResourceType Service::type() {
     return {SERVICE};
 }
 

--- a/src/viam/sdk/services/service_base.hpp
+++ b/src/viam/sdk/services/service_base.hpp
@@ -9,14 +9,14 @@
 namespace viam {
 namespace sdk {
 
-class ServiceBase : public ResourceBase {
+class Service : public Resource {
    public:
     viam::common::v1::ResourceName get_resource_name(std::string name) override;
     ResourceType type() override;
-    ServiceBase();
+    Service();
 
    protected:
-    explicit ServiceBase(std::string name) : ResourceBase(std::move(name)){};
+    explicit Service(std::string name) : Resource(std::move(name)){};
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/tests/mocks/camera_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.cpp
@@ -14,8 +14,6 @@ namespace camera {
 
 using namespace viam::sdk;
 
-MockCamera::~MockCamera() = default;
-
 AttributeMap MockCamera::do_command(AttributeMap command) {
     return map_;
 }

--- a/src/viam/sdk/tests/mocks/camera_mocks.hpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.hpp
@@ -16,7 +16,6 @@ using namespace viam::sdk;
 
 class MockCamera : public Camera {
    public:
-    virtual ~MockCamera();
     AttributeMap do_command(AttributeMap command) override;
     raw_image get_image(std::string mime_type) override;
     point_cloud get_point_cloud(std::string mime_type) override;

--- a/src/viam/sdk/tests/mocks/generic_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/generic_mocks.cpp
@@ -15,8 +15,6 @@ namespace generic {
 
 using namespace viam::sdk;
 
-MockGeneric::~MockGeneric() = default;
-
 std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>>
 MockGeneric::do_command(
     std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> command) {

--- a/src/viam/sdk/tests/mocks/generic_mocks.hpp
+++ b/src/viam/sdk/tests/mocks/generic_mocks.hpp
@@ -16,7 +16,6 @@ using namespace viam::sdk;
 
 class MockGeneric : public Generic {
    public:
-    virtual ~MockGeneric();
     MockGeneric(std::string name) : Generic(std::move(name)){};
     std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> do_command(
         std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> command)

--- a/src/viam/sdk/tests/mocks/mock_motor.cpp
+++ b/src/viam/sdk/tests/mocks/mock_motor.cpp
@@ -16,8 +16,6 @@ namespace motor {
 
 using namespace viam::sdk;
 
-MockMotor::~MockMotor() = default;
-
 void MockMotor::set_power(double power_pct) {
     power_status_.is_on = power_pct != 0.0;
     power_status_.power_pct = power_pct;

--- a/src/viam/sdk/tests/mocks/mock_motor.hpp
+++ b/src/viam/sdk/tests/mocks/mock_motor.hpp
@@ -16,7 +16,6 @@ using viam::sdk::Motor;
 
 class MockMotor : public Motor {
    public:
-    virtual ~MockMotor();
     void set_power(double power_pct) override;
     void go_for(double rpm, double revolutions) override;
     void go_to(double rpm, double position_revolutions) override;


### PR DESCRIPTION
#### Major Changes
- `ResourceBase` -> `Resource`
- `ComponentBase` -> `Component`
- `ServiceBase` -> `Service`
- `Resource` -> `ResourceConfig`
- Default destructors for `Resource` and `ResourceServer`

#### Minor changes
- add missing `array` import to `linear_algebra`
- remove destructors from resource wrappers that derive from `Resource`

#### Note to reviewers
I opted to not change the file names (e.g., `resource_base.cpp` -> `resource.cpp`). `resource.cpp` and `component.cpp` just felt like too bland/generic of names. I think `_base` there kind of helps provide a bit of clarity when absent the virtual methods and comments/documentation clarifying use, and the risk of confusion/collision with the `base` component is much lower. I don't have particularly strong feelings here though, happy to modify if others feel strongly.