### PR TITLE
RSDK-5364 RSDK-5195 RSDK-3534

### DIFF
--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(PROTO_GEN_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-# TODO (RSDK-5364): update code to comply with up-to-date proto, then stop pinning to this commit
-set(BUF_PROTO_SOURCE buf.build/viamrobotics/api:2109757288234ffc8248121f60437cdd)
+set(BUF_PROTO_SOURCE buf.build/viamrobotics/api)
 set(BUF_PROTO_COMPONENTS
   app/v1
   common

--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(PROTO_GEN_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-set(BUF_PROTO_SOURCE buf.build/viamrobotics/api)
+# TODO (RSDK-5441): modify this pin through an automated process
+set(BUF_PROTO_SOURCE buf.build/viamrobotics/api:57108c60d0da8f46df147a496845bdf2160facd6)
 set(BUF_PROTO_COMPONENTS
   app/v1
   common

--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(PROTO_GEN_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 # TODO (RSDK-5441): modify this pin through an automated process
-set(BUF_PROTO_SOURCE buf.build/viamrobotics/api:57108c60d0da8f46df147a496845bdf2160facd6)
+set(BUF_PROTO_SOURCE buf.build/viamrobotics/api:v0.1.216)
 set(BUF_PROTO_COMPONENTS
   app/v1
   common

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -20,7 +20,7 @@ extern "C" char* dial(const char* uri,
                       const char* type,
                       const char* payload,
                       bool allow_insecure,
-                      const float timeout,
+                      float timeout,
                       void* ptr);
 namespace viam {
 namespace sdk {
@@ -57,7 +57,7 @@ void DialOptions::set_entity(boost::optional<std::string> entity) {
     auth_entity_ = entity;
 }
 
-void DialOptions::set_timeout(const float timeout) {
+void DialOptions::set_timeout(float timeout) {
     timeout_ = timeout;
 }
 
@@ -69,7 +69,7 @@ const boost::optional<Credentials>& DialOptions::credentials() const {
     return credentials_;
 }
 
-const float DialOptions::timeout() const {
+float DialOptions::timeout() const {
     return timeout_;
 }
 

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -68,6 +68,10 @@ void DialOptions::set_allow_insecure_downgrade(bool allow) {
     allow_insecure_downgrade_ = allow;
 }
 
+void DialOptions::set_timeout(float timeout) {
+    timeout_ = timeout;
+}
+
 bool DialOptions::allows_insecure_downgrade() const {
     return allow_insecure_downgrade_;
 }
@@ -76,6 +80,7 @@ std::shared_ptr<ViamChannel> ViamChannel::dial(const char* uri,
                                                boost::optional<DialOptions> options) {
     void* ptr = init_rust_runtime();
     const DialOptions opts = options.get_value_or(DialOptions());
+    const float timeout = options.get_value_or(20.0);
     const char* type = nullptr;
     const char* entity = nullptr;
     const char* payload = nullptr;
@@ -87,7 +92,7 @@ std::shared_ptr<ViamChannel> ViamChannel::dial(const char* uri,
     if (opts.entity()) {
         entity = opts.entity()->c_str();
     }
-    char* socket_path = ::dial(uri, entity, type, payload, opts.allows_insecure_downgrade(), ptr);
+    char* socket_path = ::dial(uri, entity, type, payload, opts.allows_insecure_downgrade(), timeout, ptr);
     if (socket_path == NULL) {
         free_rust_runtime(ptr);
         // TODO(RSDK-1742) Replace throwing of strings with throwing of

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -59,8 +59,8 @@ void DialOptions::set_entity(boost::optional<std::string> entity) {
     auth_entity_ = entity;
 }
 
-void DialOptions::set_timeout(std::chrono::seconds timeout) {
-    timeout_ = timeout;
+void DialOptions::set_timeout(std::chrono::duration<float> timeout) {
+    timeout_ = std::move(timeout);
 }
 
 const boost::optional<std::string>& DialOptions::entity() const {
@@ -71,7 +71,7 @@ const boost::optional<Credentials>& DialOptions::credentials() const {
     return credentials_;
 }
 
-std::chrono::seconds DialOptions::timeout() const {
+const std::chrono::duration<float>& DialOptions::timeout() const {
     return timeout_;
 }
 

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -69,7 +69,7 @@ const boost::optional<Credentials>& DialOptions::credentials() const {
     return credentials_;
 }
 
-float DialOptions::timeout() const {
+const float DialOptions::timeout() const {
     return timeout_;
 }
 

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -69,7 +69,7 @@ const boost::optional<Credentials>& DialOptions::credentials() const {
     return credentials_;
 }
 
-const float DialOptions::timeout() const {
+float DialOptions::timeout() const {
     return timeout_;
 }
 
@@ -85,7 +85,6 @@ std::shared_ptr<ViamChannel> ViamChannel::dial(const char* uri,
                                                boost::optional<DialOptions> options) {
     void* ptr = init_rust_runtime();
     const DialOptions opts = options.get_value_or(DialOptions());
-    const float timeout = opts.timeout();
     const char* type = nullptr;
     const char* entity = nullptr;
     const char* payload = nullptr;
@@ -97,7 +96,7 @@ std::shared_ptr<ViamChannel> ViamChannel::dial(const char* uri,
     if (opts.entity()) {
         entity = opts.entity()->c_str();
     }
-    char* socket_path = ::dial(uri, entity, type, payload, opts.allows_insecure_downgrade(), timeout, ptr);
+    char* socket_path = ::dial(uri, entity, type, payload, opts.allows_insecure_downgrade(), opts.timeout(), ptr);
     if (socket_path == NULL) {
         free_rust_runtime(ptr);
         // TODO(RSDK-1742) Replace throwing of strings with throwing of

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -85,6 +85,7 @@ std::shared_ptr<ViamChannel> ViamChannel::dial(const char* uri,
                                                boost::optional<DialOptions> options) {
     void* ptr = init_rust_runtime();
     const DialOptions opts = options.get_value_or(DialOptions());
+    const float timeout = opts.timeout();
     const char* type = nullptr;
     const char* entity = nullptr;
     const char* payload = nullptr;
@@ -96,7 +97,7 @@ std::shared_ptr<ViamChannel> ViamChannel::dial(const char* uri,
     if (opts.entity()) {
         entity = opts.entity()->c_str();
     }
-    char* socket_path = ::dial(uri, entity, type, payload, opts.allows_insecure_downgrade(), opts.timeout(), ptr);
+    char* socket_path = ::dial(uri, entity, type, payload, opts.allows_insecure_downgrade(), timeout , ptr);
     if (socket_path == NULL) {
         free_rust_runtime(ptr);
         // TODO(RSDK-1742) Replace throwing of strings with throwing of

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -97,7 +97,8 @@ std::shared_ptr<ViamChannel> ViamChannel::dial(const char* uri,
     if (opts.entity()) {
         entity = opts.entity()->c_str();
     }
-    char* socket_path = ::dial(uri, entity, type, payload, opts.allows_insecure_downgrade(), timeout , ptr);
+    char* socket_path =
+        ::dial(uri, entity, type, payload, opts.allows_insecure_downgrade(), timeout, ptr);
     if (socket_path == NULL) {
         free_rust_runtime(ptr);
         // TODO(RSDK-1742) Replace throwing of strings with throwing of

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -20,6 +20,7 @@ extern "C" char* dial(const char* uri,
                       const char* type,
                       const char* payload,
                       bool allow_insecure,
+                      float timeout,
                       void* ptr);
 namespace viam {
 namespace sdk {
@@ -56,6 +57,10 @@ void DialOptions::set_entity(boost::optional<std::string> entity) {
     auth_entity_ = entity;
 }
 
+void DialOptions::set_timeout(float timeout) {
+    timeout_ = timeout;
+}
+
 const boost::optional<std::string>& DialOptions::entity() const {
     return auth_entity_;
 }
@@ -64,12 +69,12 @@ const boost::optional<Credentials>& DialOptions::credentials() const {
     return credentials_;
 }
 
-void DialOptions::set_allow_insecure_downgrade(bool allow) {
-    allow_insecure_downgrade_ = allow;
+const float DialOptions::timeout() const {
+    return timeout_;
 }
 
-void DialOptions::set_timeout(float timeout) {
-    timeout_ = timeout;
+void DialOptions::set_allow_insecure_downgrade(bool allow) {
+    allow_insecure_downgrade_ = allow;
 }
 
 bool DialOptions::allows_insecure_downgrade() const {
@@ -80,7 +85,7 @@ std::shared_ptr<ViamChannel> ViamChannel::dial(const char* uri,
                                                boost::optional<DialOptions> options) {
     void* ptr = init_rust_runtime();
     const DialOptions opts = options.get_value_or(DialOptions());
-    const float timeout = options.get_value_or(20.0);
+    const float timeout = opts.timeout();
     const char* type = nullptr;
     const char* entity = nullptr;
     const char* payload = nullptr;

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -20,7 +20,7 @@ extern "C" char* dial(const char* uri,
                       const char* type,
                       const char* payload,
                       bool allow_insecure,
-                      float timeout,
+                      const float timeout,
                       void* ptr);
 namespace viam {
 namespace sdk {
@@ -57,7 +57,7 @@ void DialOptions::set_entity(boost::optional<std::string> entity) {
     auth_entity_ = entity;
 }
 
-void DialOptions::set_timeout(float timeout) {
+void DialOptions::set_timeout(const float timeout) {
     timeout_ = timeout;
 }
 

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -49,7 +49,7 @@ class DialOptions {
     const boost::optional<Credentials>& credentials() const;
     const boost::optional<std::string>& entity() const;
     bool allows_insecure_downgrade() const;
-    const float timeout() const;
+    float timeout() const;
 
     void set_entity(boost::optional<std::string> entity);
     void set_credentials(boost::optional<Credentials> creds);

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -41,11 +41,12 @@ class Credentials {
 class DialOptions {
    public:
     DialOptions()
-        : auth_entity_(boost::none), credentials_(boost::none), allow_insecure_downgrade_(false) {}
+        : auth_entity_(boost::none), credentials_(boost::none), allow_insecure_downgrade_(false), timeout_(20.0f) {}
 
     const boost::optional<Credentials>& credentials() const;
     const boost::optional<std::string>& entity() const;
     bool allows_insecure_downgrade() const;
+    const float timeout() const;
 
     void set_entity(boost::optional<std::string> entity);
     void set_credentials(boost::optional<Credentials> creds);

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -50,6 +50,7 @@ class DialOptions {
     void set_entity(boost::optional<std::string> entity);
     void set_credentials(boost::optional<Credentials> creds);
     void set_allow_insecure_downgrade(bool allow);
+    void set_timeout(float timeout);
 
    private:
     // TODO (RSDK-917): We currently don't provide a flag for disabling webRTC, instead relying on a
@@ -64,6 +65,10 @@ class DialOptions {
     /// @brief Allows the RPC connection to be downgraded to an insecure connection if detected.
     /// This is only used when credentials are not present.
     bool allow_insecure_downgrade_;
+
+    /// @brief Number of seconds before the dial connection times out
+    /// Set to 20sec to match _defaultOfferDeadline in goutils/rpc/wrtc_call_queue.go
+    float timeout_;
 };
 
 class Options {

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -41,7 +41,10 @@ class Credentials {
 class DialOptions {
    public:
     DialOptions()
-        : auth_entity_(boost::none), credentials_(boost::none), allow_insecure_downgrade_(false), timeout_(20.0f) {}
+        : auth_entity_(boost::none),
+          credentials_(boost::none),
+          allow_insecure_downgrade_(false),
+          timeout_(20.0f) {}
 
     const boost::optional<Credentials>& credentials() const;
     const boost::optional<std::string>& entity() const;

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -54,7 +54,7 @@ class DialOptions {
     void set_entity(boost::optional<std::string> entity);
     void set_credentials(boost::optional<Credentials> creds);
     void set_allow_insecure_downgrade(bool allow);
-    void set_timeout(const float timeout);
+    void set_timeout(float timeout);
 
    private:
     // TODO (RSDK-917): We currently don't provide a flag for disabling webRTC, instead relying on a
@@ -72,7 +72,7 @@ class DialOptions {
 
     /// @brief Number of seconds before the dial connection times out
     /// Set to 20sec to match _defaultOfferDeadline in goutils/rpc/wrtc_call_queue.go
-    const float timeout_;
+    float timeout_;
 };
 
 class Options {

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -45,12 +45,12 @@ class DialOptions {
     const boost::optional<Credentials>& credentials() const;
     const boost::optional<std::string>& entity() const;
     bool allows_insecure_downgrade() const;
-    std::chrono::seconds timeout() const;
+    const std::chrono::duration<float>& timeout() const;
 
     void set_entity(boost::optional<std::string> entity);
     void set_credentials(boost::optional<Credentials> creds);
     void set_allow_insecure_downgrade(bool allow);
-    void set_timeout(std::chrono::seconds timeout);
+    void set_timeout(std::chrono::duration<float> timeout);
 
    private:
     // TODO (RSDK-917): We currently don't provide a flag for disabling webRTC, instead relying on a
@@ -68,7 +68,7 @@ class DialOptions {
 
     /// @brief Duration before the dial connection times out
     /// Set to 20sec to match _defaultOfferDeadline in goutils/rpc/wrtc_call_queue.go
-    std::chrono::seconds timeout_ = std::chrono::seconds(20);
+    std::chrono::duration<float> timeout_{20};
 };
 
 class Options {

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -40,21 +40,17 @@ class Credentials {
 
 class DialOptions {
    public:
-    DialOptions()
-        : auth_entity_(boost::none),
-          credentials_(boost::none),
-          allow_insecure_downgrade_(false),
-          timeout_(20.0f) {}
+    DialOptions();
 
     const boost::optional<Credentials>& credentials() const;
     const boost::optional<std::string>& entity() const;
     bool allows_insecure_downgrade() const;
-    float timeout() const;
+    std::chrono::seconds timeout() const;
 
     void set_entity(boost::optional<std::string> entity);
     void set_credentials(boost::optional<Credentials> creds);
     void set_allow_insecure_downgrade(bool allow);
-    void set_timeout(float timeout);
+    void set_timeout(std::chrono::seconds timeout);
 
    private:
     // TODO (RSDK-917): We currently don't provide a flag for disabling webRTC, instead relying on a
@@ -68,11 +64,11 @@ class DialOptions {
 
     /// @brief Allows the RPC connection to be downgraded to an insecure connection if detected.
     /// This is only used when credentials are not present.
-    bool allow_insecure_downgrade_;
+    bool allow_insecure_downgrade_ = false;
 
-    /// @brief Number of seconds before the dial connection times out
+    /// @brief Duration before the dial connection times out
     /// Set to 20sec to match _defaultOfferDeadline in goutils/rpc/wrtc_call_queue.go
-    float timeout_;
+    std::chrono::seconds timeout_ = std::chrono::seconds(20);
 };
 
 class Options {

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -51,7 +51,7 @@ class DialOptions {
     void set_entity(boost::optional<std::string> entity);
     void set_credentials(boost::optional<Credentials> creds);
     void set_allow_insecure_downgrade(bool allow);
-    void set_timeout(float timeout);
+    void set_timeout(const float timeout);
 
    private:
     // TODO (RSDK-917): We currently don't provide a flag for disabling webRTC, instead relying on a
@@ -69,7 +69,7 @@ class DialOptions {
 
     /// @brief Number of seconds before the dial connection times out
     /// Set to 20sec to match _defaultOfferDeadline in goutils/rpc/wrtc_call_queue.go
-    float timeout_;
+    const float timeout_;
 };
 
 class Options {

--- a/src/viam/sdk/services/motion/motion.hpp
+++ b/src/viam/sdk/services/motion/motion.hpp
@@ -32,12 +32,28 @@ class MotionRegistration : public ResourceRegistration {
                                                 std::shared_ptr<grpc::Channel> chan) override;
 };
 
+/// @struct obstacle_detector_name
+/// @brief Defines configuration for obstacle detectors by pairing a vision service name and a
+/// camera name.
+/// @ingroup Motion
+struct obstacle_detector {
+    /// @brief The name of the vision service to be used for obstacle detection.
+    Name vision_service;
+    /// @brief The name of the camera component to be used for obstacle detection.
+    Name camera;
+
+    service::motion::v1::ObstacleDetector to_proto() const;
+    static obstacle_detector from_proto(const service::motion::v1::ObstacleDetector& proto);
+    friend bool operator==(const obstacle_detector& lhs, const obstacle_detector& rhs);
+    friend std::ostream& operator<<(std::ostream& os, const obstacle_detector& v);
+};
+
 /// @struct motion_configuration
 /// @brief Defines configuration options for certain `Motion` APIs.
 /// @ingroup Motion
 struct motion_configuration {
-    /// @brief The name of the vision service(s) that will be used for obstacle detection.
-    std::vector<Name> vision_services;
+    /// @brief The obstacle detectors to be used for the API call.
+    std::vector<obstacle_detector> obstacle_detectors;
 
     /// @brief If not null, sets the frequency to poll for the position of the robot.
     boost::optional<double> position_polling_frequency_hz;


### PR DESCRIPTION
Updates pin for `api` buf build commit. Cherry-picks commit from #155 to get @hexbabe's changes for a new `timeout` dial option (makes the C++ SDK compatible with the latest version of `rust-utils`). Adds new `obstacle_detector` type and uses it within motion configurations.