### PR TITLE
RSDK-4006 Fixes from working on mlmodel tutorial

### DIFF
--- a/src/viam/examples/mlmodel/example_audio_classification_client.cpp
+++ b/src/viam/examples/mlmodel/example_audio_classification_client.cpp
@@ -242,7 +242,7 @@ int main(int argc, char* argv[]) try {
         // first signal is just silence, and the second is just noise.
         const std::vector<float> silence(15600, 0.0);
         const std::vector<float> noise = [&silence]() {
-            std::vector temp{silence};
+            std::vector<float> temp{silence};
             std::random_device seed;
             std::uniform_real_distribution<float> dist{-1.0, 1.0};
             std::generate(begin(temp), end(temp), [&dist, e = std::mt19937(seed())]() mutable {
@@ -387,8 +387,11 @@ int main(int argc, char* argv[]) try {
     std::cout << argv[0] << ": "
               << "Failed: a std::exception was thrown: `" << ex.what() << "``" << std::endl;
     return EXIT_FAILURE;
+} catch (const std::string& ex) {
+    std::cout << argv[0] << ": "
+              << "Failed: a std::string was thrown: `" << ex << "``" << std::endl;
 } catch (...) {
     std::cout << argv[0] << ": "
-              << "Failed: an unknown excetion was thrown" << std::endl;
+              << "Failed: an unknown exception was thrown" << std::endl;
     return EXIT_FAILURE;
 }

--- a/src/viam/examples/mlmodel/example_audio_classification_client.cpp
+++ b/src/viam/examples/mlmodel/example_audio_classification_client.cpp
@@ -357,7 +357,7 @@ int main(int argc, char* argv[]) try {
 
             // Print out the top 5 (or fewer) label/score pairs.
             for (size_t i = 0; i != std::min(5UL, scored_labels.size()); ++i) {
-                // TODO: Avoid hardcdoding the width here.
+                // TODO: Avoid hardcoding the width here.
                 std::cout << boost::format("%1%: %2% %|40t|%3%\n") % i % *scored_labels[i].label %
                                  scored_labels[i].score;
             }

--- a/src/viam/examples/modules/CMakeLists.txt
+++ b/src/viam/examples/modules/CMakeLists.txt
@@ -26,10 +26,31 @@ install(
   COMPONENT examples
 )
 
+option(VIAMCPPSDK_BUILD_TFLITE_EXAMPLE_MODULE "Select whether to build the tflite module (builds tflite too!)" OFF)
 
-find_path(TFLITE_INCLUDE_PATH "tensorflow/lite/c/c_api.h")
-find_library(TFLITE_LIBRARY "tensorflowlite_c")
-if (EXISTS ${TFLITE_INCLUDE_PATH} AND EXISTS ${TFLITE_LIBRARY})
+if (VIAMCPPSDK_BUILD_TFLITE_EXAMPLE_MODULE)
+
+  # In theory, this should make the change of `BUILD_SHARED_LIBS`
+  # scoped just to the tensorflow build. We always want to build
+  # tensorflow statically. If it is built dynamically, then we need to
+  # install it. However, that requires building with
+  # `TFLITE_ENABLE_INSTALL` in order to ensure that the dynamic
+  # libraries get installed to the instalation root, which seems to
+  # just not really work. Yes, this feels bad.
+  function(fetchcontent_tflite)
+    set(BUILD_SHARED_LIBS OFF)
+    set(TFLITE_C_BUILD_SHARED_LIBS OFF)
+    FetchContent_Declare(
+      tensorflow
+      GIT_REPOSITORY https://github.com/tensorflow/tensorflow.git
+      GIT_PROGRESS TRUE
+      GIT_TAG v2.13.0
+      SOURCE_SUBDIR tensorflow/lite/c
+    )
+    FetchContent_MakeAvailable(tensorflow)
+  endfunction()
+  fetchcontent_tflite()
+
   add_executable(example_mlmodelservice_tflite
     example_mlmodelservice_tflite.cpp
   )
@@ -44,7 +65,5 @@ if (EXISTS ${TFLITE_INCLUDE_PATH} AND EXISTS ${TFLITE_LIBRARY})
     TARGETS example_mlmodelservice_tflite
     COMPONENT examples
   )
-else()
-  message(WARNING "Failed to find tflite C headers/library: tflite example module will not be built")
-  message(WARNING "If you have tflite in a non-standard location, add -DCMAKE_PREFIX_PATH=/path/to/tflite to your CMake invocation")
+
 endif()

--- a/src/viam/examples/modules/example_mlmodelservice_tflite.cpp
+++ b/src/viam/examples/modules/example_mlmodelservice_tflite.cpp
@@ -584,7 +584,7 @@ class MLModelServiceTFLite : public vsdk::MLModelService {
             : dependencies(std::move(dependencies)), configuration(std::move(configuration)) {}
 
         // The dependencies and configuration we were given at
-        // constuction / reconfiguration.
+        // construction / reconfiguration.
         vsdk::Dependencies dependencies;
         vsdk::ResourceConfig configuration;
 

--- a/src/viam/examples/modules/example_mlmodelservice_tflite.cpp
+++ b/src/viam/examples/modules/example_mlmodelservice_tflite.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <condition_variable>
 #include <fstream>
 #include <iostream>
 #include <mutex>
@@ -80,7 +81,7 @@ class MLModelServiceTFLite : public vsdk::MLModelService {
     grpc::StatusCode stop() noexcept final {
         using std::swap;
         try {
-            std::scoped_lock<std::mutex> lock(state_lock_);
+            std::lock_guard<std::mutex> lock(state_lock_);
             if (!stopped_) {
                 stopped_ = true;
                 std::shared_ptr<state> state;
@@ -126,7 +127,7 @@ class MLModelServiceTFLite : public vsdk::MLModelService {
         // release the lock, and then notify any callers waiting on
         // reconfiguration to complete.
         {
-            std::scoped_lock<std::mutex> lock(state_lock_);
+            std::lock_guard<std::mutex> lock(state_lock_);
             check_stopped_inlock_();
             swap(state_, state);
         }


### PR DESCRIPTION
- Fixes three places where I accidentally C++17'd. I didn't catch it because on macOS our brew absl dependency forces us into C++17 mode.
- Adds a missing header for `std::condition_variable` which was needed with libstdc++ but not libc++, so I didn't catch it on macOS builds.
- Fixes a typo in the function-level catch handler for `main` (`excetion` to `exception`).
- Adds a handler for thrown `std::string` since SDK does that.
- Adds an opt-in to build the tflite module (see next)
- Uses FetchContent to build tflite from source to satisfy the tflite dependency for the module. Otherwise, we were trying to get it from system and it just didn't work anywhere. Since this significantly adds to the build time for the SDK, guard it under the flag above.