### PR TITLE
RSDK-3006 - Add clang-tidy and fix trivial lints

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,35 @@
+# Globally Disabled checks:
+#
+# bugprone-easily-swappable-parameters: This warning is loud with no clear advice on how to fix the potential problem
+# bugprone-macro-parentheses: Can break with boost macros
+# readability-identifier-length: This complains about identifiers with length < 3 which is often not useful.
+# readability-named-parameter: Useful to fix lints about unused parameters
+# readability-implicit-bool-conversion: We have decided that !ptr-type is cleaner than ptr-type==nullptr 
+# performance-unnecessary-value-param: TODO remove this and fix all lints.
+# misc-unused-parameters: TODO remove this and fix all lints.
+#
+Checks: >
+  -*,
+  bugprone-*,
+  cert-*,
+  clang-analyzer-*,
+  concurrency-*,
+  misc-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-macro-parentheses,
+  -readability-identifier-length,
+  -readability-named-parameter,
+  -readability-implicit-bool-conversion,
+  -performance-unnecessary-value-param,
+  -misc-unused-parameters,
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle: none
+CheckOptions:
+  - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value: true
+  - key: readability-function-cognitive-complexity.Threshold
+    value: 30

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,8 +6,8 @@
 # readability-named-parameter: Useful to fix lints about unused parameters
 # readability-implicit-bool-conversion: We have decided that !ptr-type is cleaner than ptr-type==nullptr
 # readability-magic-numbers: This encourages useless variables and extra lint lines
-# performance-unnecessary-value-param: TODO remove this and fix all lints.
-# misc-unused-parameters: TODO remove this and fix all lints.
+# performance-unnecessary-value-param: TODO(RSDK-3007) remove this and fix all lints.
+# misc-unused-parameters: TODO(RSDK-3008) remove this and fix all lints.
 #
 Checks: >
   -*,
@@ -28,7 +28,6 @@ Checks: >
   -performance-unnecessary-value-param,
   -misc-unused-parameters,
 WarningsAsErrors: ''
-HeaderFilterRegex: ''
 FormatStyle: none
 CheckOptions:
   - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,8 @@
 # bugprone-macro-parentheses: Can break with boost macros
 # readability-identifier-length: This complains about identifiers with length < 3 which is often not useful.
 # readability-named-parameter: Useful to fix lints about unused parameters
-# readability-implicit-bool-conversion: We have decided that !ptr-type is cleaner than ptr-type==nullptr 
+# readability-implicit-bool-conversion: We have decided that !ptr-type is cleaner than ptr-type==nullptr
+# readability-magic-numbers: This encourages useless variables and extra lint lines
 # performance-unnecessary-value-param: TODO remove this and fix all lints.
 # misc-unused-parameters: TODO remove this and fix all lints.
 #
@@ -23,6 +24,7 @@ Checks: >
   -readability-identifier-length,
   -readability-named-parameter,
   -readability-implicit-bool-conversion,
+  -readability-magic-numbers,
   -performance-unnecessary-value-param,
   -misc-unused-parameters,
 WarningsAsErrors: ''

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,11 @@ option(VIAMCPPSDK_USE_WALL_WERROR "Build with -Wall and -Werror flags" ON)
 option(VIAMCPPSDK_SANITIZED_BUILD "Build with address and UB sanitizers (less performant)" OFF)
 
 
+# # - `VIAMCPPSDK_CLANG_TIDY`: This causes the SDK to run clang-tidy
+# with the options specified in the .clang-tidy file. 
+option(VIAMCPPSDK_CLANG_TIDY "Run the clang-tidy linter" OFF)
+
+
 # Enforce known toolchains and toolchain minima unless asked not to.
 if (VIAMCPPSDK_ENFORCE_COMPILER_MINIMA)
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -28,7 +28,11 @@ if (VIAMCPPSDK_SANITIZED_BUILD)
   target_link_options(viamsdk PRIVATE -fsanitize=undefined -fno-omit-frame-pointer -fno-sanitize-recover)
   target_compile_options(viamsdk PRIVATE -fsanitize=undefined -fno-omit-frame-pointer -fno-sanitize-recover)
 endif()
-
+if (VIAMCPPSDK_CLANG_TIDY)
+  find_program(CLANG_TIDY_EXE NAMES "clang-tidy")
+  set(CLANG_TIDY_COMMAND "${CLANG_TIDY_EXE}" "--config-file=../.clang-tidy")
+  set_target_properties(viamsdk PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
+endif()
 
 target_sources(viamsdk
   PRIVATE

--- a/src/viam/sdk/common/proto_type.cpp
+++ b/src/viam/sdk/common/proto_type.cpp
@@ -17,11 +17,14 @@ namespace sdk {
 using google::protobuf::Struct;
 using google::protobuf::Value;
 
+// NOLINTBEGIN(readability-redundant-declaration)
 Struct map_to_struct(AttributeMap dict);
 AttributeMap struct_to_map(Struct struct_);
+// NOLINTEND(readability-redundant-declaration)
 
 // float, string, struct, array, struct(map from string to any of the above)
 
+// NOLINTNEXTLINE(misc-no-recursion)
 ProtoType ProtoType::of_value(Value value) {
     switch (value.kind_case()) {
         case Value::KindCase::kBoolValue: {
@@ -35,8 +38,7 @@ ProtoType ProtoType::of_value(Value value) {
         }
         case Value::KindCase::kListValue: {
             std::vector<ProtoType*> vec;
-            google::protobuf::ListValue list_val = value.list_value();
-            for (auto& val : value.list_value().values()) {
+            for (const auto& val : value.list_value().values()) {
                 ProtoType p = ProtoType::of_value(val);
                 vec.push_back(&p);
             }
@@ -54,6 +56,7 @@ ProtoType ProtoType::of_value(Value value) {
     }
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
 Struct map_to_struct(AttributeMap dict) {
     Struct s;
     for (auto& key_and_value : *dict) {
@@ -66,12 +69,12 @@ Struct map_to_struct(AttributeMap dict) {
     return s;
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
 AttributeMap struct_to_map(Struct struct_) {
-    google::protobuf::Map<std::string, Value> struct_map = struct_.fields();
     std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> map =
         std::make_shared<std::unordered_map<std::string, std::shared_ptr<ProtoType>>>();
 
-    for (auto& val : struct_.fields()) {
+    for (const auto& val : struct_.fields()) {
         std::string key = val.first;
         std::shared_ptr<Value> val_ptr = std::make_shared<Value>(val.second);
         std::shared_ptr<ProtoType> value =
@@ -81,6 +84,7 @@ AttributeMap struct_to_map(Struct struct_) {
     return map;
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
 Value ProtoType::proto_value() {
     Value v;
     switch (proto_type_.which()) {
@@ -133,6 +137,7 @@ Value ProtoType::proto_value() {
     return v;
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
 bool operator==(const ProtoType& lhs, const ProtoType& rhs) {
     if (lhs.proto_type_.which() != rhs.proto_type_.which()) {
         return false;
@@ -169,16 +174,13 @@ bool operator==(const ProtoType& lhs, const ProtoType& rhs) {
             if (lhs_map->size() != rhs_map->size()) {
                 return false;
             }
+            // NOLINTNEXTLINE(misc-no-recursion)
             auto pred = [](auto lhs_map, auto rhs_map) {
                 return lhs_map.first == rhs_map.first && *lhs_map.second == *rhs_map.second;
             };
 
-            if (std::equal(lhs_map->begin(), lhs_map->end(), rhs_map->begin(), pred)) {
-                return true;
-            }
-            return false;
+            return std::equal(lhs_map->begin(), lhs_map->end(), rhs_map->begin(), pred);
         }
-
         case 6: {
             std::vector<ProtoType*> lhs_vec = boost::get<std::vector<ProtoType*>>(lhs.proto_type_);
             std::vector<ProtoType*> rhs_vec = boost::get<std::vector<ProtoType*>>(rhs.proto_type_);

--- a/src/viam/sdk/common/utils.cpp
+++ b/src/viam/sdk/common/utils.cpp
@@ -30,7 +30,7 @@ std::vector<ResourceName> resource_names_for_resource(std::shared_ptr<Resource> 
             continue;
         }
 
-        if (resource_type == "") {
+        if (resource_type.empty()) {
             resource_type = resource->name();
         }
 

--- a/src/viam/sdk/components/base/base.cpp
+++ b/src/viam/sdk/components/base/base.cpp
@@ -55,6 +55,7 @@ bool init() {
     return true;
 };
 
+// NOLINTNEXTLINE
 const bool inited = init();
 }  // namespace
 

--- a/src/viam/sdk/components/camera/camera.cpp
+++ b/src/viam/sdk/components/camera/camera.cpp
@@ -34,6 +34,7 @@ std::shared_ptr<ResourceSubtype> Camera::resource_subtype() {
     return std::make_shared<CameraSubtype>(sd);
 }
 
+// NOLINTNEXTLINE
 const std::string Camera::lazy_suffix = "+lazy";
 
 Subtype Camera::static_subtype() {
@@ -75,7 +76,9 @@ Camera::point_cloud Camera::from_proto(viam::component::camera::v1::GetPointClou
 Camera::intrinsic_parameters Camera::from_proto(
     viam::component::camera::v1::IntrinsicParameters proto) {
     Camera::intrinsic_parameters params;
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions)
     params.width_px = proto.width_px();
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions)
     params.height_px = proto.height_px();
     params.focal_x_px = proto.focal_x_px();
     params.focal_y_px = proto.focal_y_px();
@@ -97,11 +100,11 @@ Camera::properties Camera::from_proto(viam::component::camera::v1::GetProperties
     Camera::intrinsic_parameters intrinsic_parameters;
     Camera::properties properties;
 
-    viam::component::camera::v1::DistortionParameters distortion_parameters_proto =
+    const viam::component::camera::v1::DistortionParameters& distortion_parameters_proto =
         proto.distortion_parameters();
     distortion_parameters = from_proto(distortion_parameters_proto);
 
-    viam::component::camera::v1::IntrinsicParameters intrinsic_parameters_proto =
+    const viam::component::camera::v1::IntrinsicParameters& intrinsic_parameters_proto =
         proto.intrinsic_parameters();
     intrinsic_parameters = from_proto(intrinsic_parameters_proto);
 
@@ -161,7 +164,8 @@ bool init() {
     return true;
 };
 
-bool inited = init();
+// NOLINTNEXTLINE
+const bool inited = init();
 }  // namespace
 
 }  // namespace sdk

--- a/src/viam/sdk/components/encoder/encoder.cpp
+++ b/src/viam/sdk/components/encoder/encoder.cpp
@@ -125,6 +125,7 @@ bool init() {
     return true;
 };
 
+// NOLINTNEXTLINE
 const bool inited = init();
 }  // namespace
 

--- a/src/viam/sdk/components/generic/generic.cpp
+++ b/src/viam/sdk/components/generic/generic.cpp
@@ -49,7 +49,8 @@ bool init() {
     return true;
 };
 
-bool inited = init();
+// NOLINTNEXTLINE
+const bool inited = init();
 }  // namespace
 
 }  // namespace sdk

--- a/src/viam/sdk/components/motor/motor.cpp
+++ b/src/viam/sdk/components/motor/motor.cpp
@@ -93,7 +93,8 @@ bool init() {
     return true;
 };
 
-bool inited = init();
+// NOLINTNEXTLINE
+const bool inited = init();
 }  // namespace
 
 }  // namespace sdk

--- a/src/viam/sdk/config/resource.cpp
+++ b/src/viam/sdk/config/resource.cpp
@@ -20,10 +20,11 @@ namespace sdk {
 Name ResourceConfig::resource_name() {
     try {
         this->fix_api();
-    } catch (std::string err) {
+    } catch (std::string err) {  // NOLINT
         throw err;
     }
     std::vector<std::string> remotes;
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     boost::split(remotes, this->name_, boost::is_any_of(":"));
     if (remotes.size() > 1) {
         std::string str_name = remotes.at(remotes.size() - 1);
@@ -63,22 +64,22 @@ const AttributeMap& ResourceConfig::attributes() const {
 }
 
 void ResourceConfig::fix_api() {
-    if (this->api_.type_namespace() == "" && this->namespace__ == "") {
+    if (this->api_.type_namespace().empty() && this->namespace__.empty()) {
         this->namespace__ = RDK;
         this->api_.set_namespace(RDK);
-    } else if (this->api_.type_namespace() == "") {
+    } else if (this->api_.type_namespace().empty()) {
         this->api_.set_namespace(this->namespace__);
     } else {
         this->namespace__ = this->api_.type_namespace();
     }
 
-    if (this->api_.resource_type() == "") {
+    if (this->api_.resource_type().empty()) {
         this->api_.set_resource_type(COMPONENT);
     }
 
-    if (this->api_.resource_subtype() == "") {
+    if (this->api_.resource_subtype().empty()) {
         this->api_.set_resource_subtype(this->type_);
-    } else if (this->type_ == "") {
+    } else if (this->type_.empty()) {
         this->type_ = this->api_.resource_subtype();
     }
 
@@ -96,15 +97,15 @@ ResourceConfig ResourceConfig::from_proto(viam::app::v1::ComponentConfig proto_c
     resource.namespace__ = proto_cfg.namespace_();
     resource.type_ = proto_cfg.type();
     resource.attributes_ = struct_to_map(proto_cfg.attributes());
-    std::string api = proto_cfg.api();
-    if (api.find(":") != std::string::npos) {
+    const std::string& api = proto_cfg.api();
+    if (api.find(':') != std::string::npos) {
         resource.api_ = Subtype::from_string(api);
     }
     resource.model_ = Model::from_str(proto_cfg.model());
 
     try {
         resource.fix_api();
-    } catch (std::string err) {
+    } catch (std::string err) {  // NOLINT
         throw err;
     }
 
@@ -120,7 +121,7 @@ viam::app::v1::ComponentConfig ResourceConfig::to_proto() const {
     google::protobuf::Struct s = map_to_struct(attributes_);
     google::protobuf::RepeatedPtrField<viam::app::v1::ResourceLevelServiceConfig> service_configs;
 
-    for (auto& svc_cfg : service_config_) {
+    for (const auto& svc_cfg : service_config_) {
         viam::app::v1::ResourceLevelServiceConfig cfg;
         *cfg.mutable_type() = svc_cfg.type;
         *cfg.mutable_attributes() = map_to_struct(svc_cfg.attributes);
@@ -134,7 +135,7 @@ viam::app::v1::ComponentConfig ResourceConfig::to_proto() const {
     const std::string mm = model_.to_string();
     *proto_cfg.mutable_model() = mm;
     *proto_cfg.mutable_attributes() = map_to_struct(attributes_);
-    for (auto& dep : depends_on_) {
+    for (const auto& dep : depends_on_) {
         *proto_cfg.mutable_depends_on()->Add() = dep;
     }
     *proto_cfg.mutable_frame() = frame_.to_proto();

--- a/src/viam/sdk/module/handler_map.cpp
+++ b/src/viam/sdk/module/handler_map.cpp
@@ -16,9 +16,9 @@ namespace sdk {
 
 viam::module::v1::HandlerMap HandlerMap_::to_proto() const {
     viam::module::v1::HandlerMap proto;
-    for (auto& h : this->handles_) {
+    for (const auto& h : this->handles_) {
         viam::module::v1::HandlerDefinition hd;
-        for (auto& model : h.second) {
+        for (const auto& model : h.second) {
             const std::string m = model.to_string();
             *hd.mutable_models()->Add() = m;
         }
@@ -36,13 +36,14 @@ viam::module::v1::HandlerMap HandlerMap_::to_proto() const {
 
 HandlerMap_::HandlerMap_(){};
 
+// NOLINTNEXTLINE(readability-const-return-type)
 const HandlerMap_ HandlerMap_::from_proto(viam::module::v1::HandlerMap proto) {
     HandlerMap_ hm;
 
     google::protobuf::RepeatedPtrField<viam::module::v1::HandlerDefinition> handlers =
         proto.handlers();
 
-    for (auto& handler : handlers) {
+    for (const auto& handler : handlers) {
         std::vector<Model> models;
         viam::common::v1::ResourceName name = handler.subtype().subtype();
         Subtype subtype(name.namespace_(), name.type(), name.subtype());
@@ -50,11 +51,11 @@ const HandlerMap_ HandlerMap_::from_proto(viam::module::v1::HandlerMap proto) {
             google::protobuf::DescriptorPool::generated_pool();
         const google::protobuf::ServiceDescriptor* sd = pool->FindServiceByName(name.type());
         RPCSubtype handle(subtype, *sd);
-        for (auto& mod : handler.models()) {
+        for (const auto& mod : handler.models()) {
             try {
                 Model model = Model::from_str(mod);
                 models.push_back(model);
-            } catch (std::string error) {
+            } catch (std::string error) {  // NOLINT
                 BOOST_LOG_TRIVIAL(error) << "Error processing model " + mod;
             }
         }

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -63,7 +63,7 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
 ::grpc::Status ModuleService_::AddResource(::grpc::ServerContext* context,
                                            const ::viam::module::v1::AddResourceRequest* request,
                                            ::viam::module::v1::AddResourceResponse* response) {
-    viam::app::v1::ComponentConfig proto = request->config();
+    const viam::app::v1::ComponentConfig& proto = request->config();
     ResourceConfig cfg = ResourceConfig::from_proto(proto);
     auto module = this->module_;
     const std::lock_guard<std::mutex> lock(lock_);
@@ -90,7 +90,7 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
     ::grpc::ServerContext* context,
     const ::viam::module::v1::ReconfigureResourceRequest* request,
     ::viam::module::v1::ReconfigureResourceResponse* response) {
-    viam::app::v1::ComponentConfig proto = request->config();
+    const viam::app::v1::ComponentConfig& proto = request->config();
     ResourceConfig cfg = ResourceConfig::from_proto(proto);
     std::shared_ptr<Module> module = this->module_;
 
@@ -119,7 +119,7 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
     // if the type isn't reconfigurable by default, replace it
     try {
         res->stop();
-    } catch (std::string err) {
+    } catch (std::string err) {  // NOLINT
         BOOST_LOG_TRIVIAL(error) << "unable to stop resource: " << err;
     }
 
@@ -136,7 +136,7 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
     ::grpc::ServerContext* context,
     const ::viam::module::v1::ValidateConfigRequest* request,
     ::viam::module::v1::ValidateConfigResponse* response) {
-    viam::app::v1::ComponentConfig proto = request->config();
+    const viam::app::v1::ComponentConfig& proto = request->config();
     ResourceConfig cfg = ResourceConfig::from_proto(proto);
 
     std::shared_ptr<ModelRegistration> reg = Registry::lookup_resource(cfg.api(), cfg.model());
@@ -150,7 +150,7 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
         for (auto& dep : implicit_deps) {
             response->add_dependencies(dep);
         }
-    } catch (std::string err) {
+    } catch (std::string err) {  // NOLINT
         return grpc::Status(grpc::UNKNOWN,
                             "validation failure in resource " + cfg.name() + ": " + err);
     }
@@ -178,7 +178,7 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
 
     try {
         res->stop();
-    } catch (std::string err) {
+    } catch (std::string err) {  // NOLINT
         BOOST_LOG_TRIVIAL(error) << "unable to stop resource: " << err;
     }
 

--- a/src/viam/sdk/registry/registry.cpp
+++ b/src/viam/sdk/registry/registry.cpp
@@ -86,6 +86,7 @@ Registry::registered_resources() {
     return registry;
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 Status ModelRegistration::create_status(std::shared_ptr<Resource> resource) {
     Status status;
     *status.mutable_name() = resource->get_resource_name(resource->name());

--- a/src/viam/sdk/resource/resource.cpp
+++ b/src/viam/sdk/resource/resource.cpp
@@ -15,9 +15,13 @@
 namespace viam {
 namespace sdk {
 
+// NOLINTNEXTLINE
 const std::regex NAME_REGEX("^([\\w-]+:[\\w-]+:(?:[\\w-]+))\\/?([\\w-]+:(?:[\\w-]+:)*)?(.+)?$");
 
+// NOLINTNEXTLINE
 const std::regex MODEL_REGEX("^([\\w-]+):([\\w-]+):([\\w-]+)$");
+
+// NOLINTNEXTLINE
 std::regex SINGLE_FIELD_REGEX("^([\\w-]+)$");
 
 std::string Type::to_string() const {
@@ -60,9 +64,8 @@ Subtype Subtype::from_string(std::string subtype) {
         std::vector<std::string> subtype_parts;
         boost::split(subtype_parts, subtype, boost::is_any_of(":"));
         return {subtype_parts.at(0), subtype_parts.at(1), subtype_parts.at(2)};
-    } else {
-        throw "string " + subtype + " is not a valid subtype name";
     }
+    throw "string " + subtype + " is not a valid subtype name";
 }
 
 Subtype::Subtype(Type type, std::string resource_subtype)
@@ -93,14 +96,14 @@ const std::string& Name::remote_name() const {
 
 std::string Name::to_string() const {
     std::string subtype_name = Subtype::to_string();
-    if (remote_name_ == "") {
+    if (remote_name_.empty()) {
         return subtype_name + "/" + name_;
     }
     return subtype_name + "/" + remote_name_ + ":" + name_;
 }
 
 std::string Name::short_name() const {
-    if (remote_name_ != "") {
+    if (!remote_name_.empty()) {
         return remote_name_ + ":" + name_;
     }
     return name_;
@@ -126,7 +129,7 @@ Name Name::from_string(std::string name) {
 
     std::vector<std::string> colon_splits;
     boost::split(colon_splits, slash_splits.at(1), boost::is_any_of(":"));
-    std::string remote = "";
+    std::string remote;
     std::string resource_name = colon_splits.at(0);
     if (colon_splits.size() > 1) {
         remote = colon_splits.at(0);
@@ -193,15 +196,15 @@ Model Model::from_str(std::string model) {
         std::vector<std::string> model_parts;
         boost::split(model_parts, model, boost::is_any_of(":"));
         return {model_parts.at(0), model_parts.at(1), model_parts.at(2)};
-    } else if (std::regex_match(model, SINGLE_FIELD_REGEX)) {
-        return {"rdk", "builtin", model};
-    } else {
-        throw "string " + model + " is not a valid model name";
     }
+    if (std::regex_match(model, SINGLE_FIELD_REGEX)) {
+        return {"rdk", "builtin", model};
+    }
+    throw "string " + model + " is not a valid model name";
 }
 
 std::string ModelFamily::to_string() const {
-    if (namespace_ == "") {
+    if (namespace_.empty()) {
         return family_;
     }
     return namespace_ + ":" + family_;
@@ -209,7 +212,7 @@ std::string ModelFamily::to_string() const {
 
 std::string Model::to_string() const {
     const std::string mf = model_family_.to_string();
-    if (mf == "") {
+    if (mf.empty()) {
         return model_name_;
     }
     return mf + ":" + model_name_;

--- a/src/viam/sdk/robot/service.hpp
+++ b/src/viam/sdk/robot/service.hpp
@@ -55,7 +55,7 @@ class RobotService_ : public ResourceServer, public viam::robot::v1::RobotServic
    private:
     std::mutex lock_;
     std::vector<ResourceName> generate_metadata();
-    std::vector<Status> generate_status(RepeatedPtrField<ResourceName> resources);
+    std::vector<Status> generate_status(RepeatedPtrField<ResourceName> resource_names);
 
     void stream_status(const ::viam::robot::v1::StreamStatusRequest* request,
                        ::grpc::ServerWriter<::viam::robot::v1::StreamStatusResponse>* writer,

--- a/src/viam/sdk/rpc/server.cpp
+++ b/src/viam/sdk/rpc/server.cpp
@@ -44,8 +44,9 @@ void Server::add_listening_port(std::string address,
 }
 
 void Server::wait() {
-    if (server_)
+    if (server_) {
         server_->Wait();
+    }
 }
 
 void Server::shutdown() {

--- a/src/viam/sdk/tests/mocks/mock_robot.cpp
+++ b/src/viam/sdk/tests/mocks/mock_robot.cpp
@@ -155,8 +155,8 @@ std::vector<FrameSystemConfig> mock_config_response() {
     ::grpc::ServerContext* context,
     const ::viam::robot::v1::FrameSystemConfigRequest* request,
     ::viam::robot::v1::FrameSystemConfigResponse* response) {
-    auto configs = response->mutable_frame_system_configs();
-    for (auto& c : mock_config_response()) {
+    auto* configs = response->mutable_frame_system_configs();
+    for (const auto& c : mock_config_response()) {
         *configs->Add() = c;
     }
     return ::grpc::Status();
@@ -166,7 +166,7 @@ std::vector<FrameSystemConfig> mock_config_response() {
     ::grpc::ServerContext* context,
     const ::viam::robot::v1::DiscoverComponentsRequest* request,
     ::viam::robot::v1::DiscoverComponentsResponse* response) {
-    auto discovery = response->mutable_discovery();
+    auto* discovery = response->mutable_discovery();
     for (auto& d : mock_discovery_response()) {
         *discovery->Add() = d;
     }
@@ -185,7 +185,7 @@ std::vector<FrameSystemConfig> mock_config_response() {
     ::grpc::ServerContext* context,
     const ::viam::robot::v1::GetOperationsRequest* request,
     ::viam::robot::v1::GetOperationsResponse* response) {
-    auto ops = response->mutable_operations();
+    auto* ops = response->mutable_operations();
     for (auto& op : mock_operations_response()) {
         *ops->Add() = op;
     }


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-3006

This adds clang-tidy to our repository. Clang-tidy was picked due to its ubiquity and its good integration with out existing tooling.

Important notes:
 1) VIAMCPPSDK_CLANG_TIDY is currently disabled by default because of the extra compile time that it adds. I think it would be beneficial to create either: 
   - a DEVEL flag that automatically enables both ubsan and clang-tidy.
   - make the etc/docker/tests/run_test.sh exist much higher in our repository and have that be the recommended pre-PR check script.
 2) This .clang_tidy originally came my most-respected cpp project, [SerenityOS ](https://github.com/SerenityOS/serenity). I have modified it to fit our needs