### PR TITLE
Rsdk-4053 patch - create metadata object

### DIFF
--- a/etc/docker/Dockerfile.debian.bookworm
+++ b/etc/docker/Dockerfile.debian.bookworm
@@ -42,5 +42,3 @@ RUN apt-get update
 RUN apt-get -y --no-install-recommends install -t llvm-toolchain-bookworm-15 \
     clang-15 \
     clang-tidy-15
-
-ADD ./ ${HOME}/opt/src/viam-cpp-sdk

--- a/etc/docker/Dockerfile.debian.bookworm
+++ b/etc/docker/Dockerfile.debian.bookworm
@@ -42,3 +42,5 @@ RUN apt-get update
 RUN apt-get -y --no-install-recommends install -t llvm-toolchain-bookworm-15 \
     clang-15 \
     clang-tidy-15
+
+ADD ./ ${HOME}/opt/src/viam-cpp-sdk

--- a/src/viam/sdk/common/utils.hpp
+++ b/src/viam/sdk/common/utils.hpp
@@ -41,6 +41,25 @@ class ResourceNameEqual {
     }
 };
 
+struct response_metadata {
+    std::chrono::time_point<long long, std::chrono::nanoseconds> captured_at;
+
+    static response_metadata from_proto(const viam::common::v1::ResponseMetadata& proto);
+    static viam::common::v1::ResponseMetadata to_proto(const response_metadata& metadata);
+};
+
+bool operator==(const response_metadata& lhs, const response_metadata& rhs);
+
+/// @brief convert a google::protobuf::Timestamp to std::chrono::time_point<long long,
+/// std::chrono::nanoseconds>.
+std::chrono::time_point<long long, std::chrono::nanoseconds> timestamp_to_time_pt(
+    const google::protobuf::Timestamp& timestamp);
+
+/// @brief convert a std::chrono::time_point<long long, std::chrono::nanoseconds> to a
+/// google::protobuf::Timestamp.
+google::protobuf::Timestamp time_pt_to_timestamp(
+    const std::chrono::time_point<long long, std::chrono::nanoseconds>& time_pt);
+
 std::vector<unsigned char> string_to_bytes(std::string const& s);
 std::string bytes_to_string(std::vector<unsigned char> const& b);
 

--- a/src/viam/sdk/components/camera/camera.cpp
+++ b/src/viam/sdk/components/camera/camera.cpp
@@ -93,25 +93,6 @@ std::string Camera::format_to_MIME_string(viam::component::camera::v1::Format fo
     return viam::component::camera::v1::FORMAT_UNSPECIFIED;
 }
 
-std::chrono::time_point<long long, std::chrono::nanoseconds> Camera::timestamp_to_time_pt(
-    const google::protobuf::Timestamp& timestamp) {
-    const std::chrono::seconds seconds(timestamp.seconds());
-    const std::chrono::nanoseconds nanos(timestamp.nanos());
-    return std::chrono::time_point<long long, std::chrono::nanoseconds>(
-        std::chrono::duration_cast<std::chrono::system_clock::duration>(seconds) + nanos);
-}
-
-google::protobuf::Timestamp Camera::time_pt_to_timestamp(
-    const std::chrono::time_point<long long, std::chrono::nanoseconds>& time_pt) {
-    const std::chrono::seconds duration_s =
-        std::chrono::duration_cast<std::chrono::seconds>(time_pt.time_since_epoch());
-    const std::chrono::nanoseconds duration_ns = time_pt.time_since_epoch() - duration_s;
-    google::protobuf::Timestamp timestamp;
-    timestamp.set_seconds(duration_s.count());
-    timestamp.set_nanos(static_cast<int32_t>(duration_ns.count()));
-    return timestamp;
-}
-
 std::vector<double> repeated_field_to_vector(const google::protobuf::RepeatedField<double>& f) {
     std::vector<double> v(f.begin(), f.end());
     return v;
@@ -145,7 +126,7 @@ Camera::image_collection Camera::from_proto(viam::component::camera::v1::GetImag
         images.push_back(raw_image);
     }
     image_collection.images = std::move(images);
-    image_collection.captured_at = timestamp_to_time_pt(proto.response_metadata().captured_at());
+    image_collection.metadata = response_metadata::from_proto(proto.response_metadata());
     return image_collection;
 }
 
@@ -231,7 +212,7 @@ bool operator==(const Camera::raw_image& lhs, const Camera::raw_image& rhs) {
 }
 
 bool operator==(const Camera::image_collection& lhs, const Camera::image_collection& rhs) {
-    return lhs.images == rhs.images && lhs.captured_at == rhs.captured_at;
+    return lhs.images == rhs.images && lhs.metadata == rhs.metadata;
 }
 
 bool operator==(const Camera::intrinsic_parameters& lhs, const Camera::intrinsic_parameters& rhs) {

--- a/src/viam/sdk/components/camera/camera.hpp
+++ b/src/viam/sdk/components/camera/camera.hpp
@@ -95,7 +95,7 @@ class Camera : public Component {
     /// @brief a collection of images that were collected from a camera all at the same time.
     struct image_collection {
         std::vector<raw_image> images;
-        std::chrono::time_point<long long, std::chrono::nanoseconds> captured_at;
+        response_metadata metadata;
     };
 
     /// @brief Creates a `ResourceRegistration` for the `Camera` component.
@@ -112,14 +112,6 @@ class Camera : public Component {
 
     /// @brief convert a MIME type string with a protobuf format enum.
     static viam::component::camera::v1::Format MIME_string_to_format(std::string mime_string);
-
-    /// @brief convert a google::protobuf::Timestamp to std::chrono::system_clock::time_point.
-    static std::chrono::time_point<long long, std::chrono::nanoseconds> timestamp_to_time_pt(
-        const google::protobuf::Timestamp& timestamp);
-
-    /// @brief convert a std::chrono::system_clock::time_point to a google::protobuf::Timestamp.
-    static google::protobuf::Timestamp time_pt_to_timestamp(
-        const std::chrono::time_point<long long, std::chrono::nanoseconds>& time_pt);
 
     /// @brief Creates a `raw_image` struct from its proto representation.
     static raw_image from_proto(viam::component::camera::v1::GetImageResponse proto);

--- a/src/viam/sdk/components/camera/server.cpp
+++ b/src/viam/sdk/components/camera/server.cpp
@@ -87,9 +87,7 @@ CameraServer::CameraServer(std::shared_ptr<ResourceManager> manager) : ResourceS
         proto_image.set_image(img_string);
         *response->mutable_images()->Add() = std::move(proto_image);
     }
-    viam::common::v1::ResponseMetadata* resp_metadata = response->mutable_response_metadata();
-    google::protobuf::Timestamp ts = Camera::time_pt_to_timestamp(image_coll.captured_at);
-    *resp_metadata->mutable_captured_at() = std::move(ts);
+    *response->mutable_response_metadata() = response_metadata::to_proto(image_coll.metadata);
 
     return ::grpc::Status();
 }

--- a/src/viam/sdk/tests/mocks/camera_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.cpp
@@ -60,7 +60,7 @@ Camera::image_collection fake_raw_images() {
     std::chrono::seconds seconds(12345);
     std::chrono::nanoseconds nanos(0);
     collection.images = images;
-    collection.captured_at = std::chrono::time_point<long long, std::chrono::nanoseconds>(
+    collection.metadata.captured_at = std::chrono::time_point<long long, std::chrono::nanoseconds>(
         std::chrono::duration_cast<std::chrono::system_clock::duration>(seconds) + nanos);
     return collection;
 }

--- a/src/viam/sdk/tests/test_camera.cpp
+++ b/src/viam/sdk/tests/test_camera.cpp
@@ -122,14 +122,14 @@ BOOST_AUTO_TEST_CASE(test_get_images_service) {
     BOOST_CHECK(resp.images()[0].source_name() == images.images[0].source_name);
     BOOST_CHECK(resp.images()[1].source_name() == images.images[1].source_name);
 
-    auto converted_proto_timestamp = Camera::time_pt_to_timestamp(images.captured_at);
+    auto converted_proto_timestamp = time_pt_to_timestamp(images.metadata.captured_at);
     BOOST_CHECK(resp.response_metadata().captured_at().seconds() ==
                 converted_proto_timestamp.seconds());
     BOOST_CHECK(resp.response_metadata().captured_at().nanos() ==
                 converted_proto_timestamp.nanos());
 
-    auto tp_from_proto = Camera::timestamp_to_time_pt(resp.response_metadata().captured_at());
-    BOOST_CHECK(tp_from_proto == images.captured_at);
+    auto tp_from_proto = timestamp_to_time_pt(resp.response_metadata().captured_at());
+    BOOST_CHECK(tp_from_proto == images.metadata.captured_at);
 
     std::vector<unsigned char> bytes0 = string_to_bytes(resp.images()[0].image());
     BOOST_CHECK(bytes0 == images.images[0].bytes);


### PR DESCRIPTION
Since we are now returning a general "response metadata" message from proto, this will ensure that future additions to the metadata will not be a breaking change.