### PR TITLE
Add --output-on-failure to workflow ctest invocation

### DIFF
--- a/etc/docker/tests/run_test.sh
+++ b/etc/docker/tests/run_test.sh
@@ -8,4 +8,4 @@ cmake .. -G Ninja -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON \
 ninja all
 ninja install
 cd src/viam/sdk/tests
-ctest --output-on-failure
+UBSAN_OPTIONS="print_stacktrace=1" ctest --output-on-failure

--- a/etc/docker/tests/run_test.sh
+++ b/etc/docker/tests/run_test.sh
@@ -8,4 +8,4 @@ cmake .. -G Ninja -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON \
 ninja all
 ninja install
 cd src/viam/sdk/tests
-ctest
+ctest --output-on-failure


### PR DESCRIPTION
@stuqdog - Hopefully this gives us some insight into the test failures in CI.