### PR TITLE
RSDK-3336 Add support for easily building against a local API repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ option(VIAMCPPSDK_USE_DYNAMIC_PROTOS "Regenerate protos as part of building (net
 # - `VIAMCPPSDK_USE_LOCAL_PROTOS`
 #
 # Builds against local proto definitions, as opposed to those in the
-# buf registry. This flag assumes that there is a `buf.workspace` file
+# buf registry. This flag assumes that there is a `buf.work.yaml` file
 # in the parent directory of the C++ SDK source directory, and that
 # the API repo is in a sibling directory to the C++ SDK source, with
 # the directory name `api`. This flag requires

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,10 @@ project(viam-cpp-sdk
 
 
 # Configure cmake-level options:
+
+# - `BUILD_SHARED_LIBS`
 #
-# - `BUILD_SHARED_LIBS`: Enabled by default so that we produce a
+# Enabled by default so that we produce a
 # modern SDK, this option can be set to `OFF` to build a static
 # library. Note that this may result in non-functional examples.
 #
@@ -54,46 +56,74 @@ option(BUILD_SHARED_LIBS "If enabled, build shared libraries" ON)
 
 
 # Configure project-global options:
+
+# - `VIAMCPPSDK_ENFORCE_COMPILER_MINIMA`
 #
-# - `VIAMCPPSDK_ENFORCE_COMPILER_MINIMA`: The user can elect to
-# disable enforcement of compiler minima (at their peril).
+# The user can elect to disable enforcement of compiler minima (at
+# their peril).
+#
 option(VIAMCPPSDK_ENFORCE_COMPILER_MINIMA "Control whether we validate the selected compiler against known minima" ON)
 
 
-# # - `VIAMCPPSDK_OFFLINE_PROTO_GENERATION`: Do not use buf.builds remote
-# definitions or services and use the local proto compiler plugins to
-# do generation.
+# - `VIAMCPPSDK_OFFLINE_PROTO_GENERATION`
+#
+# Do not use buf.builds remote definitions or services and use the
+# local proto compiler plugins to do generation.
+#
 option(VIAMCPPSDK_OFFLINE_PROTO_GENERATION "Use local tools for proto generation" OFF)
 
 
-# - `VIAMCPPSDK_USE_DYNAMIC_PROTOS`: The user can select whether to
-# use the prebuilt proto files under the `gen` directory, or to
-# dynamically regenerate them as part of the build. In the latter
-# mode, additional targets are defined that will copy the newly
-# generated protos back to the source directory so they can be
-# committed:
+# - `VIAMCPPSDK_USE_DYNAMIC_PROTOS`
+#
+# The user can select whether to use the prebuilt proto files under
+# the `gen` directory, or to dynamically regenerate them as part of
+# the build. In the latter mode, additional targets are defined that
+# will copy the newly generated protos back to the source directory so
+# they can be committed:
 #
 # ```
 # cmake ... -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON
 # [make|ninja|...] update-static-protos
 # ```
 # Remember to check-in the results after regenerating!
+#
 option(VIAMCPPSDK_USE_DYNAMIC_PROTOS "Regenerate protos as part of building (network access may be required)" OFF)
 
 
-# # - `VIAMCPPSDK_USE_WALL_WERROR`: This causes the SDK's internal
-# code to compile with `-Wall` and `-Werror` flags.
+# - `VIAMCPPSDK_USE_LOCAL_PROTOS`
+#
+# Builds against local proto definitions, as opposed to those in the
+# buf registry. This flag assumes that there is a `buf.workspace` file
+# in the parent directory of the C++ SDK source directory, and that
+# the API repo is in a sibling directory to the C++ SDK source, with
+# the directory name `api`. This flag requires
+# `VIAMCPPSDK_USE_DYNAMIC_PROTOS=ON` to be set.
+#
+option(VIAMCPPSDK_USE_LOCAL_PROTOS "Generate protos against sibling `api` directory per parent directory `buf.workspace` file")
+
+
+# - `VIAMCPPSDK_USE_WALL_WERROR`
+#
+# This causes the SDK's internal code to compile with `-Wall` and
+# `-Werror` flags.
+#
 option(VIAMCPPSDK_USE_WALL_WERROR "Build with -Wall and -Werror flags" ON)
 
 
-# # - `VIAMCPPSDK_SANITIZED_BUILD`: This causes the SDK to build with
-# UBSan, helping in the detection of undefined behavior. Note that builds
-# with this flag will be less performant.
+# - `VIAMCPPSDK_SANITIZED_BUILD`
+#
+# This causes the SDK to build with UBSan, helping in the detection of
+# undefined behavior. Note that builds with this flag will be less
+# performant.
+#
 option(VIAMCPPSDK_SANITIZED_BUILD "Build with address and UB sanitizers (less performant)" OFF)
 
 
-# # - `VIAMCPPSDK_CLANG_TIDY`: This causes the SDK to run clang-tidy
-# with the options specified in the .clang-tidy file.
+# - `VIAMCPPSDK_CLANG_TIDY`
+#
+# This causes the SDK to run clang-tidy with the options specified in
+# the .clang-tidy file.
+#
 option(VIAMCPPSDK_CLANG_TIDY "Run the clang-tidy linter" OFF)
 
 

--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -1,5 +1,31 @@
 set(PROTO_GEN_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
+set(BUF_PROTO_SOURCE buf.build/viamrobotics/api)
+set(BUF_PROTO_COMPONENTS common component robot service module tagger app/v1)
+
+# If we are using local proto generation, rework the
+# `BUF_PROTO_SOURCE` and `BUF_PROTO_COMPONENTS` as required to make
+# use of the API repo as positioned relative to us.
+if (VIAMCPPSDK_USE_LOCAL_PROTOS)
+  if (NOT VIAMCPPSDK_USE_DYNAMIC_PROTOS)
+    message(FATAL_ERROR "The VIAMCPPSDK_USE_LOCAL_PROTOS option requires VIAMCPPSDK_USE_DYNAMIC_PROTOS=ON")
+  endif()
+
+  if (NOT EXISTS ${PROJECT_SOURCE_DIR}/../buf.work.yaml)
+    message(FATAL_ERROR "No `buf.work.yaml` file was found in the parent directory")
+  endif()
+
+  if (NOT EXISTS ${PROJECT_SOURCE_DIR}/../api/proto/viam)
+    message(FATAL_ERROR "No Viam api repository was found in the parent directory")
+  endif()
+
+  file(RELATIVE_PATH BUF_LOCAL_PROTO_PATH ${CMAKE_CURRENT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/..)
+  set(BUF_PROTO_SOURCE ${BUF_LOCAL_PROTO_PATH})
+  list(TRANSFORM BUF_PROTO_COMPONENTS PREPEND ${BUF_LOCAL_PROTO_PATH}/api/proto/viam/)
+endif()
+
+list(JOIN BUF_PROTO_COMPONENTS , BUF_PROTO_COMPONENTS_JOINED)
+
 if (VIAMCPPSDK_USE_DYNAMIC_PROTOS)
 
   # Look for the `buf` command in the usual places, and use it if
@@ -138,7 +164,7 @@ if (VIAMCPPSDK_USE_DYNAMIC_PROTOS)
 
     COMMAND ${BUF_COMMAND} generate buf.build/viamrobotics/goutils --template buf.gen.yaml
     COMMAND ${BUF_COMMAND} generate buf.build/googleapis/googleapis --template buf.gen.yaml --path google/rpc --path google/api
-    COMMAND ${BUF_COMMAND} generate buf.build/viamrobotics/api --template buf.gen.yaml --path common,component,robot,service,module,tagger,app/v1
+    COMMAND ${BUF_COMMAND} generate ${BUF_PROTO_SOURCE} --template buf.gen.yaml --path ${BUF_PROTO_COMPONENTS_JOINED}
     MAIN_DEPENDENCY buf.gen.yaml
   )
 

--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -1,7 +1,15 @@
 set(PROTO_GEN_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(BUF_PROTO_SOURCE buf.build/viamrobotics/api)
-set(BUF_PROTO_COMPONENTS common component robot service module tagger app/v1)
+set(BUF_PROTO_COMPONENTS
+  app/v1
+  common
+  component
+  module
+  robot
+  service
+  tagger
+)
 
 # If we are using local proto generation, rework the
 # `BUF_PROTO_SOURCE` and `BUF_PROTO_COMPONENTS` as required to make


### PR DESCRIPTION
- Reformats the options declarations. That's optional (hah!)
- Defines a new option: `VIAMCPPSDK_USE_LOCAL_PROTOS` which causes proto generation to be performed against proto definitions as currently defined in a sibling directory named `api`.