### PR TITLE
RSDK-5194 - set client_ctx auth to a placeholder value

### DIFF
--- a/src/viam/examples/dial/example_dial.cpp
+++ b/src/viam/examples/dial/example_dial.cpp
@@ -63,7 +63,11 @@ int main() {
 
     // ensure we can create clients to the robot
     auto gc = robot->resource_by_name<GenericClient>("generic1");
-    std::cout << "got generic client named " << gc->name() << std::endl;
+    if (gc) {
+        std::cout << "got generic client named " << gc->name() << std::endl;
+    }
+
+    robot->close();
 
     return EXIT_SUCCESS;
 }

--- a/src/viam/examples/modules/complex/gizmo/api.cpp
+++ b/src/viam/examples/modules/complex/gizmo/api.cpp
@@ -4,6 +4,7 @@
 
 #include <google/protobuf/descriptor.h>
 
+#include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/registry/registry.hpp>
 #include <viam/sdk/resource/resource.hpp>
 #include <viam/sdk/rpc/server.hpp>
@@ -206,6 +207,7 @@ bool GizmoClient::do_one(std::string arg1) {
     DoOneResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     request.set_arg1(arg1);
@@ -221,6 +223,7 @@ bool GizmoClient::do_one(std::string arg1) {
 bool GizmoClient::do_one_client_stream(std::vector<std::string> arg1) {
     DoOneClientStreamResponse response;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     auto writer(stub_->DoOneClientStream(&ctx, &response));
     for (std::string arg : arg1) {
@@ -244,6 +247,7 @@ bool GizmoClient::do_one_client_stream(std::vector<std::string> arg1) {
 std::vector<bool> GizmoClient::do_one_server_stream(std::string arg1) {
     DoOneServerStreamRequest request;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     request.set_arg1(arg1);
@@ -264,6 +268,7 @@ std::vector<bool> GizmoClient::do_one_server_stream(std::string arg1) {
 
 std::vector<bool> GizmoClient::do_one_bidi_stream(std::vector<std::string> arg1) {
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     auto stream(stub_->DoOneBiDiStream(&ctx));
     for (std::string arg : arg1) {
@@ -296,6 +301,7 @@ std::string GizmoClient::do_two(bool arg1) {
     DoTwoResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     request.set_arg1(arg1);

--- a/src/viam/examples/modules/complex/summation/api.cpp
+++ b/src/viam/examples/modules/complex/summation/api.cpp
@@ -4,6 +4,7 @@
 
 #include <google/protobuf/descriptor.h>
 
+#include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/registry/registry.hpp>
 #include <viam/sdk/resource/resource.hpp>
 #include <viam/sdk/rpc/server.hpp>
@@ -96,6 +97,7 @@ double SummationClient::sum(std::vector<double> numbers) {
     SumResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     for (double number : numbers) {

--- a/src/viam/sdk/common/utils.cpp
+++ b/src/viam/sdk/common/utils.cpp
@@ -11,6 +11,7 @@
 #include <boost/optional/optional.hpp>
 #include <boost/variant/get.hpp>
 #include <boost/variant/variant.hpp>
+#include <grpcpp/client_context.h>
 
 #include <viam/api/common/v1/common.pb.h>
 
@@ -128,6 +129,14 @@ void set_logger_severity_from_args(int argc, char** argv) {
 
 bool operator==(const response_metadata& lhs, const response_metadata& rhs) {
     return lhs.captured_at == rhs.captured_at;
+}
+
+// the authority is sometimes set to an invalid uri on mac, causing `rust-utils` to fail
+// to process gRPC requests. Fortunately we don't particularly care what the authority is
+// set to within the ctx once a channel is built, so we can just set a placeholder value
+// to appease rust and continue to rely on the gRPC channel to process requests correctly.
+void set_client_ctx_authority(grpc::ClientContext& ctx) {
+    ctx.set_authority("viam-placeholder");
 }
 
 bool from_dm_from_extra(const AttributeMap& extra) {

--- a/src/viam/sdk/common/utils.cpp
+++ b/src/viam/sdk/common/utils.cpp
@@ -131,10 +131,6 @@ bool operator==(const response_metadata& lhs, const response_metadata& rhs) {
     return lhs.captured_at == rhs.captured_at;
 }
 
-// the authority is sometimes set to an invalid uri on mac, causing `rust-utils` to fail
-// to process gRPC requests. Fortunately we don't particularly care what the authority is
-// set to within the ctx once a channel is built, so we can just set a placeholder value
-// to appease rust and continue to rely on the gRPC channel to process requests correctly.
 void set_client_ctx_authority(grpc::ClientContext& ctx) {
     ctx.set_authority("viam-placeholder");
 }

--- a/src/viam/sdk/common/utils.hpp
+++ b/src/viam/sdk/common/utils.hpp
@@ -66,6 +66,12 @@ std::string bytes_to_string(std::vector<unsigned char> const& b);
 
 std::chrono::microseconds from_proto(const google::protobuf::Duration& proto);
 google::protobuf::Duration to_proto(const std::chrono::microseconds& duration);
+
+// the authority is sometimes set to an invalid uri on mac, causing `rust-utils` to fail
+// to process gRPC requests. Fortunately we don't particularly care what the authority is
+// set to within the ctx once a channel is built, so we can just set a placeholder value
+// to appease rust and continue to rely on the gRPC channel to process requests correctly.
+// For more details, see https://viam.atlassian.net/browse/RSDK-5194.
 void set_client_ctx_authority(grpc::ClientContext& ctx);
 
 /// @brief Set the boost trivial logger's severity depending on args.

--- a/src/viam/sdk/common/utils.hpp
+++ b/src/viam/sdk/common/utils.hpp
@@ -6,6 +6,7 @@
 #include <boost/optional/optional.hpp>
 #include <boost/variant/get.hpp>
 #include <boost/variant/variant.hpp>
+#include <grpcpp/client_context.h>
 
 #include <viam/api/common/v1/common.pb.h>
 
@@ -65,6 +66,7 @@ std::string bytes_to_string(std::vector<unsigned char> const& b);
 
 std::chrono::microseconds from_proto(const google::protobuf::Duration& proto);
 google::protobuf::Duration to_proto(const std::chrono::microseconds& duration);
+void set_client_ctx_authority(grpc::ClientContext& ctx);
 
 /// @brief Set the boost trivial logger's severity depending on args.
 /// @param argc The number of args.

--- a/src/viam/sdk/components/base/client.cpp
+++ b/src/viam/sdk/components/base/client.cpp
@@ -30,6 +30,7 @@ void BaseClient::move_straight(int64_t distance_mm, double mm_per_sec, const Att
     viam::component::base::v1::MoveStraightResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     request.set_distance_mm(distance_mm);
@@ -47,6 +48,7 @@ void BaseClient::spin(double angle_deg, double degs_per_sec, const AttributeMap&
     viam::component::base::v1::SpinResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     request.set_angle_deg(angle_deg);
@@ -66,6 +68,7 @@ void BaseClient::set_power(const Vector3& linear,
     viam::component::base::v1::SetPowerResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_linear() = Vector3::to_proto(linear);
@@ -85,6 +88,7 @@ void BaseClient::set_velocity(const Vector3& linear,
     viam::component::base::v1::SetVelocityResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_linear() = Vector3::to_proto(linear);
@@ -102,6 +106,7 @@ grpc::StatusCode BaseClient::stop(const AttributeMap& extra) {
     viam::component::base::v1::StopResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -118,6 +123,7 @@ bool BaseClient::is_moving() {
     viam::component::base::v1::IsMovingResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
 
@@ -132,6 +138,7 @@ std::vector<GeometryConfig> BaseClient::get_geometries(const AttributeMap& extra
     viam::common::v1::GetGeometriesRequest req;
     viam::common::v1::GetGeometriesResponse resp;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *req.mutable_name() = this->name();
     *req.mutable_extra() = map_to_struct(extra);
@@ -144,6 +151,7 @@ Base::properties BaseClient::get_properties(const AttributeMap& extra) {
     component::base::v1::GetPropertiesRequest req;
     component::base::v1::GetPropertiesResponse resp;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *req.mutable_name() = this->name();
     *req.mutable_extra() = map_to_struct(extra);
@@ -157,6 +165,7 @@ AttributeMap BaseClient::do_command(const AttributeMap& command) {
     viam::common::v1::DoCommandResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     const google::protobuf::Struct proto_command = map_to_struct(command);
     *request.mutable_command() = proto_command;

--- a/src/viam/sdk/components/board/client.cpp
+++ b/src/viam/sdk/components/board/client.cpp
@@ -27,6 +27,7 @@ Board::status BoardClient::get_status(const AttributeMap& extra) {
     viam::component::board::v1::StatusResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -43,6 +44,7 @@ void BoardClient::set_gpio(const std::string& pin, bool high, const AttributeMap
     viam::component::board::v1::SetGPIOResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -59,6 +61,7 @@ bool BoardClient::get_gpio(const std::string& pin, const AttributeMap& extra) {
     viam::component::board::v1::GetGPIOResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -76,6 +79,7 @@ double BoardClient::get_pwm_duty_cycle(const std::string& pin, const AttributeMa
     viam::component::board::v1::PWMResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -95,6 +99,7 @@ void BoardClient::set_pwm_duty_cycle(const std::string& pin,
     viam::component::board::v1::SetPWMResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -112,6 +117,7 @@ uint64_t BoardClient::get_pwm_frequency(const std::string& pin, const AttributeM
     viam::component::board::v1::PWMFrequencyResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -131,6 +137,7 @@ void BoardClient::set_pwm_frequency(const std::string& pin,
     viam::component::board::v1::SetPWMFrequencyResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -148,6 +155,7 @@ AttributeMap BoardClient::do_command(const AttributeMap& command) {
     viam::common::v1::DoCommandResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     const google::protobuf::Struct proto_command = map_to_struct(command);
     *request.mutable_command() = proto_command;
@@ -166,6 +174,7 @@ Board::analog_value BoardClient::read_analog(const std::string& analog_reader_na
     viam::component::board::v1::ReadAnalogReaderResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     request.set_board_name(this->name());
     request.set_analog_reader_name(analog_reader_name);
@@ -184,6 +193,7 @@ Board::digital_value BoardClient::read_digital_interrupt(const std::string& digi
     viam::component::board::v1::GetDigitalInterruptValueResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     request.set_board_name(this->name());
     request.set_digital_interrupt_name(digital_interrupt_name);
@@ -203,6 +213,7 @@ void BoardClient::set_power_mode(power_mode power_mode,
     viam::component::board::v1::SetPowerModeResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -221,6 +232,7 @@ std::vector<GeometryConfig> BoardClient::get_geometries(const AttributeMap& extr
     viam::common::v1::GetGeometriesRequest req;
     viam::common::v1::GetGeometriesResponse resp;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *req.mutable_name() = this->name();
     *req.mutable_extra() = map_to_struct(extra);

--- a/src/viam/sdk/components/camera/client.cpp
+++ b/src/viam/sdk/components/camera/client.cpp
@@ -25,6 +25,7 @@ AttributeMap CameraClient::do_command(AttributeMap command) {
     viam::common::v1::DoCommandRequest req;
     viam::common::v1::DoCommandResponse resp;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     const google::protobuf::Struct proto_command = map_to_struct(command);
     *req.mutable_command() = proto_command;
@@ -37,6 +38,7 @@ Camera::raw_image CameraClient::get_image(std::string mime_type, const Attribute
     viam::component::camera::v1::GetImageRequest req;
     viam::component::camera::v1::GetImageResponse resp;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     Camera::normalize_mime_type(mime_type);
 
@@ -52,6 +54,7 @@ Camera::image_collection CameraClient::get_images() {
     viam::component::camera::v1::GetImagesRequest req;
     viam::component::camera::v1::GetImagesResponse resp;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *req.mutable_name() = this->name();
 
@@ -64,6 +67,7 @@ Camera::point_cloud CameraClient::get_point_cloud(std::string mime_type,
     viam::component::camera::v1::GetPointCloudRequest req;
     viam::component::camera::v1::GetPointCloudResponse resp;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *req.mutable_name() = this->name();
     *req.mutable_mime_type() = mime_type;
@@ -77,6 +81,7 @@ std::vector<GeometryConfig> CameraClient::get_geometries(const AttributeMap& ext
     viam::common::v1::GetGeometriesRequest req;
     viam::common::v1::GetGeometriesResponse resp;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *req.mutable_name() = this->name();
     *req.mutable_extra() = map_to_struct(extra);
@@ -89,6 +94,7 @@ Camera::properties CameraClient::get_properties() {
     viam::component::camera::v1::GetPropertiesRequest req;
     viam::component::camera::v1::GetPropertiesResponse resp;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *req.mutable_name() = this->name();
 

--- a/src/viam/sdk/components/encoder/client.cpp
+++ b/src/viam/sdk/components/encoder/client.cpp
@@ -28,6 +28,7 @@ Encoder::position EncoderClient::get_position(const AttributeMap& extra,
     viam::component::encoder::v1::GetPositionResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     request.set_position_type(to_proto(position_type));
@@ -45,6 +46,7 @@ void EncoderClient::reset_position(const AttributeMap& extra) {
     viam::component::encoder::v1::ResetPositionResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -60,6 +62,7 @@ Encoder::properties EncoderClient::get_properties(const AttributeMap& extra) {
     viam::component::encoder::v1::GetPropertiesResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -75,6 +78,7 @@ std::vector<GeometryConfig> EncoderClient::get_geometries(const AttributeMap& ex
     viam::common::v1::GetGeometriesRequest req;
     viam::common::v1::GetGeometriesResponse resp;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *req.mutable_name() = this->name();
     *req.mutable_extra() = map_to_struct(extra);
@@ -88,6 +92,7 @@ AttributeMap EncoderClient::do_command(AttributeMap command) {
     viam::common::v1::DoCommandResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     const google::protobuf::Struct proto_command = map_to_struct(command);
     *request.mutable_command() = proto_command;

--- a/src/viam/sdk/components/generic/client.cpp
+++ b/src/viam/sdk/components/generic/client.cpp
@@ -6,6 +6,7 @@
 #include <viam/api/component/generic/v1/generic.grpc.pb.h>
 
 #include <viam/sdk/common/proto_type.hpp>
+#include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/config/resource.hpp>
 #include <viam/sdk/robot/client.hpp>
 
@@ -21,6 +22,7 @@ AttributeMap GenericClient::do_command(AttributeMap command) {
     viam::common::v1::DoCommandRequest req;
     viam::common::v1::DoCommandResponse resp;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     const google::protobuf::Struct proto_command = map_to_struct(command);
     *req.mutable_command() = proto_command;
@@ -32,6 +34,7 @@ std::vector<GeometryConfig> GenericClient::get_geometries() {
     viam::common::v1::GetGeometriesRequest req;
     viam::common::v1::GetGeometriesResponse resp;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *req.mutable_name() = this->name();
 

--- a/src/viam/sdk/components/motor/client.cpp
+++ b/src/viam/sdk/components/motor/client.cpp
@@ -27,6 +27,7 @@ void MotorClient::set_power(double power_pct, const AttributeMap& extra) {
     viam::component::motor::v1::SetPowerResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -43,6 +44,7 @@ void MotorClient::go_for(double rpm, double revolutions, const AttributeMap& ext
     viam::component::motor::v1::GoForResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -60,6 +62,7 @@ void MotorClient::go_to(double rpm, double position_revolutions, const Attribute
     viam::component::motor::v1::GoToResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -77,6 +80,7 @@ void MotorClient::reset_zero_position(double offset, const AttributeMap& extra) 
     viam::component::motor::v1::ResetZeroPositionResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -93,6 +97,7 @@ Motor::position MotorClient::get_position(const AttributeMap& extra) {
     viam::component::motor::v1::GetPositionResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -109,6 +114,7 @@ Motor::properties MotorClient::get_properties(const AttributeMap& extra) {
     viam::component::motor::v1::GetPropertiesResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -125,6 +131,7 @@ grpc::StatusCode MotorClient::stop(const AttributeMap& extra) {
     viam::component::motor::v1::StopResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -138,6 +145,7 @@ Motor::power_status MotorClient::get_power_status(const AttributeMap& extra) {
     viam::component::motor::v1::IsPoweredResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_extra() = map_to_struct(extra);
@@ -153,6 +161,7 @@ std::vector<GeometryConfig> MotorClient::get_geometries(const AttributeMap& extr
     viam::common::v1::GetGeometriesRequest req;
     viam::common::v1::GetGeometriesResponse resp;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *req.mutable_name() = this->name();
     *req.mutable_extra() = map_to_struct(extra);
@@ -166,6 +175,7 @@ bool MotorClient::is_moving() {
     viam::component::motor::v1::IsMovingResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
 
@@ -181,6 +191,7 @@ AttributeMap MotorClient::do_command(const AttributeMap& command) {
     viam::common::v1::DoCommandResponse response;
 
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_command() = map_to_struct(command);
     *request.mutable_name() = this->name();

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -90,6 +90,7 @@ std::vector<Status> RobotClient::get_status(std::vector<ResourceName>& component
     viam::robot::v1::GetStatusRequest req;
     viam::robot::v1::GetStatusResponse resp;
     ClientContext ctx;
+    set_client_ctx_authority(ctx);
     for (const ResourceName& name : components) {
         *req.mutable_resource_names()->Add() = name;
     }
@@ -115,6 +116,7 @@ std::vector<Operation> RobotClient::get_operations() {
     const viam::robot::v1::GetOperationsRequest req;
     viam::robot::v1::GetOperationsResponse resp;
     ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     std::vector<Operation> operations;
 
@@ -134,6 +136,7 @@ void RobotClient::cancel_operation(std::string id) {
     viam::robot::v1::CancelOperationRequest req;
     viam::robot::v1::CancelOperationResponse resp;
     ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     req.set_id(id);
     const grpc::Status response = stub_->CancelOperation(&ctx, req, &resp);
@@ -146,6 +149,7 @@ void RobotClient::block_for_operation(std::string id) {
     viam::robot::v1::BlockForOperationRequest req;
     viam::robot::v1::BlockForOperationResponse resp;
     ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     req.set_id(id);
 
@@ -159,6 +163,7 @@ void RobotClient::refresh() {
     const viam::robot::v1::ResourceNamesRequest req;
     viam::robot::v1::ResourceNamesResponse resp;
     ClientContext ctx;
+    set_client_ctx_authority(ctx);
     const grpc::Status response = stub_->ResourceNames(&ctx, req, &resp);
     if (is_error_response(response)) {
         BOOST_LOG_TRIVIAL(error) << "Error getting resource names: " << response.error_message();
@@ -278,6 +283,7 @@ std::vector<FrameSystemConfig> RobotClient::get_frame_system_config(
     viam::robot::v1::FrameSystemConfigRequest req;
     viam::robot::v1::FrameSystemConfigResponse resp;
     ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     RepeatedPtrField<Transform>* req_transforms = req.mutable_supplemental_transforms();
     for (const Transform& transform : additional_transforms) {
@@ -307,6 +313,7 @@ PoseInFrame RobotClient::transform_pose(PoseInFrame query,
     viam::robot::v1::TransformPoseRequest req;
     viam::robot::v1::TransformPoseResponse resp;
     ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *req.mutable_source() = query;
     *req.mutable_destination() = destination;
@@ -328,6 +335,7 @@ std::vector<Discovery> RobotClient::discover_components(std::vector<DiscoveryQue
     viam::robot::v1::DiscoverComponentsRequest req;
     viam::robot::v1::DiscoverComponentsResponse resp;
     ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     RepeatedPtrField<DiscoveryQuery>* req_queries = req.mutable_queries();
 
@@ -374,6 +382,7 @@ void RobotClient::stop_all(
     viam::robot::v1::StopAllRequest req;
     viam::robot::v1::StopAllResponse resp;
     ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     RepeatedPtrField<viam::robot::v1::StopExtraParameters>* ep = req.mutable_extra();
     for (auto& xtra : extra) {

--- a/src/viam/sdk/services/mlmodel/client.cpp
+++ b/src/viam/sdk/services/mlmodel/client.cpp
@@ -16,6 +16,7 @@
 
 #include <grpcpp/channel.h>
 
+#include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/services/mlmodel/private/proto.hpp>
 
 namespace viam {
@@ -38,6 +39,7 @@ std::shared_ptr<MLModelService::named_tensor_views> MLModelServiceClient::infer(
     *req->mutable_extra() = map_to_struct(extra);
     auto* const resp = pb::Arena::CreateMessage<mlpb::InferResponse>(arena.get());
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     struct arena_and_views {
         // NOTE: It is not necessary to capture the `resp` pointer
@@ -79,6 +81,7 @@ struct MLModelService::metadata MLModelServiceClient::metadata(const AttributeMa
 
     // Invoke the stub
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
     viam::service::mlmodel::v1::MetadataResponse resp;
     const auto stub_result = stub_->Metadata(&ctx, req, &resp);
 

--- a/src/viam/sdk/services/motion/client.cpp
+++ b/src/viam/sdk/services/motion/client.cpp
@@ -8,6 +8,7 @@
 #include <viam/api/service/motion/v1/motion.pb.h>
 
 #include <viam/sdk/common/proto_type.hpp>
+#include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/services/motion/motion.hpp>
 
 namespace viam {
@@ -26,6 +27,7 @@ bool MotionClient::move(const pose_in_frame& destination,
     service::motion::v1::MoveRequest request;
     service::motion::v1::MoveResponse response;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_component_name() = component_name.to_proto();
@@ -53,6 +55,7 @@ bool MotionClient::move_on_map(const pose& destination,
     service::motion::v1::MoveOnMapRequest request;
     service::motion::v1::MoveOnMapResponse response;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_destination() = destination.to_proto();
@@ -78,6 +81,7 @@ bool MotionClient::move_on_globe(const geo_point& destination,
     service::motion::v1::MoveOnGlobeRequest request;
     service::motion::v1::MoveOnGlobeResponse response;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_destination() = destination.to_proto();
@@ -113,6 +117,7 @@ pose_in_frame MotionClient::get_pose(
     service::motion::v1::GetPoseRequest request;
     service::motion::v1::GetPoseResponse response;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_name() = this->name();
     *request.mutable_component_name() = component_name.to_proto();
@@ -134,6 +139,7 @@ AttributeMap MotionClient::do_command(const AttributeMap& command) {
     viam::common::v1::DoCommandRequest request;
     viam::common::v1::DoCommandResponse response;
     grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
 
     *request.mutable_command() = map_to_struct(command);
     *request.mutable_name() = this->name();


### PR DESCRIPTION
#### Major changes
Set a placeholder `authority` value for gRPC client contexts.

#### What why? Please explain.
For reasons that aren't entirely clear to me, the `authority` value in the http headers sent to rust from C++ is set to the socket path to the rust runtime, e.g. `/tmp/proxy-XXXXXX.sock`. This is not a valid uri, and is causing rust to send back a `RST_STREAM` message to C++ rather than sending the request on to the server.

In python (and presumably in linux though I had some difficulty testing this), the header value was set to some valid localhost value (`127.0.0.1:50051`). It's not entirely clear to me where or why this is happening, but fortunately the authority value in the headers is not at all relevant for our use case. By simply setting the authority in the client context to some dummy value that is a syntactically valid uri, we no longer send invalid uris to rust and so are able to process calls correctly.