### PR TITLE
RSDK-4275 Handle `construct_resource` errors in module service

### DIFF
--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -75,7 +75,11 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
     const Dependencies deps = get_dependencies(this, request->dependencies());
     const std::shared_ptr<ModelRegistration> reg = Registry::lookup_model(cfg.api(), cfg.model());
     if (reg) {
-        res = reg->construct_resource(deps, cfg);
+        try {
+            res = reg->construct_resource(deps, cfg);
+        } catch (const std::exception& exc) {
+            return grpc::Status(::grpc::INTERNAL, exc.what());
+        }
     };
     const std::unordered_map<API, std::shared_ptr<ResourceManager>>& services = module->services();
     if (services.find(cfg.api()) == services.end()) {

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -131,8 +131,12 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
 
     const std::shared_ptr<ModelRegistration> reg = Registry::lookup_model(cfg.name());
     if (reg) {
-        const std::shared_ptr<Resource> res = reg->construct_resource(deps, cfg);
-        manager->replace_one(cfg.resource_name(), res);
+        try {
+            const std::shared_ptr<Resource> res = reg->construct_resource(deps, cfg);
+            manager->replace_one(cfg.resource_name(), res);
+        } catch (const std::exception& exc) {
+            return grpc::Status(::grpc::INTERNAL, exc.what());
+        }
     }
 
     return grpc::Status();


### PR DESCRIPTION
[RSDK-4275](https://viam.atlassian.net/browse/RSDK-4275)

Properly catches exceptions thrown by `construct_resource` in `ModuleService::AddResource` and `ModuleService::ReconfigureResource`. Tested with the example simple module by throwing errors in the constructor and `reconfigure` method.

[RSDK-4275]: https://viam.atlassian.net/browse/RSDK-4275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ