### PR TITLE
RSDK-3311 Make API a member of Name

### DIFF
--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -163,12 +163,11 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
     const ::viam::module::v1::RemoveResourceRequest* request,
     ::viam::module::v1::RemoveResourceResponse* response) {
     auto name = Name::from_string(request->name());
-    const API* api = name.to_api();
     const std::unordered_map<API, std::shared_ptr<ResourceManager>>& services = module_->services();
-    if (services.find(*api) == services.end()) {
-        return grpc::Status(grpc::UNKNOWN, "no grpc service for " + api->to_string());
+    if (services.find(name.api()) == services.end()) {
+        return grpc::Status(grpc::UNKNOWN, "no grpc service for " + name.api().to_string());
     }
-    const std::shared_ptr<ResourceManager> manager = services.at(*name.to_api());
+    const std::shared_ptr<ResourceManager> manager = services.at(name.api());
     const std::shared_ptr<Resource> res = manager->resource(name.name());
     if (!res) {
         return grpc::Status(

--- a/src/viam/sdk/resource/resource_api.cpp
+++ b/src/viam/sdk/resource/resource_api.cpp
@@ -83,7 +83,7 @@ bool API::is_component_type() {
     return (this->resource_type() == "component");
 }
 
-API Name::api() const {
+const API& Name::api() const {
     return api_;
 }
 

--- a/src/viam/sdk/resource/resource_api.cpp
+++ b/src/viam/sdk/resource/resource_api.cpp
@@ -83,8 +83,8 @@ bool API::is_component_type() {
     return (this->resource_type() == "component");
 }
 
-const API* Name::to_api() const {
-    return this;
+API Name::api() const {
+    return api_;
 }
 
 const std::string& Name::name() const {
@@ -96,11 +96,10 @@ const std::string& Name::remote_name() const {
 }
 
 std::string Name::to_string() const {
-    const std::string subtype_name = API::to_string();
     if (remote_name_.empty()) {
-        return subtype_name + "/" + name_;
+        return api_.to_string() + "/" + name_;
     }
-    return subtype_name + "/" + remote_name_ + ":" + name_;
+    return api_.to_string() + "/" + remote_name_ + ":" + name_;
 }
 
 std::string Name::short_name() const {
@@ -112,10 +111,10 @@ std::string Name::short_name() const {
 
 viam::common::v1::ResourceName Name::to_proto() const {
     viam::common::v1::ResourceName rn;
-    *rn.mutable_namespace_() = this->type_namespace();
+    *rn.mutable_namespace_() = this->api().type_namespace();
     *rn.mutable_name() = this->name();
-    *rn.mutable_type() = this->resource_type();
-    *rn.mutable_subtype() = this->resource_subtype();
+    *rn.mutable_type() = this->api().resource_type();
+    *rn.mutable_subtype() = this->api().resource_subtype();
     return rn;
 }
 
@@ -141,7 +140,7 @@ Name Name::from_string(std::string name) {
 }
 
 Name::Name(API api, std::string remote, std::string name)
-    : API(api), remote_name_(std::move(remote)), name_(std::move(name)) {}
+    : api_(api), remote_name_(std::move(remote)), name_(std::move(name)) {}
 
 bool operator==(const API& lhs, const API& rhs) {
     return lhs.to_string() == rhs.to_string();

--- a/src/viam/sdk/resource/resource_api.hpp
+++ b/src/viam/sdk/resource/resource_api.hpp
@@ -59,7 +59,7 @@ class Name {
     static Name from_string(std::string name);
     Name(API api, std::string remote_name, std::string name);
     Name();
-    API api() const;
+    const API& api() const;
     const std::string& name() const;
     const std::string& remote_name() const;
     friend bool operator==(const Name& lhs, const Name& rhs);

--- a/src/viam/sdk/resource/resource_api.hpp
+++ b/src/viam/sdk/resource/resource_api.hpp
@@ -49,25 +49,23 @@ class API : public APIType {
     std::string resource_subtype_;
 };
 
-// TODO: instead of inheriting from API probably this should just have a
-// API as a member
 /// @class Name
-/// @brief Extends `API` class by adding a name for specific instances of resources.
-class Name : public API {
+/// @brief A name for specific instances of resources.
+class Name {
    public:
     std::string short_name() const;
-    virtual std::string to_string() const override;
-    // TODO: this isn't necessary, instead this->API::to_string();
-    const API* to_api() const;
+    std::string to_string() const;
     viam::common::v1::ResourceName to_proto() const;
     static Name from_string(std::string name);
     Name(API api, std::string remote_name, std::string name);
     Name();
+    API api() const;
     const std::string& name() const;
     const std::string& remote_name() const;
     friend bool operator==(const Name& lhs, const Name& rhs);
 
    private:
+    API api_;
     std::string remote_name_;
     std::string name_;
 };


### PR DESCRIPTION
[RSDK-3311](https://viam.atlassian.net/browse/RSDK-3311)

Makes `API` a private member of `Name` instead of having `Name` extend `API`. Removes the `to_api` method in favor of an `api` getter.

`RemoveResource` was not working correctly for modules, as it tried to find the service registered to `name.to_api()`, which incorrectly returned the whole resource name ("rdk:generic:component/printer" instead of "rd:generic:component". I saw the related `TODO` and thought this would be a good fix.


[RSDK-3311]: https://viam.atlassian.net/browse/RSDK-3311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ