### PR TITLE
APP-2519: org API key support

### DIFF
--- a/src/viam/examples/dial_api_key/CMakeLists.txt
+++ b/src/viam/examples/dial_api_key/CMakeLists.txt
@@ -12,9 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(dial)
-add_subdirectory(dial_api_key)
-add_subdirectory(modules)
-add_subdirectory(mlmodel)
-add_subdirectory(motor)
-add_subdirectory(camera)
+add_executable(example_dial_api_key
+  example_dial_api_key.cpp
+)
+
+target_link_libraries(example_dial_api_key
+  viam-cpp-sdk::viamsdk
+)
+
+install(
+  TARGETS example_dial_api_key
+  COMPONENT viam-cpp-sdk_examples
+)

--- a/src/viam/examples/dial_api_key/example_dial_api_key.cpp
+++ b/src/viam/examples/dial_api_key/example_dial_api_key.cpp
@@ -1,0 +1,67 @@
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+#include <boost/optional.hpp>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/support/status.h>
+
+#include <viam/api/common/v1/common.pb.h>
+#include <viam/api/robot/v1/robot.grpc.pb.h>
+#include <viam/api/robot/v1/robot.pb.h>
+
+#include <viam/sdk/components/generic/client.hpp>
+#include <viam/sdk/robot/client.hpp>
+#include <viam/sdk/robot/service.hpp>
+#include <viam/sdk/rpc/dial.hpp>
+
+using viam::robot::v1::Status;
+using namespace viam::sdk;
+
+int main() {
+    const char* uri = "<your robot URI here>";
+    DialOptions dial_options;
+    std::string type = "api-key";
+    std::string entity = "<your api key id>";
+    std::string payload = "<your api key value>";
+    dial_options.set_entity(entity);
+    Credentials credentials(type, payload);
+    dial_options.set_credentials(credentials);
+    boost::optional<DialOptions> opts(dial_options);
+    std::string address(uri);
+    Options options(1, opts);
+
+    // connect to robot, ensure we can refresh it
+    std::shared_ptr<RobotClient> robot = RobotClient::at_address(address, options);
+
+    // ensure we can query resources
+    std::vector<ResourceName>* resource_names = robot->resource_names();
+    for (ResourceName resource : *resource_names) {
+        std::cout << "Resource name: " << resource.name() << resource.type() << resource.subtype()
+                  << std::endl;
+    }
+
+    // ensure we can query statuses
+    std::vector<Status> status_plural = robot->get_status();
+    std::cout << "Status plural len " << status_plural.size() << std::endl;
+    for (Status s : status_plural) {
+        std::cout << " Status! " << s.name().subtype() << std::endl;
+    }
+
+    // ensure we can send requests for specific resources
+    std::vector<ResourceName> just_one = {resource_names->at(0)};
+    std::vector<Status> status_singular = robot->get_status(just_one);
+    std::cout << "Status singular len " << status_singular.size() << std::endl;
+    for (Status s : status_singular) {
+        std::cout << " Status! " << s.name().subtype() << std::endl;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -15,8 +15,12 @@
 extern "C" void* init_rust_runtime();
 extern "C" int free_rust_runtime(void* ptr);
 extern "C" void free_string(const char* s);
-extern "C" char* dial(
-    const char* uri, const char* entity, const char* type, const char* payload, bool allow_insecure, void* ptr);
+extern "C" char* dial(const char* uri,
+                      const char* entity,
+                      const char* type,
+                      const char* payload,
+                      bool allow_insecure,
+                      void* ptr);
 namespace viam {
 namespace sdk {
 
@@ -52,6 +56,10 @@ void DialOptions::set_entity(boost::optional<std::string> entity) {
     auth_entity_ = entity;
 }
 
+const boost::optional<std::string>& DialOptions::entity() const {
+    return auth_entity_;
+}
+
 const boost::optional<Credentials>& DialOptions::credentials() const {
     return credentials_;
 }
@@ -69,13 +77,17 @@ std::shared_ptr<ViamChannel> ViamChannel::dial(const char* uri,
     void* ptr = init_rust_runtime();
     const DialOptions opts = options.get_value_or(DialOptions());
     const char* type = nullptr;
+    const char* entity = nullptr;
     const char* payload = nullptr;
 
     if (opts.credentials()) {
         type = opts.credentials()->type().c_str();
         payload = opts.credentials()->payload().c_str();
     }
-    char* socket_path = ::dial(uri, type, payload, opts.allows_insecure_downgrade(), ptr);
+    if (opts.entity()) {
+        entity = opts.entity()->c_str();
+    }
+    char* socket_path = ::dial(uri, entity, type, payload, opts.allows_insecure_downgrade(), ptr);
     if (socket_path == NULL) {
         free_rust_runtime(ptr);
         // TODO(RSDK-1742) Replace throwing of strings with throwing of

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -16,7 +16,7 @@ extern "C" void* init_rust_runtime();
 extern "C" int free_rust_runtime(void* ptr);
 extern "C" void free_string(const char* s);
 extern "C" char* dial(
-    const char* uri, const char* type, const char* payload, bool allow_insecure, void* ptr);
+    const char* uri, const char* entity, const char* type, const char* payload, bool allow_insecure, void* ptr);
 namespace viam {
 namespace sdk {
 
@@ -46,6 +46,10 @@ ViamChannel::ViamChannel(std::shared_ptr<grpc::Channel> channel, const char* pat
 
 void DialOptions::set_credentials(boost::optional<Credentials> creds) {
     credentials_ = creds;
+}
+
+void DialOptions::set_entity(boost::optional<std::string> entity) {
+    auth_entity_ = entity;
 }
 
 const boost::optional<Credentials>& DialOptions::credentials() const {

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -44,6 +44,7 @@ class DialOptions {
         : auth_entity_(boost::none), credentials_(boost::none), allow_insecure_downgrade_(false) {}
 
     const boost::optional<Credentials>& credentials() const;
+    const boost::optional<std::string>& entity() const;
     bool allows_insecure_downgrade() const;
 
     void set_entity(boost::optional<std::string> entity);

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -46,6 +46,7 @@ class DialOptions {
     const boost::optional<Credentials>& credentials() const;
     bool allows_insecure_downgrade() const;
 
+    void set_entity(boost::optional<std::string> entity);
     void set_credentials(boost::optional<Credentials> creds);
     void set_allow_insecure_downgrade(bool allow);
 


### PR DESCRIPTION
[APP-2519](https://viam.atlassian.net/browse/APP-2519)

```cpp
#include <strings>
#include <vector>

#include <boost/optional.hpp>

#include <viam/api/common/v1/common.pb.h>
#include <viam/api/robot/v1/robot.grpc.pb.h>

#include <viam/sdk/robot/client.hpp>


using namespace viam::sdk;

int main() {
  std::string host("airbot-remote-main.74fk6cl2ql.viam.cloud");
  DialOptions dial_opts;
  Credentials credentials("<key>");
  dial_opts.set_type("api-key");
  dial_opts.set_entity("<key ID>");
  dial_opts.set_credentials(credentials);
  boost::optional<DialOptions> opts(dial_opts);
  Options options(0, opts);

  auto robot = RobotClient::at_address(host, options);

  std::cout << "Resources:\n";
  for (const ResourceName& resource: *robot->resource_names()) {
    std::cout << resource.namespace_() << ":" << resource.type() << ":"
              << resource.subtype() << ":" << resource.name() << "\n";
  }
  

  return 0;
}
```

**thank you** @zaporter-work for building/compiling this and making sure it works because I couldn't get our C++ SDK to work 😭 

[APP-2519]: https://viam.atlassian.net/browse/APP-2519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ