### PR TITLE
RSDK-3102 - Backport constructor changes to previous components

### DIFF
--- a/src/viam/sdk/components/base/base.cpp
+++ b/src/viam/sdk/components/base/base.cpp
@@ -14,10 +14,8 @@
 namespace viam {
 namespace sdk {
 
-BaseClient::BaseClient(std::string name, std::shared_ptr<grpc::Channel> channel)
-    : Base(std::move(name)),
-      stub_(viam::component::base::v1::BaseService::NewStub(channel)),
-      channel_(std::move(channel)){};
+BaseRegistration::BaseRegistration(const google::protobuf::ServiceDescriptor* service_descriptor)
+    : ResourceRegistration(service_descriptor){};
 
 std::shared_ptr<ResourceServer> BaseRegistration::create_resource_server(
     std::shared_ptr<ResourceManager> manager) {

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -24,12 +24,11 @@ namespace sdk {
 /// @ingroup Base
 class BaseRegistration : public ResourceRegistration {
    public:
+    explicit BaseRegistration(const google::protobuf::ServiceDescriptor* service_descriptor);
     std::shared_ptr<ResourceServer> create_resource_server(
         std::shared_ptr<ResourceManager> manager) override;
     std::shared_ptr<Resource> create_rpc_client(std::string name,
                                                 std::shared_ptr<grpc::Channel> chan) override;
-    BaseRegistration(const google::protobuf::ServiceDescriptor* service_descriptor)
-        : ResourceRegistration(service_descriptor){};
 };
 
 /// @class Base base.hpp "components/base/base.hpp"

--- a/src/viam/sdk/components/base/client.cpp
+++ b/src/viam/sdk/components/base/client.cpp
@@ -18,6 +18,11 @@
 namespace viam {
 namespace sdk {
 
+BaseClient::BaseClient(std::string name, std::shared_ptr<grpc::Channel> channel)
+    : Base(std::move(name)),
+      stub_(viam::component::base::v1::BaseService::NewStub(channel)),
+      channel_(std::move(channel)){};
+
 void BaseClient::move_straight(int64_t distance_mm, double mm_per_sec) {
     viam::component::base::v1::MoveStraightRequest request;
     viam::component::base::v1::MoveStraightResponse response;

--- a/src/viam/sdk/components/base/client.hpp
+++ b/src/viam/sdk/components/base/client.hpp
@@ -22,7 +22,6 @@ namespace sdk {
 class BaseClient : public Base {
    public:
     BaseClient(std::string name, std::shared_ptr<grpc::Channel> channel);
-
     void move_straight(int64_t distance_mm, double mm_per_sec) override;
     void spin(double angle_deg, double degs_per_sec) override;
     void set_power(const Vector3& linear, const Vector3& angular) override;

--- a/src/viam/sdk/components/base/server.hpp
+++ b/src/viam/sdk/components/base/server.hpp
@@ -18,7 +18,7 @@ namespace sdk {
 class BaseServer : public ResourceServer, public viam::component::base::v1::BaseService::Service {
    public:
     BaseServer();
-    BaseServer(std::shared_ptr<ResourceManager> manager);
+    explicit BaseServer(std::shared_ptr<ResourceManager> manager);
 
     ::grpc::Status MoveStraight(
         ::grpc::ServerContext* context,

--- a/src/viam/sdk/components/board/client.hpp
+++ b/src/viam/sdk/components/board/client.hpp
@@ -21,7 +21,6 @@ namespace sdk {
 class BoardClient : public Board {
    public:
     BoardClient(std::string name, std::shared_ptr<grpc::Channel> channel);
-
     status get_status() override;
     void set_gpio(const std::string& pin, bool high) override;
     bool get_gpio(const std::string& pin) override;

--- a/src/viam/sdk/components/camera/camera.cpp
+++ b/src/viam/sdk/components/camera/camera.cpp
@@ -14,6 +14,10 @@
 namespace viam {
 namespace sdk {
 
+CameraRegistration::CameraRegistration(
+    const google::protobuf::ServiceDescriptor* service_descriptor)
+    : ResourceRegistration(service_descriptor){};
+
 std::shared_ptr<ResourceServer> CameraRegistration::create_resource_server(
     std::shared_ptr<ResourceManager> manager) {
     return std::make_shared<CameraServer>(manager);
@@ -133,6 +137,8 @@ viam::component::camera::v1::DistortionParameters Camera::to_proto(
     *proto.mutable_parameters() = vector_to_repeated_field(params.parameters);
     return proto;
 }
+
+Camera::Camera(std::string name) : Component(std::move(name)){};
 
 bool operator==(const Camera::point_cloud& lhs, const Camera::point_cloud& rhs) {
     return lhs.mime_type == rhs.mime_type && lhs.pc == rhs.pc;

--- a/src/viam/sdk/components/camera/camera.hpp
+++ b/src/viam/sdk/components/camera/camera.hpp
@@ -25,12 +25,11 @@ namespace sdk {
 /// @ingroup Camera
 class CameraRegistration : public ResourceRegistration {
    public:
+    explicit CameraRegistration(const google::protobuf::ServiceDescriptor* service_descriptor);
     std::shared_ptr<ResourceServer> create_resource_server(
         std::shared_ptr<ResourceManager> manager) override;
     std::shared_ptr<Resource> create_rpc_client(std::string name,
                                                 std::shared_ptr<grpc::Channel> chan) override;
-    CameraRegistration(const google::protobuf::ServiceDescriptor* service_descriptor)
-        : ResourceRegistration(service_descriptor){};
 };
 
 /// @class Camera camera.hpp "components/camera/camera.hpp"
@@ -139,7 +138,7 @@ class Camera : public Component {
     API dynamic_api() const override;
 
    protected:
-    explicit Camera(std::string name) : Component(std::move(name)){};
+    explicit Camera(std::string name);
 };
 
 bool operator==(const Camera::raw_image& lhs, const Camera::raw_image& rhs);

--- a/src/viam/sdk/components/camera/client.cpp
+++ b/src/viam/sdk/components/camera/client.cpp
@@ -16,6 +16,11 @@
 namespace viam {
 namespace sdk {
 
+CameraClient::CameraClient(std::string name, std::shared_ptr<grpc::Channel> channel)
+    : Camera(std::move(name)),
+      stub_(viam::component::camera::v1::CameraService::NewStub(channel)),
+      channel_(std::move(channel)){};
+
 std::string normalize_mime_type(const std::string& str) {
     std::string mime_type = str;
     if (str.size() >= Camera::lazy_suffix.size() &&

--- a/src/viam/sdk/components/camera/client.hpp
+++ b/src/viam/sdk/components/camera/client.hpp
@@ -21,7 +21,6 @@ namespace sdk {
 class CameraClient : public Camera {
    public:
     CameraClient(std::string name, std::shared_ptr<grpc::Channel> channel);
-
     AttributeMap do_command(AttributeMap command) override;
     raw_image get_image(std::string mime_type) override;
     point_cloud get_point_cloud(std::string mime_type) override;

--- a/src/viam/sdk/components/camera/client.hpp
+++ b/src/viam/sdk/components/camera/client.hpp
@@ -20,14 +20,12 @@ namespace sdk {
 /// @ingroup Camera
 class CameraClient : public Camera {
    public:
+    CameraClient(std::string name, std::shared_ptr<grpc::Channel> channel);
+
     AttributeMap do_command(AttributeMap command) override;
     raw_image get_image(std::string mime_type) override;
     point_cloud get_point_cloud(std::string mime_type) override;
     properties get_properties() override;
-    CameraClient(std::string name, std::shared_ptr<grpc::Channel> channel)
-        : Camera(std::move(name)),
-          stub_(viam::component::camera::v1::CameraService::NewStub(channel)),
-          channel_(std::move(channel)){};
 
    protected:
     // This constructor leaves the `channel_` as a nullptr. This is useful for testing

--- a/src/viam/sdk/components/camera/server.cpp
+++ b/src/viam/sdk/components/camera/server.cpp
@@ -8,6 +8,9 @@
 namespace viam {
 namespace sdk {
 
+CameraServer::CameraServer() : ResourceServer(std::make_shared<ResourceManager>()){};
+CameraServer::CameraServer(std::shared_ptr<ResourceManager> manager) : ResourceServer(manager){};
+
 ::grpc::Status CameraServer::DoCommand(::grpc::ServerContext* context,
                                        const ::viam::common::v1::DoCommandRequest* request,
                                        ::viam::common::v1::DoCommandResponse* response) {

--- a/src/viam/sdk/components/camera/server.hpp
+++ b/src/viam/sdk/components/camera/server.hpp
@@ -18,6 +18,9 @@ namespace sdk {
 class CameraServer : public ResourceServer,
                      public viam::component::camera::v1::CameraService::Service {
    public:
+    CameraServer();
+    explicit CameraServer(std::shared_ptr<ResourceManager> manager);
+
     ::grpc::Status DoCommand(::grpc::ServerContext* context,
                              const ::viam::common::v1::DoCommandRequest* request,
                              ::viam::common::v1::DoCommandResponse* response) override;
@@ -37,9 +40,6 @@ class CameraServer : public ResourceServer,
         ::viam::component::camera::v1::GetPropertiesResponse* response) override;
 
     void register_server(std::shared_ptr<Server> server) override;
-
-    CameraServer() : ResourceServer(std::make_shared<ResourceManager>()){};
-    CameraServer(std::shared_ptr<ResourceManager> manager) : ResourceServer(manager){};
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/component.cpp
+++ b/src/viam/sdk/components/component.cpp
@@ -15,6 +15,10 @@ namespace sdk {
 
 using viam::common::v1::ResourceName;
 
+Component::Component() : Resource("component"){};
+
+Component::Component(std::string name) : Resource(std::move(name)){};
+
 ResourceName Component::get_resource_name(std::string name) {
     auto r = this->Resource::get_resource_name(name);
     *r.mutable_type() = COMPONENT;

--- a/src/viam/sdk/components/component.hpp
+++ b/src/viam/sdk/components/component.hpp
@@ -13,12 +13,12 @@ namespace sdk {
 
 class Component : public Resource {
    public:
+    Component();
     virtual ResourceType type() const override;
     viam::common::v1::ResourceName get_resource_name(std::string name) override;
-    Component() : Resource("component"){};
 
    protected:
-    explicit Component(std::string name) : Resource(std::move(name)){};
+    explicit Component(std::string name);
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/encoder/client.hpp
+++ b/src/viam/sdk/components/encoder/client.hpp
@@ -21,7 +21,6 @@ namespace sdk {
 class EncoderClient : public Encoder {
    public:
     EncoderClient(std::string name, std::shared_ptr<grpc::Channel> channel);
-
     position get_position(position_type position_type) override;
     void reset_position() override;
     properties get_properties() override;

--- a/src/viam/sdk/components/encoder/encoder.cpp
+++ b/src/viam/sdk/components/encoder/encoder.cpp
@@ -14,6 +14,10 @@
 namespace viam {
 namespace sdk {
 
+EncoderRegistration::EncoderRegistration(
+    const google::protobuf::ServiceDescriptor* service_descriptor)
+    : ResourceRegistration(service_descriptor){};
+
 std::shared_ptr<ResourceServer> EncoderRegistration::create_resource_server(
     std::shared_ptr<ResourceManager> manager) {
     return std::make_shared<EncoderServer>(manager);

--- a/src/viam/sdk/components/encoder/encoder.hpp
+++ b/src/viam/sdk/components/encoder/encoder.hpp
@@ -23,12 +23,11 @@ namespace sdk {
 /// @ingroup Encoder
 class EncoderRegistration : public ResourceRegistration {
    public:
+    explicit EncoderRegistration(const google::protobuf::ServiceDescriptor* service_descriptor);
     std::shared_ptr<ResourceServer> create_resource_server(
         std::shared_ptr<ResourceManager> manager) override;
     std::shared_ptr<Resource> create_rpc_client(std::string name,
                                                 std::shared_ptr<grpc::Channel> chan) override;
-    EncoderRegistration(const google::protobuf::ServiceDescriptor* service_descriptor)
-        : ResourceRegistration(service_descriptor){};
 };
 
 /// @class Encoder encoder.hpp "components/encoder/encoder.hpp"

--- a/src/viam/sdk/components/generic/client.cpp
+++ b/src/viam/sdk/components/generic/client.cpp
@@ -12,6 +12,11 @@
 namespace viam {
 namespace sdk {
 
+GenericClient::GenericClient(std::string name, std::shared_ptr<grpc::Channel> channel)
+    : Generic(std::move(name)),
+      stub_(viam::component::generic::v1::GenericService::NewStub(channel)),
+      channel_(std::move(channel)){};
+
 AttributeMap GenericClient::do_command(AttributeMap command) {
     viam::common::v1::DoCommandRequest req;
     viam::common::v1::DoCommandResponse resp;

--- a/src/viam/sdk/components/generic/client.hpp
+++ b/src/viam/sdk/components/generic/client.hpp
@@ -18,11 +18,8 @@ namespace sdk {
 /// @ingroup Generic
 class GenericClient : public Generic {
    public:
+    GenericClient(std::string name, std::shared_ptr<grpc::Channel> channel);
     AttributeMap do_command(AttributeMap command) override;
-    GenericClient(std::string name, std::shared_ptr<grpc::Channel> channel)
-        : Generic(std::move(name)),
-          stub_(viam::component::generic::v1::GenericService::NewStub(channel)),
-          channel_(std::move(channel)){};
 
    protected:
     // This constructor leaves the `channel_` as a nullptr. This is useful for testing

--- a/src/viam/sdk/components/generic/generic.cpp
+++ b/src/viam/sdk/components/generic/generic.cpp
@@ -15,6 +15,10 @@
 namespace viam {
 namespace sdk {
 
+GenericRegistration::GenericRegistration(
+    const google::protobuf::ServiceDescriptor* service_descriptor)
+    : ResourceRegistration(service_descriptor){};
+
 std::shared_ptr<ResourceServer> GenericRegistration::create_resource_server(
     std::shared_ptr<ResourceManager> manager) {
     return std::make_shared<GenericServer>(manager);
@@ -42,6 +46,8 @@ API Generic::static_api() {
 API Generic::dynamic_api() const {
     return static_api();
 }
+
+Generic::Generic(std::string name) : Component(std::move(name)){};
 
 namespace {
 bool init() {

--- a/src/viam/sdk/components/generic/generic.hpp
+++ b/src/viam/sdk/components/generic/generic.hpp
@@ -22,12 +22,11 @@ namespace sdk {
 /// @ingroup Generic
 class GenericRegistration : public ResourceRegistration {
    public:
+    explicit GenericRegistration(const google::protobuf::ServiceDescriptor* service_descriptor);
     std::shared_ptr<ResourceServer> create_resource_server(
         std::shared_ptr<ResourceManager> manager) override;
     std::shared_ptr<Resource> create_rpc_client(std::string name,
                                                 std::shared_ptr<grpc::Channel> chan) override;
-    GenericRegistration(const google::protobuf::ServiceDescriptor* service_descriptor)
-        : ResourceRegistration(service_descriptor){};
 };
 
 /// @class Generic generic.hpp "components/generic/generic.hpp"
@@ -52,7 +51,7 @@ class Generic : public Component {
     API dynamic_api() const override;
 
    protected:
-    explicit Generic(std::string name) : Component(std::move(name)){};
+    explicit Generic(std::string name);
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/generic/server.cpp
+++ b/src/viam/sdk/components/generic/server.cpp
@@ -6,6 +6,9 @@
 namespace viam {
 namespace sdk {
 
+GenericServer::GenericServer() : ResourceServer(std::make_shared<ResourceManager>()){};
+GenericServer::GenericServer(std::shared_ptr<ResourceManager> manager) : ResourceServer(manager){};
+
 ::grpc::Status GenericServer::DoCommand(::grpc::ServerContext* context,
                                         const ::viam::common::v1::DoCommandRequest* request,
                                         ::viam::common::v1::DoCommandResponse* response) {

--- a/src/viam/sdk/components/generic/server.hpp
+++ b/src/viam/sdk/components/generic/server.hpp
@@ -18,14 +18,14 @@ namespace sdk {
 class GenericServer : public ResourceServer,
                       public viam::component::generic::v1::GenericService::Service {
    public:
+    GenericServer();
+    explicit GenericServer(std::shared_ptr<ResourceManager> manager);
+
     ::grpc::Status DoCommand(::grpc::ServerContext* context,
                              const ::viam::common::v1::DoCommandRequest* request,
                              ::viam::common::v1::DoCommandResponse* response) override;
 
     void register_server(std::shared_ptr<Server> server) override;
-
-    GenericServer() : ResourceServer(std::make_shared<ResourceManager>()){};
-    GenericServer(std::shared_ptr<ResourceManager> manager) : ResourceServer(manager){};
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/motor/client.cpp
+++ b/src/viam/sdk/components/motor/client.cpp
@@ -17,6 +17,11 @@
 namespace viam {
 namespace sdk {
 
+MotorClient::MotorClient(std::string name, std::shared_ptr<grpc::Channel> channel)
+    : Motor(std::move(name)),
+      stub_(viam::component::motor::v1::MotorService::NewStub(channel)),
+      channel_(std::move(channel)){};
+
 void MotorClient::set_power(double power_pct) {
     viam::component::motor::v1::SetPowerRequest request;
     viam::component::motor::v1::SetPowerResponse response;

--- a/src/viam/sdk/components/motor/client.hpp
+++ b/src/viam/sdk/components/motor/client.hpp
@@ -20,6 +20,7 @@ namespace sdk {
 /// @ingroup Motor
 class MotorClient : public Motor {
    public:
+    MotorClient(std::string name, std::shared_ptr<grpc::Channel> channel);
     void set_power(double power_pct) override;
     void go_for(double rpm, double revolutions) override;
     void go_to(double rpm, double position_revolutions) override;
@@ -30,10 +31,6 @@ class MotorClient : public Motor {
     power_status get_power_status() override;
     bool is_moving() override;
     AttributeMap do_command(AttributeMap command) override;
-    MotorClient(std::string name, std::shared_ptr<grpc::Channel> channel)
-        : Motor(std::move(name)),
-          stub_(viam::component::motor::v1::MotorService::NewStub(channel)),
-          channel_(std::move(channel)){};
 
    private:
     std::unique_ptr<viam::component::motor::v1::MotorService::StubInterface> stub_;

--- a/src/viam/sdk/components/motor/motor.cpp
+++ b/src/viam/sdk/components/motor/motor.cpp
@@ -23,6 +23,8 @@ std::shared_ptr<Resource> MotorRegistration::create_rpc_client(
     std::string name, std::shared_ptr<grpc::Channel> chan) {
     return std::make_shared<MotorClient>(std::move(name), std::move(chan));
 };
+MotorRegistration::MotorRegistration(const google::protobuf::ServiceDescriptor* service_descriptor)
+    : ResourceRegistration(service_descriptor){};
 
 std::shared_ptr<ResourceRegistration> Motor::resource_registration() {
     const google::protobuf::DescriptorPool* p = google::protobuf::DescriptorPool::generated_pool();
@@ -78,6 +80,8 @@ viam::component::motor::v1::GetPropertiesResponse Motor::to_proto(properties pro
     proto.set_position_reporting(properties.position_reporting);
     return proto;
 }
+
+Motor::Motor(std::string name) : Component(std::move(name)){};
 
 bool operator==(const Motor::power_status& lhs, const Motor::power_status& rhs) {
     return (lhs.is_on == rhs.is_on && lhs.power_pct == rhs.power_pct);

--- a/src/viam/sdk/components/motor/motor.hpp
+++ b/src/viam/sdk/components/motor/motor.hpp
@@ -23,12 +23,11 @@ namespace sdk {
 /// @ingroup Motor
 class MotorRegistration : public ResourceRegistration {
    public:
+    explicit MotorRegistration(const google::protobuf::ServiceDescriptor* service_descriptor);
     std::shared_ptr<ResourceServer> create_resource_server(
         std::shared_ptr<ResourceManager> manager) override;
     std::shared_ptr<Resource> create_rpc_client(std::string name,
                                                 std::shared_ptr<grpc::Channel> chan) override;
-    MotorRegistration(const google::protobuf::ServiceDescriptor* service_descriptor)
-        : ResourceRegistration(service_descriptor){};
 };
 
 /// @class Motor motor.hpp "components/motor/motor.hpp"
@@ -132,7 +131,7 @@ class Motor : public Component {
     API dynamic_api() const override;
 
    protected:
-    explicit Motor(std::string name) : Component(std::move(name)){};
+    explicit Motor(std::string name);
 };
 
 bool operator==(const Motor::power_status& lhs, const Motor::power_status& rhs);

--- a/src/viam/sdk/components/motor/server.cpp
+++ b/src/viam/sdk/components/motor/server.cpp
@@ -8,6 +8,9 @@
 namespace viam {
 namespace sdk {
 
+MotorServer::MotorServer() : ResourceServer(std::make_shared<ResourceManager>()){};
+MotorServer::MotorServer(std::shared_ptr<ResourceManager> manager) : ResourceServer(manager){};
+
 ::grpc::Status MotorServer::SetPower(::grpc::ServerContext* context,
                                      const ::viam::component::motor::v1::SetPowerRequest* request,
                                      ::viam::component::motor::v1::SetPowerResponse* response) {

--- a/src/viam/sdk/components/motor/server.hpp
+++ b/src/viam/sdk/components/motor/server.hpp
@@ -18,6 +18,9 @@ namespace sdk {
 class MotorServer : public ResourceServer,
                     public viam::component::motor::v1::MotorService::Service {
    public:
+    MotorServer();
+    explicit MotorServer(std::shared_ptr<ResourceManager> manager);
+
     ::grpc::Status SetPower(::grpc::ServerContext* context,
                             const ::viam::component::motor::v1::SetPowerRequest* request,
                             ::viam::component::motor::v1::SetPowerResponse* response) override;
@@ -62,9 +65,6 @@ class MotorServer : public ResourceServer,
                              viam::common::v1::DoCommandResponse* response) override;
 
     void register_server(std::shared_ptr<Server> server) override;
-
-    MotorServer() : ResourceServer(std::make_shared<ResourceManager>()){};
-    MotorServer(std::shared_ptr<ResourceManager> manager) : ResourceServer(manager){};
 };
 
 }  // namespace sdk


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-3102

As we have created more components, we have changed how constructors are defined to prevent inlining (part of our styleguide) and to add explicit annotations to constructors when possible.

This brings those changes to the previous components.