### PR TITLE
RSDK-2069 - stop using remote generation for proto

### DIFF
--- a/src/viam/api/config/buf.gen.custom.remote.yaml.in
+++ b/src/viam/api/config/buf.gen.custom.remote.yaml.in
@@ -20,5 +20,5 @@ plugins:
     # with the `-1` bit if so? Or should this be a fixed value, rather
     # than being derived from the version of gRPC against which we are
     # building?
-  - remote: buf.build/grpc/plugins/cpp:v@VIAMCPPSDK_GRPCXX_VERSION@-1
+  - plugin: buf.build/grpc/cpp:v@VIAMCPPSDK_GRPCXX_VERSION@-1
     out: gen/viam/api


### PR DESCRIPTION
#### Major changes
Stop using remote generation for proto.

#### Testing
Successful proto generation locally, will confirm the github action works as well once this is merged.