### PR TITLE
Fix complex module client

### DIFF
--- a/src/viam/examples/dial/example_dial.cpp
+++ b/src/viam/examples/dial/example_dial.cpp
@@ -42,7 +42,7 @@ int main() {
     // ensure we can query resources
     std::vector<ResourceName>* resource_names = robot->resource_names();
     std::cout << "Resources" << std::endl;
-    for (ResourceName& resource : *resource_names) {
+    for (const ResourceName& resource : *resource_names) {
         std::cout << "\tname: " << resource.name() << " (type:" << resource.type()
                   << " subtype:" << resource.subtype() << ")" << std::endl;
     }
@@ -50,7 +50,7 @@ int main() {
     // ensure we can query statuses
     std::vector<Status> status_plural = robot->get_status();
     std::cout << "Status plural len " << status_plural.size() << std::endl;
-    for (Status& s : status_plural) {
+    for (const Status& s : status_plural) {
         std::cout << " Status! " << s.name().subtype() << std::endl;
     }
 
@@ -58,7 +58,7 @@ int main() {
     std::vector<ResourceName> just_one = {resource_names->at(0)};
     std::vector<Status> status_singular = robot->get_status(just_one);
     std::cout << "Status singular len " << status_singular.size() << std::endl;
-    for (Status& s : status_singular) {
+    for (const Status& s : status_singular) {
         std::cout << " Status! " << s.name().subtype() << std::endl;
     }
 

--- a/src/viam/examples/dial/example_dial.cpp
+++ b/src/viam/examples/dial/example_dial.cpp
@@ -41,15 +41,16 @@ int main() {
 
     // ensure we can query resources
     std::vector<ResourceName>* resource_names = robot->resource_names();
-    for (ResourceName resource : *resource_names) {
-        std::cout << "Resource name: " << resource.name() << resource.type() << resource.subtype()
-                  << std::endl;
+    std::cout << "Resources" << std::endl;
+    for (ResourceName& resource : *resource_names) {
+        std::cout << "\tname: " << resource.name() << " (type:" << resource.type()
+                  << " subtype:" << resource.subtype() << ")" << std::endl;
     }
 
     // ensure we can query statuses
     std::vector<Status> status_plural = robot->get_status();
     std::cout << "Status plural len " << status_plural.size() << std::endl;
-    for (Status s : status_plural) {
+    for (Status& s : status_plural) {
         std::cout << " Status! " << s.name().subtype() << std::endl;
     }
 
@@ -57,7 +58,7 @@ int main() {
     std::vector<ResourceName> just_one = {resource_names->at(0)};
     std::vector<Status> status_singular = robot->get_status(just_one);
     std::cout << "Status singular len " << status_singular.size() << std::endl;
-    for (Status s : status_singular) {
+    for (Status& s : status_singular) {
         std::cout << " Status! " << s.name().subtype() << std::endl;
     }
 

--- a/src/viam/examples/dial_api_key/example_dial_api_key.cpp
+++ b/src/viam/examples/dial_api_key/example_dial_api_key.cpp
@@ -43,15 +43,16 @@ int main() {
 
     // ensure we can query resources
     std::vector<ResourceName>* resource_names = robot->resource_names();
-    for (ResourceName resource : *resource_names) {
-        std::cout << "Resource name: " << resource.name() << resource.type() << resource.subtype()
-                  << std::endl;
+    std::cout << "Resources" << std::endl;
+    for (const ResourceName& resource : *resource_names) {
+        std::cout << "\tname: " << resource.name() << " (type:" << resource.type()
+                  << " subtype:" << resource.subtype() << ")" << std::endl;
     }
 
     // ensure we can query statuses
     std::vector<Status> status_plural = robot->get_status();
     std::cout << "Status plural len " << status_plural.size() << std::endl;
-    for (Status s : status_plural) {
+    for (const Status& s : status_plural) {
         std::cout << " Status! " << s.name().subtype() << std::endl;
     }
 
@@ -59,7 +60,7 @@ int main() {
     std::vector<ResourceName> just_one = {resource_names->at(0)};
     std::vector<Status> status_singular = robot->get_status(just_one);
     std::cout << "Status singular len " << status_singular.size() << std::endl;
-    for (Status s : status_singular) {
+    for (const Status& s : status_singular) {
         std::cout << " Status! " << s.name().subtype() << std::endl;
     }
 

--- a/src/viam/examples/modules/complex/README.md
+++ b/src/viam/examples/modules/complex/README.md
@@ -52,7 +52,6 @@ An example configuration for a gizmo component, a summation service, and a base 
     {
       "name": "base1",
       "type": "base",
-      "namespace": "viam",
       "model": "viam:base:mybase",
       "attributes": {
         "left": "motor1",

--- a/src/viam/examples/modules/complex/client.cpp
+++ b/src/viam/examples/modules/complex/client.cpp
@@ -78,11 +78,11 @@ int main() {
     // Exercise Summation methods.
     auto sc = robot->resource_by_name<SummationClient>("mysum1");
     if (!sc) {
-        std::cerr << "could not get 'summation1' resource from robot" << std::endl;
+        std::cerr << "could not get 'mysum1' resource from robot" << std::endl;
         return EXIT_FAILURE;
     }
     double sum = sc->sum({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
-    std::cout << "summation1 sum of numbers [0, 10) is: " << sum << std::endl;
+    std::cout << "mysum1 sum of numbers [0, 10) is: " << sum << std::endl;
 
     // Exercise a Base method.
     auto bc = robot->resource_by_name<BaseClient>("base1");

--- a/src/viam/examples/modules/complex/client.cpp
+++ b/src/viam/examples/modules/complex/client.cpp
@@ -47,7 +47,7 @@ int main() {
     // Print resources.
     std::cout << "Resources" << std::endl;
     std::vector<ResourceName>* resource_names = robot->resource_names();
-    for (ResourceName& resource : *resource_names) {
+    for (const ResourceName& resource : *resource_names) {
         std::cout << "\tname: " << resource.name() << " (type:" << resource.type()
                   << " subtype:" << resource.subtype() << ")" << std::endl;
     }

--- a/src/viam/examples/modules/complex/client.cpp
+++ b/src/viam/examples/modules/complex/client.cpp
@@ -24,7 +24,6 @@
 #include "gizmo/api.hpp"
 #include "summation/api.hpp"
 
-using viam::robot::v1::Status;
 using namespace viam::sdk;
 
 int main() {
@@ -38,14 +37,19 @@ int main() {
     std::string address(uri);
     Options options(1, opts);
 
+    // Register custom gizmo and summation API so robot client can access resources
+    // of that type from the server.
+    Registry::register_resource(Gizmo::static_api(), Gizmo::resource_registration());
+    Registry::register_resource(Summation::static_api(), Summation::resource_registration());
+
     // Connect to robot.
     std::shared_ptr<RobotClient> robot = RobotClient::at_address(address, options);
     // Print resources.
     std::cout << "Resources" << std::endl;
     std::vector<ResourceName>* resource_names = robot->resource_names();
-    for (ResourceName resource : *resource_names) {
-        std::cout << "\tResource name: " << resource.name() << resource.type() << resource.subtype()
-                  << std::endl;
+    for (ResourceName& resource : *resource_names) {
+        std::cout << "\tname: " << resource.name() << " (type:" << resource.type()
+                  << " subtype:" << resource.subtype() << ")" << std::endl;
     }
 
     // Exercise Gizmo methods.
@@ -55,24 +59,24 @@ int main() {
         return EXIT_FAILURE;
     }
     bool do_one_ret = gc->do_one("arg1");
-    std::cout << "gizmo1 do_one returned: " << do_one_ret;
+    std::cout << "gizmo1 do_one returned: " << do_one_ret << std::endl;
     bool do_one_client_stream_ret = gc->do_one_client_stream({"arg1", "arg1", "arg1"});
-    std::cout << "gizmo1 do_one_client_stream returned: " << do_one_client_stream_ret;
+    std::cout << "gizmo1 do_one_client_stream returned: " << do_one_client_stream_ret << std::endl;
     std::string do_two_ret = gc->do_two(false);
-    std::cout << "gizmo1 do_two returned: " << do_two_ret;
+    std::cout << "gizmo1 do_two returned: " << do_two_ret << std::endl;
     std::vector<bool> do_one_server_stream_ret = gc->do_one_server_stream("arg1");
-    std::cout << "gizmo1 do_one_server_stream returned: ";
+    std::cout << "gizmo1 do_one_server_stream returned: " << std::endl;
     for (bool ret : do_one_server_stream_ret) {
         std::cout << '\t' << ret << std::endl;
     }
     std::vector<bool> do_one_bidi_stream_ret = gc->do_one_bidi_stream({"arg1", "arg2", "arg3"});
-    std::cout << "gizmo1 do_one_bidi_stream returned: ";
+    std::cout << "gizmo1 do_one_bidi_stream returned: " << std::endl;
     for (bool ret : do_one_bidi_stream_ret) {
         std::cout << '\t' << ret << std::endl;
     }
 
     // Exercise Summation methods.
-    auto sc = robot->resource_by_name<SummationClient>("summation1");
+    auto sc = robot->resource_by_name<SummationClient>("mysum1");
     if (!sc) {
         std::cerr << "could not get 'summation1' resource from robot" << std::endl;
         return EXIT_FAILURE;


### PR DESCRIPTION
Prints resources more cleanly in complex client, example dial and API key example dial. Uses const references in for loops for all three (my linter was complaining, and using const refs where possible in for-each loops seems idiomatic). Removes erroneous `namespace` field from `mybase` complex module example JSON (namespace should be `rdk` which is the default). Registers gizmo and summation APIs in complex module client. Adds missing newlines to complex module client ouput. Output now looks like:

```
Resources
	name: base1 (type:component subtype:base)
	name: motor1 (type:component subtype:motor)
	name: gizmo1 (type:component subtype:gizmo)
	name: mysum1 (type:service subtype:summation)
	name: builtin (type:service subtype:data_manager)
	name: builtin (type:service subtype:motion)
	name: builtin (type:service subtype:sensors)
	name: motor2 (type:component subtype:motor)
gizmo1 do_one returned: 1
gizmo1 do_one_client_stream returned: 1
gizmo1 do_two returned: arg1=false
gizmo1 do_one_server_stream returned: 
	1
	0
	1
	0
gizmo1 do_one_bidi_stream returned: 
	0
	0
summation1 sum of numbers [0, 10) is: 45
base1 is not moving
```