### PR TITLE
RSDK-5194 - use factory function for client ctx

### DIFF
--- a/src/viam/examples/modules/complex/gizmo/api.cpp
+++ b/src/viam/examples/modules/complex/gizmo/api.cpp
@@ -211,10 +211,9 @@ bool GizmoClient::do_one(std::string arg1) {
 
 bool GizmoClient::do_one_client_stream(std::vector<std::string> arg1) {
     DoOneClientStreamResponse response;
-    grpc::ClientContext ctx;
-    set_client_ctx_authority(ctx);
+    ClientContext ctx;
 
-    auto writer(stub_->DoOneClientStream(&ctx, &response));
+    auto writer(stub_->DoOneClientStream(ctx, &response));
     for (std::string arg : arg1) {
         DoOneClientStreamRequest curr_req = {};
         *curr_req.mutable_name() = this->name();
@@ -235,13 +234,12 @@ bool GizmoClient::do_one_client_stream(std::vector<std::string> arg1) {
 
 std::vector<bool> GizmoClient::do_one_server_stream(std::string arg1) {
     DoOneServerStreamRequest request;
-    grpc::ClientContext ctx;
-    set_client_ctx_authority(ctx);
+    ClientContext ctx;
 
     *request.mutable_name() = this->name();
     request.set_arg1(arg1);
 
-    auto reader(stub_->DoOneServerStream(&ctx, request));
+    auto reader(stub_->DoOneServerStream(ctx, request));
     DoOneServerStreamResponse curr_resp = {};
     std::vector<bool> rets = {};
     while (reader->Read(&curr_resp)) {
@@ -256,10 +254,9 @@ std::vector<bool> GizmoClient::do_one_server_stream(std::string arg1) {
 }
 
 std::vector<bool> GizmoClient::do_one_bidi_stream(std::vector<std::string> arg1) {
-    grpc::ClientContext ctx;
-    set_client_ctx_authority(ctx);
+    ClientContext ctx;
 
-    auto stream(stub_->DoOneBiDiStream(&ctx));
+    auto stream(stub_->DoOneBiDiStream(ctx));
     for (std::string arg : arg1) {
         DoOneBiDiStreamRequest curr_req = {};
         *curr_req.mutable_name() = this->name();
@@ -289,13 +286,12 @@ std::string GizmoClient::do_two(bool arg1) {
     DoTwoRequest request;
     DoTwoResponse response;
 
-    grpc::ClientContext ctx;
-    set_client_ctx_authority(ctx);
+    ClientContext ctx;
 
     *request.mutable_name() = this->name();
     request.set_arg1(arg1);
 
-    const grpc::Status status = stub_->DoTwo(&ctx, request, &response);
+    const grpc::Status status = stub_->DoTwo(ctx, request, &response);
     if (!status.ok()) {
         throw std::runtime_error(status.error_message());
     }

--- a/src/viam/examples/modules/complex/proto/buf.lock
+++ b/src/viam/examples/modules/complex/proto/buf.lock
@@ -4,5 +4,5 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: b30c5775bfb3485d9da2e87b26590ac9
-    digest: shake256:9d0caaf056949a0e1c883b9849d8a2fa66e22f18a2a48f867d1a8c700aa22abee50ad3ef0d8171637457cadc43c584998bdf3adac55da0f9e4614c72686b057d
+    commit: a86849a25cc04f4dbe9b15ddddfbc488
+    digest: shake256:e19143328f8cbfe13fc226aeee5e63773ca494693a72740a7560664270039a380d94a1344234b88c7691311460df9a9b1c2982190d0a2612eae80368718e1943

--- a/src/viam/sdk/common/client_helper.hpp
+++ b/src/viam/sdk/common/client_helper.hpp
@@ -50,10 +50,9 @@ class ClientHelper {
     template <typename ResponseHandlerCallable, typename ErrorHandlerCallable>
     auto invoke(ResponseHandlerCallable&& rhc, ErrorHandlerCallable&& ehc) {
         *request_.mutable_name() = client_->name();
-        ::grpc::ClientContext ctx;
-        set_client_ctx_authority(ctx);
+        ClientContext ctx;
 
-        const auto result = (stub_->*pfn_)(&ctx, request_, &response_);
+        const auto result = (stub_->*pfn_)(ctx, request_, &response_);
         if (result.ok()) {
             return std::forward<ResponseHandlerCallable>(rhc)(
                 const_cast<const ResponseType&>(response_));

--- a/src/viam/sdk/common/utils.cpp
+++ b/src/viam/sdk/common/utils.cpp
@@ -132,8 +132,20 @@ bool operator==(const response_metadata& lhs, const response_metadata& rhs) {
     return lhs.captured_at == rhs.captured_at;
 }
 
-void set_client_ctx_authority(grpc::ClientContext& ctx) {
-    ctx.set_authority("viam-placeholder");
+void ClientContext::set_client_ctx_authority_() {
+    wrapped_context_.set_authority("viam-placeholder");
+}
+
+ClientContext::ClientContext() {
+    set_client_ctx_authority_();
+}
+
+ClientContext::operator const grpc::ClientContext*() const {
+    return &wrapped_context_;
+}
+
+ClientContext::operator grpc::ClientContext*() {
+    return &wrapped_context_;
 }
 
 bool from_dm_from_extra(const AttributeMap& extra) {

--- a/src/viam/sdk/common/utils.hpp
+++ b/src/viam/sdk/common/utils.hpp
@@ -67,12 +67,21 @@ std::string bytes_to_string(std::vector<unsigned char> const& b);
 std::chrono::microseconds from_proto(const google::protobuf::Duration& proto);
 google::protobuf::Duration to_proto(const std::chrono::microseconds& duration);
 
-// the authority is sometimes set to an invalid uri on mac, causing `rust-utils` to fail
-// to process gRPC requests. Fortunately we don't particularly care what the authority is
-// set to within the ctx once a channel is built, so we can just set a placeholder value
-// to appease rust and continue to rely on the gRPC channel to process requests correctly.
+// the authority on a grpc::ClientContext is sometimes set to an invalid uri on mac, causing
+// `rust-utils` to fail to process gRPC requests. This class provides a convenience wrapper around a
+// grpc ClientContext that allows us to make any necessary modifications to authority or else where
+// to avoid runtime issues.
 // For more details, see https://viam.atlassian.net/browse/RSDK-5194.
-void set_client_ctx_authority(grpc::ClientContext& ctx);
+class ClientContext {
+   public:
+    ClientContext();
+    operator grpc::ClientContext*();
+    operator const grpc::ClientContext*() const;
+
+   private:
+    void set_client_ctx_authority_();
+    grpc::ClientContext wrapped_context_;
+};
 
 /// @brief Set the boost trivial logger's severity depending on args.
 /// @param argc The number of args.

--- a/src/viam/sdk/components/board/client.cpp
+++ b/src/viam/sdk/components/board/client.cpp
@@ -93,15 +93,13 @@ Board::analog_value BoardClient::read_analog(const std::string& analog_reader_na
                                              const AttributeMap& extra) {
     viam::component::board::v1::ReadAnalogReaderRequest request;
     viam::component::board::v1::ReadAnalogReaderResponse response;
-
-    grpc::ClientContext ctx;
-    set_client_ctx_authority(ctx);
+    ClientContext ctx;
 
     request.set_board_name(this->name());
     request.set_analog_reader_name(analog_reader_name);
     *request.mutable_extra() = map_to_struct(extra);
 
-    const grpc::Status status = stub_->ReadAnalogReader(&ctx, request, &response);
+    const grpc::Status status = stub_->ReadAnalogReader(ctx, request, &response);
     if (!status.ok()) {
         throw std::runtime_error(status.error_message());
     }
@@ -124,15 +122,13 @@ Board::digital_value BoardClient::read_digital_interrupt(const std::string& digi
                                                          const AttributeMap& extra) {
     viam::component::board::v1::GetDigitalInterruptValueRequest request;
     viam::component::board::v1::GetDigitalInterruptValueResponse response;
-
-    grpc::ClientContext ctx;
-    set_client_ctx_authority(ctx);
+    ClientContext ctx;
 
     request.set_board_name(this->name());
     request.set_digital_interrupt_name(digital_interrupt_name);
     *request.mutable_extra() = map_to_struct(extra);
 
-    const grpc::Status status = stub_->GetDigitalInterruptValue(&ctx, request, &response);
+    const grpc::Status status = stub_->GetDigitalInterruptValue(ctx, request, &response);
     if (!status.ok()) {
         throw std::runtime_error(status.error_message());
     }

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -40,7 +40,6 @@ namespace sdk {
 // TODO(RSDK-4573) Having all these proto types exposed here in the APIs is sad. Let's fix that.
 
 using google::protobuf::RepeatedPtrField;
-using grpc::ClientContext;
 using viam::common::v1::PoseInFrame;
 using viam::common::v1::ResourceName;
 using viam::common::v1::Transform;
@@ -93,12 +92,11 @@ std::vector<Status> RobotClient::get_status(std::vector<ResourceName>& component
     viam::robot::v1::GetStatusRequest req;
     viam::robot::v1::GetStatusResponse resp;
     ClientContext ctx;
-    set_client_ctx_authority(ctx);
     for (const ResourceName& name : components) {
         *req.mutable_resource_names()->Add() = name;
     }
 
-    const grpc::Status response = stub_->GetStatus(&ctx, req, &resp);
+    const grpc::Status response = stub_->GetStatus(ctx, req, &resp);
     if (is_error_response(response)) {
         BOOST_LOG_TRIVIAL(error) << "Error getting status: " << response.error_message()
                                  << response.error_details();
@@ -119,11 +117,10 @@ std::vector<Operation> RobotClient::get_operations() {
     const viam::robot::v1::GetOperationsRequest req;
     viam::robot::v1::GetOperationsResponse resp;
     ClientContext ctx;
-    set_client_ctx_authority(ctx);
 
     std::vector<Operation> operations;
 
-    grpc::Status const response = stub_->GetOperations(&ctx, req, &resp);
+    grpc::Status const response = stub_->GetOperations(ctx, req, &resp);
     if (is_error_response(response)) {
         BOOST_LOG_TRIVIAL(error) << "Error getting operations: " << response.error_message();
     }
@@ -139,10 +136,9 @@ void RobotClient::cancel_operation(std::string id) {
     viam::robot::v1::CancelOperationRequest req;
     viam::robot::v1::CancelOperationResponse resp;
     ClientContext ctx;
-    set_client_ctx_authority(ctx);
 
     req.set_id(id);
-    const grpc::Status response = stub_->CancelOperation(&ctx, req, &resp);
+    const grpc::Status response = stub_->CancelOperation(ctx, req, &resp);
     if (is_error_response(response)) {
         BOOST_LOG_TRIVIAL(error) << "Error canceling operation with id " << id;
     }
@@ -152,11 +148,10 @@ void RobotClient::block_for_operation(std::string id) {
     viam::robot::v1::BlockForOperationRequest req;
     viam::robot::v1::BlockForOperationResponse resp;
     ClientContext ctx;
-    set_client_ctx_authority(ctx);
 
     req.set_id(id);
 
-    const grpc::Status response = stub_->BlockForOperation(&ctx, req, &resp);
+    const grpc::Status response = stub_->BlockForOperation(ctx, req, &resp);
     if (is_error_response(response)) {
         BOOST_LOG_TRIVIAL(error) << "Error blocking for operation with id " << id;
     }
@@ -166,8 +161,8 @@ void RobotClient::refresh() {
     const viam::robot::v1::ResourceNamesRequest req;
     viam::robot::v1::ResourceNamesResponse resp;
     ClientContext ctx;
-    set_client_ctx_authority(ctx);
-    const grpc::Status response = stub_->ResourceNames(&ctx, req, &resp);
+
+    const grpc::Status response = stub_->ResourceNames(ctx, req, &resp);
     if (is_error_response(response)) {
         BOOST_LOG_TRIVIAL(error) << "Error getting resource names: " << response.error_message();
     }
@@ -286,14 +281,13 @@ std::vector<FrameSystemConfig> RobotClient::get_frame_system_config(
     viam::robot::v1::FrameSystemConfigRequest req;
     viam::robot::v1::FrameSystemConfigResponse resp;
     ClientContext ctx;
-    set_client_ctx_authority(ctx);
 
     RepeatedPtrField<Transform>* req_transforms = req.mutable_supplemental_transforms();
     for (const Transform& transform : additional_transforms) {
         *req_transforms->Add() = transform;
     }
 
-    const grpc::Status response = stub_->FrameSystemConfig(&ctx, req, &resp);
+    const grpc::Status response = stub_->FrameSystemConfig(ctx, req, &resp);
     if (is_error_response(response)) {
         BOOST_LOG_TRIVIAL(error) << "Error getting frame system config: "
                                  << response.error_message();
@@ -316,7 +310,6 @@ PoseInFrame RobotClient::transform_pose(PoseInFrame query,
     viam::robot::v1::TransformPoseRequest req;
     viam::robot::v1::TransformPoseResponse resp;
     ClientContext ctx;
-    set_client_ctx_authority(ctx);
 
     *req.mutable_source() = query;
     *req.mutable_destination() = destination;
@@ -326,7 +319,7 @@ PoseInFrame RobotClient::transform_pose(PoseInFrame query,
         *req_transforms->Add() = transform;
     }
 
-    const grpc::Status response = stub_->TransformPose(&ctx, req, &resp);
+    const grpc::Status response = stub_->TransformPose(ctx, req, &resp);
     if (is_error_response(response)) {
         BOOST_LOG_TRIVIAL(error) << "Error getting PoseInFrame: " << response.error_message();
     }
@@ -338,7 +331,6 @@ std::vector<Discovery> RobotClient::discover_components(std::vector<DiscoveryQue
     viam::robot::v1::DiscoverComponentsRequest req;
     viam::robot::v1::DiscoverComponentsResponse resp;
     ClientContext ctx;
-    set_client_ctx_authority(ctx);
 
     RepeatedPtrField<DiscoveryQuery>* req_queries = req.mutable_queries();
 
@@ -346,7 +338,7 @@ std::vector<Discovery> RobotClient::discover_components(std::vector<DiscoveryQue
         *req_queries->Add() = query;
     }
 
-    const grpc::Status response = stub_->DiscoverComponents(&ctx, req, &resp);
+    const grpc::Status response = stub_->DiscoverComponents(ctx, req, &resp);
     if (is_error_response(response)) {
         BOOST_LOG_TRIVIAL(error) << "Error discovering components: " << response.error_message();
     }
@@ -385,7 +377,6 @@ void RobotClient::stop_all(
     viam::robot::v1::StopAllRequest req;
     viam::robot::v1::StopAllResponse resp;
     ClientContext ctx;
-    set_client_ctx_authority(ctx);
 
     RepeatedPtrField<viam::robot::v1::StopExtraParameters>* ep = req.mutable_extra();
     for (auto& xtra : extra) {
@@ -399,7 +390,7 @@ void RobotClient::stop_all(
         *stop.mutable_params() = s;
         *ep->Add() = stop;
     }
-    const grpc::Status response = stub_->StopAll(&ctx, req, &resp);
+    const grpc::Status response = stub_->StopAll(ctx, req, &resp);
     if (is_error_response(response)) {
         BOOST_LOG_TRIVIAL(error) << "Error stopping all: " << response.error_message()
                                  << response.error_details();

--- a/src/viam/sdk/services/mlmodel/client.cpp
+++ b/src/viam/sdk/services/mlmodel/client.cpp
@@ -38,8 +38,7 @@ std::shared_ptr<MLModelService::named_tensor_views> MLModelServiceClient::infer(
     req->set_name(this->name());
     *req->mutable_extra() = map_to_struct(extra);
     auto* const resp = pb::Arena::CreateMessage<mlpb::InferResponse>(arena.get());
-    grpc::ClientContext ctx;
-    set_client_ctx_authority(ctx);
+    ClientContext ctx;
 
     struct arena_and_views {
         // NOTE: It is not necessary to capture the `resp` pointer
@@ -57,7 +56,7 @@ std::shared_ptr<MLModelService::named_tensor_views> MLModelServiceClient::infer(
         mlmodel_details::copy_sdk_tensor_to_api_tensor(kv.second, &emplaced);
     }
 
-    const auto result = stub_->Infer(&ctx, *req, resp);
+    const auto result = stub_->Infer(ctx, *req, resp);
     if (!result.ok()) {
         throw std::runtime_error(result.error_message());
     }
@@ -80,10 +79,9 @@ struct MLModelService::metadata MLModelServiceClient::metadata(const AttributeMa
     *req.mutable_extra() = map_to_struct(extra);
 
     // Invoke the stub
-    grpc::ClientContext ctx;
-    set_client_ctx_authority(ctx);
+    ClientContext ctx;
     viam::service::mlmodel::v1::MetadataResponse resp;
-    const auto stub_result = stub_->Metadata(&ctx, req, &resp);
+    const auto stub_result = stub_->Metadata(ctx, req, &resp);
 
     struct metadata result;
     if (resp.has_metadata()) {

--- a/src/viam/sdk/services/motion/client.cpp
+++ b/src/viam/sdk/services/motion/client.cpp
@@ -101,44 +101,30 @@ pose_in_frame MotionClient::get_pose(
 }
 
 void MotionClient::stop_plan(const Name& name, const AttributeMap& extra) {
-    service::motion::v1::StopPlanRequest request;
-    service::motion::v1::StopPlanResponse response;
-    grpc::ClientContext ctx;
-    set_client_ctx_authority(ctx);
-
-    *request.mutable_name() = this->name();
-    *request.mutable_extra() = map_to_struct(extra);
-
-    const grpc::Status status = stub_->StopPlan(&ctx, request, &response);
-    if (!status.ok()) {
-        throw std::runtime_error(status.error_message());
-    }
+    return make_client_helper(this, *stub_, &StubType::StopPlan)
+        .with(extra, [&](auto& request) { *request.mutable_component_name() = name.to_proto(); })
+        .invoke();
 }
 
 std::pair<Motion::plan_with_status, std::vector<Motion::plan_with_status>> MotionClient::get_plan_(
-    const Name& name,
+    const Name& component_name,
     boost::optional<std::string> execution_id,
     bool last_plan_only,
     const AttributeMap& extra) {
-    service::motion::v1::GetPlanRequest request;
-    service::motion::v1::GetPlanResponse response;
-    grpc::ClientContext ctx;
-    set_client_ctx_authority(ctx);
-
-    *request.mutable_name() = this->name();
-    *request.mutable_extra() = map_to_struct(extra);
-    request.set_last_plan_only(last_plan_only);
-    if (execution_id) {
-        *request.mutable_execution_id() = *execution_id;
-    }
-
-    const grpc::Status status = stub_->GetPlan(&ctx, request, &response);
-    if (!status.ok()) {
-        throw std::runtime_error(status.error_message());
-    }
-
-    return {Motion::plan_with_status::from_proto(response.current_plan_with_status()),
-            Motion::plan_with_status::from_proto(response.replan_history())};
+    return make_client_helper(this, *stub_, &StubType::GetPlan)
+        .with(extra,
+              [&](auto& request) {
+                  *request.mutable_component_name() = component_name.to_proto();
+                  request.set_last_plan_only(last_plan_only);
+                  if (execution_id) {
+                      *request.mutable_execution_id() = *execution_id;
+                  }
+              })
+        .invoke([](auto& response) {
+            return std::pair<Motion::plan_with_status, std::vector<Motion::plan_with_status>>(
+                Motion::plan_with_status::from_proto(response.current_plan_with_status()),
+                Motion::plan_with_status::from_proto(response.replan_history()));
+        });
 }
 
 Motion::plan_with_status MotionClient::get_plan(const Name& name,
@@ -166,26 +152,16 @@ MotionClient::get_latest_plan_with_replan_history(const Name& name, const Attrib
 
 std::vector<Motion::plan_status_with_id> MotionClient::list_plan_statuses_(
     bool only_active_plans, const AttributeMap& extra) {
-    service::motion::v1::ListPlanStatusesRequest request;
-    service::motion::v1::ListPlanStatusesResponse response;
-    grpc::ClientContext ctx;
-    set_client_ctx_authority(ctx);
+    return make_client_helper(this, *stub_, &StubType::ListPlanStatuses)
+        .with(extra, [&](auto& request) { request.set_only_active_plans(only_active_plans); })
+        .invoke([](auto& response) {
+            std::vector<Motion::plan_status_with_id> statuses;
+            for (const auto& proto : response.plan_statuses_with_ids()) {
+                statuses.push_back(Motion::plan_status_with_id::from_proto(proto));
+            }
 
-    *request.mutable_name() = this->name();
-    *request.mutable_extra() = map_to_struct(extra);
-    request.set_only_active_plans(only_active_plans);
-
-    const grpc::Status status = stub_->ListPlanStatuses(&ctx, request, &response);
-    if (!status.ok()) {
-        throw std::runtime_error(status.error_message());
-    }
-
-    std::vector<Motion::plan_status_with_id> statuses;
-    for (const auto& proto : response.plan_statuses_with_ids()) {
-        statuses.push_back(Motion::plan_status_with_id::from_proto(proto));
-    }
-
-    return statuses;
+            return statuses;
+        });
 }
 
 std::vector<Motion::plan_status_with_id> MotionClient::list_plan_statuses(

--- a/src/viam/sdk/services/motion/motion.hpp
+++ b/src/viam/sdk/services/motion/motion.hpp
@@ -420,7 +420,7 @@ class Motion : public Service {
     /// @param component_name The name of the component which the MoveOnGlobe request asked to move.
     /// @param execution_id The execution id of the requested plan.
     /// @return the plan and status of the requested execution's move the requested component
-    inline plan_with_status get_plan(Name component_name, const std::string& execution_id) {
+    inline plan_with_status get_plan(const Name& component_name, const std::string& execution_id) {
         return get_plan(component_name, execution_id, {});
     }
 


### PR DESCRIPTION
Uses a factory function to generate a client ctx with a set authority to minimize both runtime errors and boilerplate.