### PR TITLE
RSDK-3312 - fix docs, stop throwing strings

### DIFF
--- a/src/viam/examples/modules/example_module.cpp
+++ b/src/viam/examples/modules/example_module.cpp
@@ -99,12 +99,12 @@ int main(int argc, char** argv) {
         m,
         [](Dependencies, ResourceConfig cfg) { return std::make_unique<MyModule>(cfg); },
         // Custom validation can be done by specifying a validate function like
-        // this one. Validate functions can `throw` error strings that will be
+        // this one. Validate functions can `throw` exceptions that will be
         // returned to the parent through gRPC. Validate functions can also return
         // a vector of strings representing the implicit dependencies of the resource.
         [](ResourceConfig cfg) -> std::vector<std::string> {
             if (cfg.attributes()->find("invalidattribute") != cfg.attributes()->end()) {
-                throw std::string(
+                throw std::runtime_error(
                     "'invalidattribute' attribute not allowed for model 'acme:demo:printer'");
             }
 

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -17,7 +17,7 @@
 namespace viam {
 namespace sdk {
 
-/// @defgroup Base Classes related to the `Base` component.
+/// @defgroup Base Classes related to the Base component.
 
 /// @class BaseRegistration
 /// @brief Defines a `ResourceRegistration` for the `Base` component.

--- a/src/viam/sdk/components/board/board.hpp
+++ b/src/viam/sdk/components/board/board.hpp
@@ -17,7 +17,7 @@
 namespace viam {
 namespace sdk {
 
-/// @defgroup Board Classes related to the `Board` component.
+/// @defgroup Board Classes related to the Board component.
 
 /// @class BoardRegistration
 /// @brief Defines a `ResourceRegistration` for the `Board` component.

--- a/src/viam/sdk/components/camera/camera.hpp
+++ b/src/viam/sdk/components/camera/camera.hpp
@@ -18,7 +18,7 @@
 namespace viam {
 namespace sdk {
 
-/// @defgroup Camera Classes related to the `Camera` component.
+/// @defgroup Camera Classes related to the Camera component.
 
 /// @class CameraRegistration
 /// @brief Defines a `ResourceRegistration` for the `Camera` component.

--- a/src/viam/sdk/components/encoder/encoder.hpp
+++ b/src/viam/sdk/components/encoder/encoder.hpp
@@ -16,7 +16,7 @@
 namespace viam {
 namespace sdk {
 
-/// @defgroup Encoder Classes related to the `Encoder` component.
+/// @defgroup Encoder Classes related to the Encoder component.
 
 /// @class EncoderRegistration
 /// @brief Defines a `ResourceRegistration` for the `Encoder` component.

--- a/src/viam/sdk/components/generic/generic.hpp
+++ b/src/viam/sdk/components/generic/generic.hpp
@@ -15,7 +15,7 @@ namespace viam {
 namespace sdk {
 
 // TODO(RSDK-1742): one class per header
-/// @defgroup Generic Classes related to the `Generic` component.
+/// @defgroup Generic Classes related to the Generic component.
 
 /// @class GenericRegistration
 /// @brief Defines a `ResourceRegistration` for the `Generic` component.

--- a/src/viam/sdk/components/motor/motor.hpp
+++ b/src/viam/sdk/components/motor/motor.hpp
@@ -16,7 +16,7 @@
 namespace viam {
 namespace sdk {
 
-/// @defgroup Motor Classes related to the `Motor` component.
+/// @defgroup Motor Classes related to the Motor component.
 
 /// @class MotorRegistration
 /// @brief Defines a `ResourceRegistration` for the `Motor` component.

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -119,7 +119,7 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
     // if the type isn't reconfigurable by default, replace it
     try {
         res->stop();
-    } catch (const std::exception& err) {  // NOLINT
+    } catch (const std::exception& err) {
         BOOST_LOG_TRIVIAL(error) << "unable to stop resource: " << err.what();
     }
 
@@ -150,7 +150,7 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
         for (auto& dep : implicit_deps) {
             response->add_dependencies(dep);
         }
-    } catch (const std::exception& err) {  // NOLINT
+    } catch (const std::exception& err) {
         return grpc::Status(grpc::UNKNOWN,
                             "validation failure in resource " + cfg.name() + ": " + err.what());
     }
@@ -177,7 +177,7 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
 
     try {
         res->stop();
-    } catch (const std::exception& err) {  // NOLINT
+    } catch (const std::exception& err) {
         BOOST_LOG_TRIVIAL(error) << "unable to stop resource: " << err.what();
     }
 

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -1,8 +1,10 @@
 #include <viam/sdk/module/service.hpp>
 
 #include <csignal>
+#include <exception>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -111,14 +113,14 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
     try {
         res->reconfigure(deps, cfg);
         return grpc::Status();
-    } catch (std::exception& exc) {
+    } catch (const std::exception& exc) {
     }
 
     // if the type isn't reconfigurable by default, replace it
     try {
         res->stop();
-    } catch (std::string err) {  // NOLINT
-        BOOST_LOG_TRIVIAL(error) << "unable to stop resource: " << err;
+    } catch (const std::exception& err) {  // NOLINT
+        BOOST_LOG_TRIVIAL(error) << "unable to stop resource: " << err.what();
     }
 
     std::shared_ptr<ModelRegistration> reg = Registry::lookup_model(cfg.name());
@@ -148,9 +150,9 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
         for (auto& dep : implicit_deps) {
             response->add_dependencies(dep);
         }
-    } catch (std::string err) {  // NOLINT
+    } catch (const std::exception& err) {  // NOLINT
         return grpc::Status(grpc::UNKNOWN,
-                            "validation failure in resource " + cfg.name() + ": " + err);
+                            "validation failure in resource " + cfg.name() + ": " + err.what());
     }
     return grpc::Status();
 };
@@ -175,8 +177,8 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
 
     try {
         res->stop();
-    } catch (std::string err) {  // NOLINT
-        BOOST_LOG_TRIVIAL(error) << "unable to stop resource: " << err;
+    } catch (const std::exception& err) {  // NOLINT
+        BOOST_LOG_TRIVIAL(error) << "unable to stop resource: " << err.what();
     }
 
     manager->remove(name);
@@ -223,7 +225,7 @@ void ModuleService_::close() {
     if (parent_) {
         try {
             parent_->close();
-        } catch (std::exception& exc) {
+        } catch (const std::exception& exc) {
             BOOST_LOG_TRIVIAL(error) << exc.what();
         }
     }

--- a/src/viam/sdk/registry/registry.hpp
+++ b/src/viam/sdk/registry/registry.hpp
@@ -95,6 +95,8 @@ class ModelRegistration {
     std::function<std::shared_ptr<Resource>(Dependencies, ResourceConfig)> construct_resource;
 
     /// @brief Validates a resource config.
+    /// @return a list of the resource's implicit dependencies.
+    /// @throws Can throw exceptions, which will be returned to the parent via gRPC.
     std::function<std::vector<std::string>(ResourceConfig)> validate;
 
     /// @brief Creates a `Status` object for a given resource.

--- a/src/viam/sdk/robot/client.hpp
+++ b/src/viam/sdk/robot/client.hpp
@@ -30,7 +30,7 @@ using viam::robot::v1::RobotService;
 using viam::robot::v1::Status;
 
 // TODO(RSDK-1742) replace all `ResourceName` references in API with `Name`
-/// @defgroup Robot Classes related to a `Robot` representation.
+/// @defgroup Robot Classes related to a Robot representation.
 
 /// @class RobotClient client.h "robot/client.h"
 /// @brief gRPC client for a robot, to be used for all interactions with a robot.


### PR DESCRIPTION
#### Major changes
Remove `<t><t>` tags from `modules` page in documentation
Stop throwing/catching strings anywhere, consistently throw exceptions
Make catches `const&`
Clarify documentation on `validate` method