### PR TITLE
RSDK-4760 consume .a from rust-utils

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,5 +26,6 @@ jobs:
           if [ -n "$GEN_DIFF" ]; then
               echo 'linting resulted in changes not in git' 1>&2
               git status
+              git diff
               exit 1
           fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,9 +225,9 @@ find_package(Threads REQUIRED)
 # TODO: When this is removed, also remove the
 # `target_link_directories` call down in src/CMakeLists.txt, as it
 # will no longer be neede.
-set(viam_rust_utils_file ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils${CMAKE_SHARED_LIBRARY_SUFFIX})
+set(viam_rust_utils_file ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils${CMAKE_STATIC_LIBRARY_SUFFIX})
 
-file(GLOB viam_rust_utils_files ${PROJECT_SOURCE_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils*${CMAKE_SHARED_LIBRARY_SUFFIX})
+file(GLOB viam_rust_utils_files ${PROJECT_SOURCE_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils*${CMAKE_STATIC_LIBRARY_SUFFIX})
 
 if (viam_rust_utils_files)
   list(LENGTH viam_rust_utils_files num_viam_rust_utils_files)
@@ -246,7 +246,7 @@ else()
   endif()
   file(
     DOWNLOAD
-    https://github.com/viamrobotics/rust-utils/releases/latest/download/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils-${lvru_system_name}_${CMAKE_SYSTEM_PROCESSOR}${CMAKE_SHARED_LIBRARY_SUFFIX}
+    https://github.com/viamrobotics/rust-utils/releases/latest/download/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils-${lvru_system_name}_${CMAKE_SYSTEM_PROCESSOR}${CMAKE_STATIC_LIBRARY_SUFFIX}
     ${viam_rust_utils_file}
     STATUS lvru_status
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,15 +225,9 @@ find_package(Threads REQUIRED)
 # TODO: When this is removed, also remove the
 # `target_link_directories` call down in src/CMakeLists.txt, as it
 # will no longer be needed.
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  # note: we use shared on osx because system-security fails to link with static
-  set(viam_rust_suffix ${CMAKE_SHARED_LIBRARY_SUFFIX})
-else()
-  set(viam_rust_suffix ${CMAKE_STATIC_LIBRARY_SUFFIX})
-endif()
-set(viam_rust_utils_file ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils${viam_rust_suffix})
+set(viam_rust_utils_file ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils${CMAKE_STATIC_LIBRARY_SUFFIX})
 
-file(GLOB viam_rust_utils_files ${PROJECT_SOURCE_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils*${viam_rust_suffix})
+file(GLOB viam_rust_utils_files ${PROJECT_SOURCE_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils*${CMAKE_STATIC_LIBRARY_SUFFIX})
 
 if (viam_rust_utils_files)
   list(LENGTH viam_rust_utils_files num_viam_rust_utils_files)
@@ -252,7 +246,7 @@ else()
   endif()
   file(
     DOWNLOAD
-    https://github.com/viamrobotics/rust-utils/releases/latest/download/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils-${lvru_system_name}_${CMAKE_SYSTEM_PROCESSOR}${viam_rust_suffix}
+    https://github.com/viamrobotics/rust-utils/releases/latest/download/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils-${lvru_system_name}_${CMAKE_SYSTEM_PROCESSOR}${CMAKE_STATIC_LIBRARY_SUFFIX}
     ${viam_rust_utils_file}
     STATUS lvru_status
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,10 +224,16 @@ find_package(Threads REQUIRED)
 #
 # TODO: When this is removed, also remove the
 # `target_link_directories` call down in src/CMakeLists.txt, as it
-# will no longer be neede.
-set(viam_rust_utils_file ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils${CMAKE_STATIC_LIBRARY_SUFFIX})
+# will no longer be needed.
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  # note: we use shared on osx because system-security fails to link with static
+  set(viam_rust_suffix ${CMAKE_SHARED_LIBRARY_SUFFIX})
+else()
+  set(viam_rust_suffix ${CMAKE_STATIC_LIBRARY_SUFFIX})
+endif()
+set(viam_rust_utils_file ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils${viam_rust_suffix})
 
-file(GLOB viam_rust_utils_files ${PROJECT_SOURCE_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils*${CMAKE_STATIC_LIBRARY_SUFFIX})
+file(GLOB viam_rust_utils_files ${PROJECT_SOURCE_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils*${viam_rust_suffix})
 
 if (viam_rust_utils_files)
   list(LENGTH viam_rust_utils_files num_viam_rust_utils_files)
@@ -246,7 +252,7 @@ else()
   endif()
   file(
     DOWNLOAD
-    https://github.com/viamrobotics/rust-utils/releases/latest/download/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils-${lvru_system_name}_${CMAKE_SYSTEM_PROCESSOR}${CMAKE_STATIC_LIBRARY_SUFFIX}
+    https://github.com/viamrobotics/rust-utils/releases/latest/download/${CMAKE_SHARED_LIBRARY_PREFIX}viam_rust_utils-${lvru_system_name}_${CMAKE_SYSTEM_PROCESSOR}${viam_rust_suffix}
     ${viam_rust_utils_file}
     STATUS lvru_status
   )

--- a/src/viam/examples/modules/simple/main.cpp
+++ b/src/viam/examples/modules/simple/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <sstream>
 #include <memory>
 #include <signal.h>
 

--- a/src/viam/examples/modules/simple/main.cpp
+++ b/src/viam/examples/modules/simple/main.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
-#include <sstream>
 #include <memory>
 #include <signal.h>
+#include <sstream>
 
 #include <boost/log/trivial.hpp>
 #include <grpcpp/grpcpp.h>

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -202,6 +202,11 @@ target_link_libraries(viamsdk
 )
 
 
+if (APPLE)
+  target_link_libraries(viamsdk PUBLIC "-framework Security")
+endif()
+
+
 install(
   TARGETS viamsdk
   EXPORT viamsdk


### PR DESCRIPTION
## what changed
- download the `.a` instead of the `.so` for libviam_rust_utils
- I did this because the `.so` ends up in a nested directory and therefore adds complexity to module bundling; with the `.a`, there's nothing to bundle
- I think this makes the distributable size for a C++ module smaller
## incidental changes
- added sstream to examples/modules/simple to fix compile error; not sure why this worked before + is failing now
- convenience change to show lint diff in CI when it fails
## optional configuration
- if we want to preserve the old behavior, I can put the file extension behind a config flag
## possible extra testing
- ~:apple: this works on x86 + arm linux per [this module-example-cpp CI run](https://github.com/viamrobotics/module-example-cpp/actions/runs/6150750042), but I didn't try this on a mac~ -> works on mac now