### PR TITLE
RSDK-794 PoC ServiceHelper to simplify service method implementations

### DIFF
--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -46,6 +46,7 @@ target_sources(viamsdk
     common/linear_algebra.cpp
     common/pose.cpp
     common/proto_type.cpp
+    common/service_helper.cpp
     common/utils.cpp
     common/world_state.cpp
     components/base/base.cpp

--- a/src/viam/sdk/common/service_helper.cpp
+++ b/src/viam/sdk/common/service_helper.cpp
@@ -21,9 +21,9 @@ namespace sdk {
 ::grpc::Status ServiceHelperBase::failNoResource(const std::string& name) const noexcept try {
     std::ostringstream stream;
     stream << "Failed to find resource `" << name << "`";
-    return fail(::grpc::INVALID_ARGUMENT, stream.str().c_str());
+    return fail(::grpc::NOT_FOUND, stream.str().c_str());
 } catch (...) {
-    return fail(::grpc::INVALID_ARGUMENT, "Failed to find resource");
+    return fail(::grpc::NOT_FOUND, "Failed to find resource");
 }
 
 ::grpc::Status ServiceHelperBase::failStdException(const std::exception& xcp) const noexcept try {

--- a/src/viam/sdk/common/service_helper.cpp
+++ b/src/viam/sdk/common/service_helper.cpp
@@ -1,0 +1,40 @@
+#include <viam/sdk/common/service_helper.hpp>
+
+namespace viam {
+namespace sdk {
+
+::grpc::Status ServiceHelperBase::fail(::grpc::StatusCode code, const char* message) const noexcept
+    try {
+    std::ostringstream stream;
+    stream << '[' << method_ << "]: " << message;
+    return {code, stream.str()};
+} catch (...) {
+    return {code, message};
+}
+
+::grpc::Status ServiceHelperBase::failNoRequest() const noexcept {
+    return fail(::grpc::INVALID_ARGUMENT, "Called without a `request` object");
+}
+
+::grpc::Status ServiceHelperBase::failNoResource(const std::string& name) const noexcept try {
+    std::ostringstream stream;
+    stream << "Failed to find resource `" << name << "`";
+    return fail(::grpc::INVALID_ARGUMENT, stream.str().c_str());
+} catch (...) {
+    return fail(::grpc::INVALID_ARGUMENT, "Failed to find resource");
+}
+
+::grpc::Status ServiceHelperBase::failStdException(const std::exception& xcp) const noexcept try {
+    std::ostringstream stream;
+    stream << "Failed with a std::exception: " << xcp.what();
+    return fail(::grpc::INTERNAL, stream.str().c_str());
+} catch (...) {
+    return fail(::grpc::INTERNAL, "Failed with a std::exception: <unknown>");
+}
+
+::grpc::Status ServiceHelperBase::failUnknownException() const noexcept {
+    return fail(::grpc::INTERNAL, "Failed with an unknown exception");
+}
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/common/service_helper.cpp
+++ b/src/viam/sdk/common/service_helper.cpp
@@ -1,5 +1,7 @@
 #include <viam/sdk/common/service_helper.hpp>
 
+#include <sstream>
+
 namespace viam {
 namespace sdk {
 

--- a/src/viam/sdk/common/service_helper.hpp
+++ b/src/viam/sdk/common/service_helper.hpp
@@ -30,7 +30,7 @@ template <typename ServiceType, typename RequestType>
 class ServiceHelper : public ServiceHelperBase {
    public:
     ServiceHelper(const char* method, ResourceServer* rs, RequestType* request) noexcept
-        : ServiceHelperBase(method), rs_{rs}, request_{request} {};
+        : ServiceHelperBase{method}, rs_{rs}, request_{request} {};
 
     template <typename Callable>
     ::grpc::Status operator()(Callable&& callable) const noexcept try {

--- a/src/viam/sdk/common/service_helper.hpp
+++ b/src/viam/sdk/common/service_helper.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <type_traits>
+
+#include <viam/sdk/resource/resource_server_base.hpp>
+
+namespace viam {
+namespace sdk {
+
+class ServiceHelperBase {
+   public:
+    ::grpc::Status fail(::grpc::StatusCode code, const char* message) const noexcept;
+
+    ::grpc::Status failNoRequest() const noexcept;
+
+    ::grpc::Status failNoResource(const std::string& name) const noexcept;
+
+    ::grpc::Status failStdException(const std::exception& xcp) const noexcept;
+
+    ::grpc::Status failUnknownException() const noexcept;
+
+   protected:
+    explicit ServiceHelperBase(const char* method) noexcept : method_{method} {}
+
+   private:
+    const char* method_;
+};
+
+template <typename ServiceType, typename RequestType>
+class ServiceHelper : public ServiceHelperBase {
+   public:
+    ServiceHelper(const char* method, ResourceServer* rs, RequestType* request) noexcept
+        : ServiceHelperBase(method), rs_{rs}, request_{request} {};
+
+    template <typename Callable>
+    ::grpc::Status operator()(Callable&& callable) const noexcept try {
+        if (!request_) {
+            return failNoRequest();
+        }
+        const auto resource = rs_->resource_manager()->resource<ServiceType>(request_->name());
+        if (!resource) {
+            return failNoResource(request_->name());
+        }
+        return invoke_(std::forward<Callable>(callable), std::move(resource));
+    } catch (const std::exception& xcp) {
+        return failStdException(xcp);
+    } catch (...) {
+        return failUnknownException();
+    }
+
+    auto getExtra() const {
+        return request_->has_extra() ? struct_to_map(request_->extra()) : AttributeMap{};
+    }
+
+   private:
+    template <typename Callable, typename... Args>
+    using is_void_result = std::is_void<std::result_of_t<Callable(Args...)>>;
+
+    // Implementation of `invoke_` for a Callable returning non-void,
+    // presumably an error return, which we return as a
+    // ::grpc::Status.
+    template <typename Callable,
+              typename ResourcePtrType,
+              std::enable_if_t<!is_void_result<Callable, ServiceHelper&, ResourcePtrType&&>::value,
+                               bool> = true>
+    ::grpc::Status invoke_(Callable&& callable, ResourcePtrType&& resource) const {
+        return std::forward<Callable>(callable)(*this, std::forward<ResourcePtrType>(resource));
+    }
+
+    // Implementation of `invoke_` for a Callable returning void,
+    // which is therefore either non-failing or communicates errors by
+    // throwing exceptions. We return an OK status automatically.
+    template <typename Callable,
+              typename ResourcePtrType,
+              std::enable_if_t<is_void_result<Callable, ServiceHelper&, ResourcePtrType&&>::value,
+                               bool> = true>
+    ::grpc::Status invoke_(Callable&& callable, ResourcePtrType&& resource) const {
+        std::forward<Callable>(callable)(*this, std::forward<ResourcePtrType>(resource));
+        return {};
+    }
+
+    const char* method_;
+    ResourceServer* rs_;
+    RequestType* request_;
+};
+
+template <typename ServiceType, typename RequestType>
+auto make_service_helper(const char* method, ResourceServer* rs, RequestType* request) {
+    return ServiceHelper<ServiceType, RequestType>{method, rs, request};
+}
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/common/service_helper.hpp
+++ b/src/viam/sdk/common/service_helper.hpp
@@ -79,7 +79,6 @@ class ServiceHelper : public ServiceHelperBase {
         return {};
     }
 
-    const char* method_;
     ResourceServer* rs_;
     RequestType* request_;
 };

--- a/src/viam/sdk/components/encoder/server.cpp
+++ b/src/viam/sdk/components/encoder/server.cpp
@@ -1,5 +1,6 @@
 #include <viam/sdk/components/encoder/server.hpp>
 
+#include <viam/sdk/common/service_helper.hpp>
 #include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/components/encoder/encoder.hpp>
 #include <viam/sdk/config/resource.hpp>
@@ -14,132 +15,56 @@ EncoderServer::EncoderServer(std::shared_ptr<ResourceManager> manager) : Resourc
 ::grpc::Status EncoderServer::GetPosition(
     ::grpc::ServerContext* context,
     const ::viam::component::encoder::v1::GetPositionRequest* request,
-    ::viam::component::encoder::v1::GetPositionResponse* response) {
-    if (!request) {
-        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
-                              "Called [Encoder::GetPosition] without a request");
-    };
-
-    const std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
-    if (!rb) {
-        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
-    }
-
-    const std::shared_ptr<Encoder> encoder = std::dynamic_pointer_cast<Encoder>(rb);
-
-    AttributeMap extra;
-    if (request->has_extra()) {
-        extra = struct_to_map(request->extra());
-    }
-
-    const Encoder::position result =
-        encoder->get_position(extra, Encoder::from_proto(request->position_type()));
-    response->set_value(result.value);
-    response->set_position_type(Encoder::to_proto(result.type));
-
-    return ::grpc::Status();
+    ::viam::component::encoder::v1::GetPositionResponse* response) noexcept {
+    return make_service_helper<Encoder>(
+        "EncoderServer::GetPosition", this, request)([&](auto& wrapper, auto& encoder) {
+        const Encoder::position result = encoder->get_position(
+            wrapper.getExtra(), Encoder::from_proto(request->position_type()));
+        response->set_value(result.value);
+        response->set_position_type(Encoder::to_proto(result.type));
+    });
 }
 
 ::grpc::Status EncoderServer::ResetPosition(
     ::grpc::ServerContext* context,
     const ::viam::component::encoder::v1::ResetPositionRequest* request,
-    ::viam::component::encoder::v1::ResetPositionResponse* response) {
-    if (!request) {
-        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
-                              "Called [Encoder::ResetPosition] without a request");
-    };
-
-    const std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
-    if (!rb) {
-        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
-    }
-
-    const std::shared_ptr<Encoder> encoder = std::dynamic_pointer_cast<Encoder>(rb);
-
-    AttributeMap extra;
-    if (request->has_extra()) {
-        extra = struct_to_map(request->extra());
-    }
-
-    encoder->reset_position(extra);
-
-    return ::grpc::Status();
+    ::viam::component::encoder::v1::ResetPositionResponse* response) noexcept {
+    return make_service_helper<Encoder>("EncoderServer::GetPosition", this, request)(
+        [&](auto& wrapper, auto& encoder) { encoder->reset_position(wrapper.getExtra()); });
 }
 
 ::grpc::Status EncoderServer::GetProperties(
     ::grpc::ServerContext* context,
     const ::viam::component::encoder::v1::GetPropertiesRequest* request,
-    ::viam::component::encoder::v1::GetPropertiesResponse* response) {
-    if (!request) {
-        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
-                              "Called [Encoder::GetProperties] without a request");
-    };
-
-    const std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
-    if (!rb) {
-        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
-    }
-
-    const std::shared_ptr<Encoder> encoder = std::dynamic_pointer_cast<Encoder>(rb);
-
-    AttributeMap extra;
-    if (request->has_extra()) {
-        extra = struct_to_map(request->extra());
-    }
-
-    const Encoder::properties result = encoder->get_properties(extra);
-    response->set_ticks_count_supported(result.ticks_count_supported);
-    response->set_angle_degrees_supported(result.angle_degrees_supported);
-
-    return ::grpc::Status();
+    ::viam::component::encoder::v1::GetPropertiesResponse* response) noexcept {
+    return make_service_helper<Encoder>(
+        "EncoderServer::GetProperties", this, request)([&](auto& wrapper, auto& encoder) {
+        const Encoder::properties result = encoder->get_properties(wrapper.getExtra());
+        response->set_ticks_count_supported(result.ticks_count_supported);
+        response->set_angle_degrees_supported(result.angle_degrees_supported);
+    });
 }
 
 ::grpc::Status EncoderServer::GetGeometries(::grpc::ServerContext* context,
                                             const ::viam::common::v1::GetGeometriesRequest* request,
-                                            ::viam::common::v1::GetGeometriesResponse* response) {
-    if (!request) {
-        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
-                              "Called [GetGeometries] without a request");
-    };
-
-    const std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
-    if (!rb) {
-        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
-    }
-
-    AttributeMap extra;
-    if (request->has_extra()) {
-        extra = struct_to_map(request->extra());
-    }
-
-    const std::shared_ptr<Encoder> encoder = std::dynamic_pointer_cast<Encoder>(rb);
-    const std::vector<GeometryConfig> geometries = encoder->get_geometries(extra);
-    for (const auto& geometry : geometries) {
-        *response->mutable_geometries()->Add() = geometry.to_proto();
-    }
-
-    return ::grpc::Status();
+                                            ::viam::common::v1::GetGeometriesResponse* response) noexcept {
+    return make_service_helper<Encoder>(
+        "EncoderServer::GetGeometries", this, request)([&](auto& wrapper, auto& encoder) {
+        const std::vector<GeometryConfig> geometries = encoder->get_geometries(wrapper.getExtra());
+        for (const auto& geometry : geometries) {
+            *response->mutable_geometries()->Add() = geometry.to_proto();
+        }
+    });
 }
 
 ::grpc::Status EncoderServer::DoCommand(grpc::ServerContext* context,
                                         const viam::common::v1::DoCommandRequest* request,
-                                        viam::common::v1::DoCommandResponse* response) {
-    if (!request) {
-        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
-                              "Called [Encoder::DoCommand] without a request");
-    };
-
-    const std::shared_ptr<Resource> rb = resource_manager()->resource(request->name());
-    if (!rb) {
-        return grpc::Status(grpc::UNKNOWN, "resource not found: " + request->name());
-    }
-
-    const std::shared_ptr<Encoder> encoder = std::dynamic_pointer_cast<Encoder>(rb);
-    const AttributeMap result = encoder->do_command(struct_to_map(request->command()));
-
-    *response->mutable_result() = map_to_struct(result);
-
-    return ::grpc::Status();
+                                        viam::common::v1::DoCommandResponse* response) noexcept {
+    return make_service_helper<Encoder>(
+        "EncoderServer::DoCommand", this, request)([&](auto& wrapper, auto& encoder) {
+        const AttributeMap result = encoder->do_command(struct_to_map(request->command()));
+        *response->mutable_result() = map_to_struct(result);
+    });
 }
 
 void EncoderServer::register_server(std::shared_ptr<Server> server) {

--- a/src/viam/sdk/components/encoder/server.cpp
+++ b/src/viam/sdk/components/encoder/server.cpp
@@ -17,9 +17,9 @@ EncoderServer::EncoderServer(std::shared_ptr<ResourceManager> manager) : Resourc
     const ::viam::component::encoder::v1::GetPositionRequest* request,
     ::viam::component::encoder::v1::GetPositionResponse* response) noexcept {
     return make_service_helper<Encoder>(
-        "EncoderServer::GetPosition", this, request)([&](auto& wrapper, auto& encoder) {
-        const Encoder::position result = encoder->get_position(
-            wrapper.getExtra(), Encoder::from_proto(request->position_type()));
+        "EncoderServer::GetPosition", this, request)([&](auto& helper, auto& encoder) {
+        const Encoder::position result =
+            encoder->get_position(helper.getExtra(), Encoder::from_proto(request->position_type()));
         response->set_value(result.value);
         response->set_position_type(Encoder::to_proto(result.type));
     });
@@ -29,8 +29,8 @@ EncoderServer::EncoderServer(std::shared_ptr<ResourceManager> manager) : Resourc
     ::grpc::ServerContext* context,
     const ::viam::component::encoder::v1::ResetPositionRequest* request,
     ::viam::component::encoder::v1::ResetPositionResponse* response) noexcept {
-    return make_service_helper<Encoder>("EncoderServer::GetPosition", this, request)(
-        [&](auto& wrapper, auto& encoder) { encoder->reset_position(wrapper.getExtra()); });
+    return make_service_helper<Encoder>("EncoderServer::ResetPosition", this, request)(
+        [&](auto& helper, auto& encoder) { encoder->reset_position(helper.getExtra()); });
 }
 
 ::grpc::Status EncoderServer::GetProperties(
@@ -38,19 +38,20 @@ EncoderServer::EncoderServer(std::shared_ptr<ResourceManager> manager) : Resourc
     const ::viam::component::encoder::v1::GetPropertiesRequest* request,
     ::viam::component::encoder::v1::GetPropertiesResponse* response) noexcept {
     return make_service_helper<Encoder>(
-        "EncoderServer::GetProperties", this, request)([&](auto& wrapper, auto& encoder) {
-        const Encoder::properties result = encoder->get_properties(wrapper.getExtra());
+        "EncoderServer::GetProperties", this, request)([&](auto& helper, auto& encoder) {
+        const Encoder::properties result = encoder->get_properties(helper.getExtra());
         response->set_ticks_count_supported(result.ticks_count_supported);
         response->set_angle_degrees_supported(result.angle_degrees_supported);
     });
 }
 
-::grpc::Status EncoderServer::GetGeometries(::grpc::ServerContext* context,
-                                            const ::viam::common::v1::GetGeometriesRequest* request,
-                                            ::viam::common::v1::GetGeometriesResponse* response) noexcept {
+::grpc::Status EncoderServer::GetGeometries(
+    ::grpc::ServerContext* context,
+    const ::viam::common::v1::GetGeometriesRequest* request,
+    ::viam::common::v1::GetGeometriesResponse* response) noexcept {
     return make_service_helper<Encoder>(
-        "EncoderServer::GetGeometries", this, request)([&](auto& wrapper, auto& encoder) {
-        const std::vector<GeometryConfig> geometries = encoder->get_geometries(wrapper.getExtra());
+        "EncoderServer::GetGeometries", this, request)([&](auto& helper, auto& encoder) {
+        const std::vector<GeometryConfig> geometries = encoder->get_geometries(helper.getExtra());
         for (const auto& geometry : geometries) {
             *response->mutable_geometries()->Add() = geometry.to_proto();
         }
@@ -61,7 +62,7 @@ EncoderServer::EncoderServer(std::shared_ptr<ResourceManager> manager) : Resourc
                                         const viam::common::v1::DoCommandRequest* request,
                                         viam::common::v1::DoCommandResponse* response) noexcept {
     return make_service_helper<Encoder>(
-        "EncoderServer::DoCommand", this, request)([&](auto& wrapper, auto& encoder) {
+        "EncoderServer::DoCommand", this, request)([&](auto& helper, auto& encoder) {
         const AttributeMap result = encoder->do_command(struct_to_map(request->command()));
         *response->mutable_result() = map_to_struct(result);
     });

--- a/src/viam/sdk/components/encoder/server.hpp
+++ b/src/viam/sdk/components/encoder/server.hpp
@@ -36,9 +36,10 @@ class EncoderServer : public ResourceServer,
         const ::viam::component::encoder::v1::GetPropertiesRequest* request,
         ::viam::component::encoder::v1::GetPropertiesResponse* response) noexcept override;
 
-    ::grpc::Status GetGeometries(::grpc::ServerContext* context,
-                                 const ::viam::common::v1::GetGeometriesRequest* request,
-                                 ::viam::common::v1::GetGeometriesResponse* response) noexcept override;
+    ::grpc::Status GetGeometries(
+        ::grpc::ServerContext* context,
+        const ::viam::common::v1::GetGeometriesRequest* request,
+        ::viam::common::v1::GetGeometriesResponse* response) noexcept override;
 
     ::grpc::Status DoCommand(grpc::ServerContext* context,
                              const viam::common::v1::DoCommandRequest* request,

--- a/src/viam/sdk/components/encoder/server.hpp
+++ b/src/viam/sdk/components/encoder/server.hpp
@@ -24,25 +24,25 @@ class EncoderServer : public ResourceServer,
     ::grpc::Status GetPosition(
         ::grpc::ServerContext* context,
         const ::viam::component::encoder::v1::GetPositionRequest* request,
-        ::viam::component::encoder::v1::GetPositionResponse* response) override;
+        ::viam::component::encoder::v1::GetPositionResponse* response) noexcept override;
 
     ::grpc::Status ResetPosition(
         ::grpc::ServerContext* context,
         const ::viam::component::encoder::v1::ResetPositionRequest* request,
-        ::viam::component::encoder::v1::ResetPositionResponse* response) override;
+        ::viam::component::encoder::v1::ResetPositionResponse* response) noexcept override;
 
     ::grpc::Status GetProperties(
         ::grpc::ServerContext* context,
         const ::viam::component::encoder::v1::GetPropertiesRequest* request,
-        ::viam::component::encoder::v1::GetPropertiesResponse* response) override;
+        ::viam::component::encoder::v1::GetPropertiesResponse* response) noexcept override;
 
     ::grpc::Status GetGeometries(::grpc::ServerContext* context,
                                  const ::viam::common::v1::GetGeometriesRequest* request,
-                                 ::viam::common::v1::GetGeometriesResponse* response) override;
+                                 ::viam::common::v1::GetGeometriesResponse* response) noexcept override;
 
     ::grpc::Status DoCommand(grpc::ServerContext* context,
                              const viam::common::v1::DoCommandRequest* request,
-                             viam::common::v1::DoCommandResponse* response) override;
+                             viam::common::v1::DoCommandResponse* response) noexcept override;
 
     void register_server(std::shared_ptr<Server> server) override;
 };

--- a/src/viam/sdk/resource/resource_manager.hpp
+++ b/src/viam/sdk/resource/resource_manager.hpp
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 
 #include <boost/optional/optional.hpp>
@@ -27,8 +28,12 @@ class ResourceManager {
     /// @throws `std::runtime_error` if the desired resource does not exist.
     std::shared_ptr<Resource> resource(const std::string& name);
 
+    /// @brief Returns a resource after dynamically downcasting to `T`.
+    /// @param name of the desired resource.
+    /// @throws `std::runtime_error` if the desired resource does not exist.
     template<typename T>
     std::shared_ptr<T> resource(const std::string& name) {
+        static_assert(std::is_base_of<Resource, T>::value, "T is not derived from Resource");
         return std::dynamic_pointer_cast<T>(resource(name));
     }
 

--- a/src/viam/sdk/resource/resource_manager.hpp
+++ b/src/viam/sdk/resource/resource_manager.hpp
@@ -27,6 +27,11 @@ class ResourceManager {
     /// @throws `std::runtime_error` if the desired resource does not exist.
     std::shared_ptr<Resource> resource(const std::string& name);
 
+    template<typename T>
+    std::shared_ptr<T> resource(const std::string& name) {
+        return std::dynamic_pointer_cast<T>(resource(name));
+    }
+
     /// @brief Replaces all resources in the manager.
     /// @param resources The resources to replace with.
     void replace_all(const std::unordered_map<Name, std::shared_ptr<Resource>>& resources);

--- a/src/viam/sdk/resource/resource_manager.hpp
+++ b/src/viam/sdk/resource/resource_manager.hpp
@@ -31,7 +31,7 @@ class ResourceManager {
     /// @brief Returns a resource after dynamically downcasting to `T`.
     /// @param name of the desired resource.
     /// @throws `std::runtime_error` if the desired resource does not exist.
-    template<typename T>
+    template <typename T>
     std::shared_ptr<T> resource(const std::string& name) {
         static_assert(std::is_base_of<Resource, T>::value, "T is not derived from Resource");
         return std::dynamic_pointer_cast<T>(resource(name));

--- a/src/viam/sdk/services/mlmodel/server.cpp
+++ b/src/viam/sdk/services/mlmodel/server.cpp
@@ -101,11 +101,8 @@ class RequestWrapper : public RequestWrapperBase {
         return failUnknownException();
     }
 
-    AttributeMap getExtra() const {
-        if (request_->has_extra()) {
-            return struct_to_map(request_->extra());
-        }
-        return {};
+    auto getExtra() const {
+        return request_->has_extra() ? struct_to_map(request_->extra()) : AttributeMap{};
     }
 
    private:

--- a/src/viam/sdk/services/mlmodel/server.cpp
+++ b/src/viam/sdk/services/mlmodel/server.cpp
@@ -37,7 +37,7 @@ class ServiceHelperBase {
    public:
     ::grpc::Status fail(::grpc::StatusCode code, const char* message) const noexcept try {
         std::ostringstream stream;
-        stream << '[' << method_ << "]: ";
+        stream << '[' << method_ << "]: " << message;
         return {code, stream.str()};
     } catch (...) {
         return {code, message};


### PR DESCRIPTION
This is my PoC response to the discussion in the Sensor review: https://github.com/viamrobotics/viam-cpp-sdk/pull/174/files#r1386948048

There is a lot to understand in the `ServiceHelper` and `ServiceHelperBase` classes, but I think the boilerplate reduction that it enables (which can be seen most clearly in the `encoder` server changes) is pretty compelling.

I changed the `MLModelServiceServer` class to show how the `ServiceHelper` works in the case where the RPC handler needs to return custom errors and therefore the lambda traffics in `Status` returns, and also did the `EncoderServer` case to show that it also works when there are no `Status` returns and the lambda therefore returns void.

Handling both cases is dealt with through some SFINAE magic.

If this sort of approach is appealing (or at least acceptable) to those on the review list, I'll continue this PR with a helper for client side boilerplate as well, as a response to the `stub_wrapper` also in #174.

Various reviewers on this:
- @benjirewis since it is in response to #174.
- @stuqdog as project owners
- @abe-winter since he wrote the original `stub_wrapper` and `ServerWrapper` boilerplate reduction concepts.
- @zaporter-work since I think he will be interested in this w.r.t. his error handling thoughts.

Please let me know your thoughts.