### PR TITLE
RSDK-2725 Add set_logger_severity_from_args

### DIFF
--- a/src/viam/examples/modules/example_module.cpp
+++ b/src/viam/examples/modules/example_module.cpp
@@ -3,6 +3,7 @@
 #include <pthread.h>
 #include <signal.h>
 
+#include <boost/log/trivial.hpp>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/server_context.h>
 
@@ -79,6 +80,11 @@ int main(int argc, char** argv) {
     if (argc < 2) {
         throw "need socket path as command line argument";
     }
+
+    // Use set_logger_severity_from_args to set the boost trivial logger's
+    // severity depending on commandline arguments.
+    set_logger_severity_from_args(argc, argv);
+    BOOST_LOG_TRIVIAL(debug) << "Starting module with debug level logging";
 
     // C++ modules must handle SIGINT and SIGTERM. Make sure to create a sigset
     // for SIGINT and SIGTERM that can be later awaited in a thread that cleanly

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -193,7 +193,7 @@ target_link_libraries(viamsdk
   PUBLIC ${VIAMCPPSDK_PROTOBUF_LIBRARIES}
   PRIVATE ${VIAMCPPSDK_GRPCXX_REFLECTION_LIBRARIES}
   PUBLIC Boost::headers
-  PRIVATE Boost::log
+  PUBLIC Boost::log
   PRIVATE viam_rust_utils
   PRIVATE Threads::Threads
 )

--- a/src/viam/sdk/common/utils.cpp
+++ b/src/viam/sdk/common/utils.cpp
@@ -5,6 +5,9 @@
 #include <vector>
 
 #include <boost/blank.hpp>
+#include <boost/log/core.hpp>
+#include <boost/log/expressions.hpp>
+#include <boost/log/trivial.hpp>
 #include <boost/optional/optional.hpp>
 #include <boost/variant/get.hpp>
 #include <boost/variant/variant.hpp>
@@ -80,6 +83,15 @@ google::protobuf::Duration to_proto(const std::chrono::microseconds& duration) {
     proto.set_nanos(static_cast<int32_t>(nanos.count()));
     proto.set_seconds(seconds.count());
     return proto;
+}
+
+void set_logger_severity_from_args(int argc, char** argv) {
+    if (argc >= 3 && strcmp(argv[2], "--log-level=debug") == 0) {
+        boost::log::core::get()->set_filter(boost::log::trivial::severity >=
+                                            boost::log::trivial::debug);
+        return;
+    }
+    boost::log::core::get()->set_filter(boost::log::trivial::severity >= boost::log::trivial::info);
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/common/utils.hpp
+++ b/src/viam/sdk/common/utils.hpp
@@ -47,5 +47,15 @@ std::string bytes_to_string(std::vector<unsigned char> const& b);
 std::chrono::microseconds from_proto(const google::protobuf::Duration& proto);
 google::protobuf::Duration to_proto(const std::chrono::microseconds& duration);
 
+/// @brief Set the boost trivial logger's severity depending on args.
+/// @param argc The number of args.
+/// @param argv The commandline arguments to parse.
+///
+/// Sets the boost trivial logger's severity to debug if "--log-level=debug" is the
+/// the third argument. Sets severity to info otherwise. Useful for module
+/// implementations. See LogLevel documentation in the RDK for more information on
+/// how to start modules with a "log-level" commandline argument.
+void set_logger_severity_from_args(int argc, char** argv);
+
 }  // namespace sdk
 }  // namespace viam


### PR DESCRIPTION
[RSDK-2725](https://viam.atlassian.net/browse/RSDK-2725)

Adds a new utility function `set_logger_severity_from_args` that allows users to set the boost trivial logger's severity to `debug` or `info` if `--log-level=debug` was the third command line argument.

Tested that `BOOST_LOG_TRIVIAL(debug)` statements are printed when server is started with -debug or module is configured with log_level: debug. Tested that `BOOST_LOG_TRIVIAL(debug)` statements are not printed when server is started with -debug but module is configured with `log_level: warn`.

[RSDK-2725]: https://viam.atlassian.net/browse/RSDK-2725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ