### PR TITLE
RSDK-794 Client side helper to replace `stub_wrapper`

### DIFF
--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(viamsdk
     # consider making all necessary runtime values a single `context` that has to
     # be initialized within main before anything else happens?
     registry/registry.cpp
+    common/client_helper.cpp
     common/linear_algebra.cpp
     common/pose.cpp
     common/proto_type.cpp
@@ -106,9 +107,11 @@ target_sources(viamsdk
     BASE_DIRS
       ../..
     FILES
+      ../../viam/sdk/common/client_helper.hpp
       ../../viam/sdk/common/linear_algebra.hpp
       ../../viam/sdk/common/pose.hpp
       ../../viam/sdk/common/proto_type.hpp
+      ../../viam/sdk/common/service_helper.hpp
       ../../viam/sdk/common/utils.hpp
       ../../viam/sdk/common/world_state.hpp
       ../../viam/sdk/components/base/base.hpp

--- a/src/viam/sdk/common/client_helper.cpp
+++ b/src/viam/sdk/common/client_helper.cpp
@@ -1,0 +1,19 @@
+#include <viam/sdk/common/client_helper.hpp>
+
+#include <cstdlib>
+
+#include <boost/log/trivial.hpp>
+
+namespace viam {
+namespace sdk {
+
+namespace client_helper_details {
+
+[[noreturn]] void errorHandlerReturnedUnexpectedly(const ::grpc::Status& status) noexcept {
+  BOOST_LOG_TRIVIAL(fatal) << "ClientHelper error handler callback returned instead of throwing: " << status.error_message() << '(' << status.error_details() << ')';
+  std::abort();
+}
+
+}  // namespace client_helper_details
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/common/client_helper.cpp
+++ b/src/viam/sdk/common/client_helper.cpp
@@ -10,8 +10,9 @@ namespace sdk {
 namespace client_helper_details {
 
 [[noreturn]] void errorHandlerReturnedUnexpectedly(const ::grpc::Status& status) noexcept {
-  BOOST_LOG_TRIVIAL(fatal) << "ClientHelper error handler callback returned instead of throwing: " << status.error_message() << '(' << status.error_details() << ')';
-  std::abort();
+    BOOST_LOG_TRIVIAL(fatal) << "ClientHelper error handler callback returned instead of throwing: "
+                             << status.error_message() << '(' << status.error_details() << ')';
+    std::abort();
 }
 
 }  // namespace client_helper_details

--- a/src/viam/sdk/common/client_helper.hpp
+++ b/src/viam/sdk/common/client_helper.hpp
@@ -7,6 +7,10 @@
 namespace viam {
 namespace sdk {
 
+namespace client_helper_details {
+[[noreturn]] void errorHandlerReturnedUnexpectedly(const ::grpc::Status&) noexcept;
+}  // namespace client_helper_details
+
 template <typename ClientType, typename StubType, typename RequestType, typename ResponseType>
 class ClientHelper {
     static void default_rsc_(RequestType&) {}
@@ -56,7 +60,7 @@ class ClientHelper {
         }
 
         std::forward<ErrorHandlerCallable>(ehc)(result);
-        std::abort();
+        client_helper_details::errorHandlerReturnedUnexpectedly(result);
     }
 
    private:

--- a/src/viam/sdk/common/client_helper.hpp
+++ b/src/viam/sdk/common/client_helper.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <grpcpp/client_context.h>
+#include <viam/sdk/common/proto_type.hpp>
+#include <viam/sdk/common/utils.hpp>
+
+namespace viam {
+namespace sdk {
+
+template <typename ClientType, typename StubType, typename RequestType, typename ResponseType>
+class ClientHelper {
+    static void default_rsc_(RequestType&) {}
+    static void default_rhc_(const ResponseType&) {}
+    static void default_ehc_(const ::grpc::Status& status) {
+        throw std::runtime_error(status.error_message());
+    }
+
+   public:
+    using PFn = ::grpc::Status (StubType::*)(::grpc::ClientContext*,
+                                             const RequestType&,
+                                             ResponseType*);
+    explicit ClientHelper(ClientType* client, StubType* stub, PFn pfn)
+        : client_(client), stub_(stub), pfn_(pfn) {}
+
+    ClientHelper& with(const AttributeMap& extra) {
+        return with(extra, default_rsc_);
+    }
+
+    template <typename RequestSetupCallable>
+    ClientHelper& with(RequestSetupCallable&& rsc) {
+        std::forward<RequestSetupCallable>(rsc)(request_);
+        return *this;
+    }
+
+    template <typename RequestSetupCallable>
+    ClientHelper& with(const AttributeMap& extra, RequestSetupCallable&& rsc) {
+        *request_.mutable_extra() = map_to_struct(extra);
+        return with(std::forward<RequestSetupCallable>(rsc));
+    }
+
+    template <typename ResponseHandlerCallable = decltype(default_rhc_)>
+    auto invoke(ResponseHandlerCallable&& rhc = default_rhc_) {
+        return invoke(std::forward<ResponseHandlerCallable>(rhc), default_ehc_);
+    }
+
+    template <typename ResponseHandlerCallable, typename ErrorHandlerCallable>
+    auto invoke(ResponseHandlerCallable&& rhc, ErrorHandlerCallable&& ehc) {
+        *request_.mutable_name() = client_->name();
+        ::grpc::ClientContext ctx;
+        set_client_ctx_authority(ctx);
+
+        const auto result = (stub_->*pfn_)(&ctx, request_, &response_);
+        if (result.ok()) {
+            return std::forward<ResponseHandlerCallable>(rhc)(
+                const_cast<const ResponseType&>(response_));
+        }
+
+        std::forward<ErrorHandlerCallable>(ehc)(result);
+        std::abort();
+    }
+
+   private:
+    ClientType* client_;
+    StubType* stub_;
+    PFn pfn_;
+    RequestType request_;
+    ResponseType response_;
+};
+
+// TODO: Stop returns the status???
+
+template <typename ClientType, typename StubType, typename RequestType, typename ResponseType>
+auto make_client_helper(ClientType* client,
+                        StubType& stub,
+                        ::grpc::Status (StubType::*method)(::grpc::ClientContext*,
+                                                           const RequestType&,
+                                                           ResponseType*)) {
+    return ClientHelper<ClientType, StubType, RequestType, ResponseType>(client, &stub, method);
+}
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/common/client_helper.hpp
+++ b/src/viam/sdk/common/client_helper.hpp
@@ -67,8 +67,6 @@ class ClientHelper {
     ResponseType response_;
 };
 
-// TODO: Stop returns the status???
-
 template <typename ClientType, typename StubType, typename RequestType, typename ResponseType>
 auto make_client_helper(ClientType* client,
                         StubType& stub,

--- a/src/viam/sdk/components/motor/client.cpp
+++ b/src/viam/sdk/components/motor/client.cpp
@@ -61,10 +61,38 @@ class ClientHelper {
             const_cast<const ResponseType&>(response));
     }
 
+    template<typename T>
+    class InvocationProxy {
+        friend ClientHelper;
+    public:
+    private:
+        InvocationProxy(T&& callable, ClientHelper& helper) : callable_(std::move(callable)), helper_(helper) {}
+
+        T callable_;
+        ClientHelper& helper_;
+    };
+
+    static constexpr auto drsc = [](RequestType&) {};
+
+    template<typename RequestSetupCallable = decltype(drsc)>
+    InvocationProxy<RequestSetupCallable> invoke(RequestSetupCallable rsc = drsc) {
+        *request_.mutable_name() = client_->name();
+        return InvocationProxy<RequestSetupCallable>{std::move(rsc), *this};
+    }
+
+    template <typename RequestSetupCallable = decltype(drsc)>
+    auto invoke(const AttributeMap& extra, RequestSetupCallable rsc = drsc) {
+        *request_.mutable_extra() = map_to_struct(extra);
+        return invoke(std::move(rsc));
+    }
+
    private:
     ClientType* client_;
     StubType& stub_;
     PFn pfn_;
+    RequestType request_;
+    ResponseType response_;
+    ::grpc::Status result_;
 };
 
 // TODO: EXTRA
@@ -79,9 +107,30 @@ auto make_client_helper(ClientType* client,
     return ClientHelper<ClientType, StubType, RequestType, ResponseType>(client, stub, method);
 }
 
+auto xxx() { }
+    
 void MotorClient::set_power(double power_pct, const AttributeMap& extra) {
     return make_client_helper(this, *stub_, &StubType::SetPower)(
         [&](auto& request) { request.set_power_pct(power_pct); });
+#if 0
+    return make_client_helper(this, *stub_, &StubType::SetPower)
+        .invoke([&](auto& request) {
+            req.set_power_pct = power_pct;
+        })
+        .then([&](auto& resp) {
+            return resp.foo();
+        })
+        .or([&](auto& status) {
+            throw std::runtime_error(status.error_message());
+        });
+
+    return make_client_helper(this, *stub_, &StubType::SetPower)
+        .invoke()
+        .then([&](auto& resp) {
+        return resp.foo();
+    });
+#endif
+    auto ip = make_client_helper(this, *stub_, &StubType::SetPower).invoke(extra);
 }
 
 void MotorClient::go_for(double rpm, double revolutions, const AttributeMap& extra) {

--- a/src/viam/sdk/components/motor/client.cpp
+++ b/src/viam/sdk/components/motor/client.cpp
@@ -1,3 +1,4 @@
+#include "viam/sdk/common/proto_type.hpp"
 #include <viam/sdk/components/motor/client.hpp>
 
 #include <algorithm>
@@ -24,9 +25,9 @@ MotorClient::MotorClient(std::string name, std::shared_ptr<grpc::Channel> channe
 
 template <typename ClientType, typename StubType, typename RequestType, typename ResponseType>
 class ClientHelper {
-    static void default_rsc(RequestType&) {}
-    static void default_rhc(const ResponseType&) {}
-    static void default_ehc(const ::grpc::Status& status) {
+    static void default_rsc_(RequestType&) {}
+    static void default_rhc_(const ResponseType&) {}
+    static void default_ehc_(const ::grpc::Status& status) {
         throw std::runtime_error(status.error_message());
     }
 
@@ -37,37 +38,51 @@ class ClientHelper {
     explicit ClientHelper(ClientType* client, StubType& stub, PFn pfn)
         : client_(client), stub_(stub), pfn_(pfn) {}
 
-    template <typename RequestSetupCallable = decltype(default_rsc),
-              typename ResponseHandlerCallable = decltype(default_rhc),
-              typename ErrorHandlerCallable = decltype(default_ehc)>
-    auto operator()(RequestSetupCallable&& rsc = default_rsc,
-                    ResponseHandlerCallable&& rhc = default_rhc,
-                    ErrorHandlerCallable&& ehc = default_ehc) {
-        RequestType request;
-        *request.mutable_name() = client_->name();
-        std::forward<RequestSetupCallable>(rsc)(request);
+    ClientHelper& with(const AttributeMap& extra) {
+        return with(extra, default_rsc_);
+    }
 
+    template <typename RequestSetupCallable>
+    ClientHelper& with(RequestSetupCallable&& rsc) {
+        std::forward<RequestSetupCallable>(rsc)(request_);
+        return *this;
+    }
+
+    template <typename RequestSetupCallable>
+    ClientHelper& with(const AttributeMap& extra, RequestSetupCallable&& rsc) {
+        *request_.mutable_extra() = map_to_struct(extra);
+        return with(std::forward<RequestSetupCallable>(rsc));
+    }
+
+    template <typename ResponseHandlerCallable = decltype(default_rhc_)>
+    auto invoke(ResponseHandlerCallable&& rhc = default_rhc_) {
+        return invoke(std::forward<ResponseHandlerCallable>(rhc), default_ehc_);
+    }
+
+    template <typename ResponseHandlerCallable, typename ErrorHandlerCallable>
+    auto invoke(ResponseHandlerCallable&& rhc, ErrorHandlerCallable&& ehc) {
+        *request_.mutable_name() = client_->name();
         ::grpc::ClientContext ctx;
         set_client_ctx_authority(ctx);
 
-        ResponseType response;
-        const auto result = (stub_.*pfn_)(&ctx, request, &response);
+        const auto result = (stub_.*pfn_)(&ctx, request_, &response_);
         if (!result.ok()) {
             std::forward<ErrorHandlerCallable>(ehc)(result);
-            default_ehc(result);
+            // TODO ABORT?
         }
 
         return std::forward<ResponseHandlerCallable>(rhc)(
-            const_cast<const ResponseType&>(response));
+            const_cast<const ResponseType&>(response_));
     }
 
    private:
     ClientType* client_;
     StubType& stub_;
     PFn pfn_;
+    RequestType request_;
+    ResponseType response_;
 };
 
-// TODO: EXTRA
 // TODO: Stop returns the status???
 
 template <typename ClientType, typename StubType, typename RequestType, typename ResponseType>
@@ -80,37 +95,47 @@ auto make_client_helper(ClientType* client,
 }
 
 void MotorClient::set_power(double power_pct, const AttributeMap& extra) {
-    return make_client_helper(this, *stub_, &StubType::SetPower)(
-        [&](auto& request) { request.set_power_pct(power_pct); });
+    return make_client_helper(this, *stub_, &StubType::SetPower)
+        .with(extra, [&](auto& request) { request.set_power_pct(power_pct); })
+        .invoke();
 }
 
 void MotorClient::go_for(double rpm, double revolutions, const AttributeMap& extra) {
-    return make_client_helper(this, *stub_, &StubType::GoFor)([&](auto& request) {
-        request.set_rpm(rpm);
-        request.set_revolutions(revolutions);
-    });
+    return make_client_helper(this, *stub_, &StubType::GoFor)
+        .with(extra,
+              [&](auto& request) {
+                  request.set_rpm(rpm);
+                  request.set_revolutions(revolutions);
+              })
+        .invoke();
 }
 
 void MotorClient::go_to(double rpm, double position_revolutions, const AttributeMap& extra) {
-    return make_client_helper(this, *stub_, &StubType::GoTo)([&](auto& request) {
-        request.set_rpm(rpm);
-        request.set_position_revolutions(position_revolutions);
-    });
+    return make_client_helper(this, *stub_, &StubType::GoTo)
+        .with(extra,
+              [&](auto& request) {
+                  request.set_rpm(rpm);
+                  request.set_position_revolutions(position_revolutions);
+              })
+        .invoke();
 }
 
 void MotorClient::reset_zero_position(double offset, const AttributeMap& extra) {
-    return make_client_helper(this, *stub_, &StubType::ResetZeroPosition)(
-        [&](auto& request) { request.set_offset(offset); });
+    return make_client_helper(this, *stub_, &StubType::ResetZeroPosition)
+        .with(extra, [&](auto& request) { request.set_offset(offset); })
+        .invoke();
 }
 
 Motor::position MotorClient::get_position(const AttributeMap& extra) {
-    return make_client_helper(this, *stub_, &StubType::GetPosition)(
-        [](auto&) {}, [](auto& response) { return from_proto(response); });
+    return make_client_helper(this, *stub_, &StubType::GetPosition)
+        .with(extra)
+        .invoke([](auto& response) { return from_proto(response); });
 }
 
 Motor::properties MotorClient::get_properties(const AttributeMap& extra) {
-    return make_client_helper(this, *stub_, &StubType::GetProperties)(
-        [](auto&) {}, [](auto& response) { return from_proto(response); });
+    return make_client_helper(this, *stub_, &StubType::GetProperties)
+        .with(extra)
+        .invoke([](auto& response) { return from_proto(response); });
 }
 
 grpc::StatusCode MotorClient::stop(const AttributeMap& extra) {
@@ -128,25 +153,27 @@ grpc::StatusCode MotorClient::stop(const AttributeMap& extra) {
 }
 
 Motor::power_status MotorClient::get_power_status(const AttributeMap& extra) {
-    return make_client_helper(this, *stub_, &StubType::IsPowered)(
-        [](auto&) {}, [](auto& response) { return from_proto(response); });
+    return make_client_helper(this, *stub_, &StubType::IsPowered)
+        .with(extra)
+        .invoke([](auto& response) { return from_proto(response); });
 }
 
 std::vector<GeometryConfig> MotorClient::get_geometries(const AttributeMap& extra) {
-    return make_client_helper(this, *stub_, &StubType::GetGeometries)(
-        [](auto&) {},
-        [](auto& response) { return GeometryConfig::from_proto(response); });
+    return make_client_helper(this, *stub_, &StubType::GetGeometries)
+        .with(extra)
+        .invoke([](auto& response) { return GeometryConfig::from_proto(response); });
 }
 
 bool MotorClient::is_moving() {
-    return make_client_helper(this, *stub_, &StubType::IsMoving)(
-        [](auto&) {}, [](auto& response) { return response.is_moving(); });
+    return make_client_helper(this, *stub_, &StubType::IsMoving).invoke([](auto& response) {
+        return response.is_moving();
+    });
 }
 
 AttributeMap MotorClient::do_command(const AttributeMap& command) {
-    return make_client_helper(this, *stub_, &StubType::DoCommand)(
-        [&](auto& request) { *request.mutable_command() = map_to_struct(command); },
-        [](auto& response) { return struct_to_map(response.result()); });
+    return make_client_helper(this, *stub_, &StubType::DoCommand)
+        .with([&](auto& request) { *request.mutable_command() = map_to_struct(command); })
+        .invoke([](auto& response) { return struct_to_map(response.result()); });
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/components/motor/client.cpp
+++ b/src/viam/sdk/components/motor/client.cpp
@@ -105,12 +105,12 @@ void MotorClient::reset_zero_position(double offset, const AttributeMap& extra) 
 
 Motor::position MotorClient::get_position(const AttributeMap& extra) {
     return make_client_helper(this, *stub_, &StubType::GetPosition)(
-        [](auto) {}, [](auto& response) { return from_proto(response); });
+        [](auto&) {}, [](auto& response) { return from_proto(response); });
 }
 
 Motor::properties MotorClient::get_properties(const AttributeMap& extra) {
     return make_client_helper(this, *stub_, &StubType::GetProperties)(
-        [](auto) {}, [](auto& response) { return from_proto(response); });
+        [](auto&) {}, [](auto& response) { return from_proto(response); });
 }
 
 grpc::StatusCode MotorClient::stop(const AttributeMap& extra) {
@@ -129,18 +129,18 @@ grpc::StatusCode MotorClient::stop(const AttributeMap& extra) {
 
 Motor::power_status MotorClient::get_power_status(const AttributeMap& extra) {
     return make_client_helper(this, *stub_, &StubType::IsPowered)(
-        [](auto) {}, [](auto& response) { return from_proto(response); });
+        [](auto&) {}, [](auto& response) { return from_proto(response); });
 }
 
 std::vector<GeometryConfig> MotorClient::get_geometries(const AttributeMap& extra) {
     return make_client_helper(this, *stub_, &StubType::GetGeometries)(
-        [](auto) {},
+        [](auto&) {},
         [](auto& response) { return GeometryConfig::from_proto(response); });
 }
 
 bool MotorClient::is_moving() {
     return make_client_helper(this, *stub_, &StubType::IsMoving)(
-        [](auto) {}, [](auto& response) { return response.is_moving(); });
+        [](auto&) {}, [](auto& response) { return response.is_moving(); });
 }
 
 AttributeMap MotorClient::do_command(const AttributeMap& command) {

--- a/src/viam/sdk/components/motor/client.cpp
+++ b/src/viam/sdk/components/motor/client.cpp
@@ -31,7 +31,6 @@ class ClientHelper {
     }
 
    public:
-    void foo() {}
     using PFn = ::grpc::Status (StubType::*)(::grpc::ClientContext*,
                                              const RequestType&,
                                              ResponseType*);

--- a/src/viam/sdk/components/motor/client.hpp
+++ b/src/viam/sdk/components/motor/client.hpp
@@ -53,7 +53,8 @@ class MotorClient : public Motor {
     using Motor::stop;
 
    private:
-    std::unique_ptr<viam::component::motor::v1::MotorService::StubInterface> stub_;
+    using StubType = viam::component::motor::v1::MotorService::StubInterface;
+    std::unique_ptr<StubType> stub_;
     std::shared_ptr<grpc::Channel> channel_;
 };
 

--- a/src/viam/sdk/components/movement_sensor/client.cpp
+++ b/src/viam/sdk/components/movement_sensor/client.cpp
@@ -9,6 +9,7 @@
 #include <viam/api/common/v1/common.pb.h>
 #include <viam/api/component/movementsensor/v1/movementsensor.grpc.pb.h>
 
+#include <viam/sdk/common/client_helper.hpp>
 #include <viam/sdk/common/linear_algebra.hpp>
 #include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/components/movement_sensor/movement_sensor.hpp>
@@ -26,90 +27,71 @@ MovementSensorClient::MovementSensorClient(std::string name, std::shared_ptr<grp
 using namespace viam::component::movementsensor::v1;
 
 Vector3 MovementSensorClient::get_linear_velocity(const AttributeMap& extra) {
-    GetLinearVelocityResponse response;
-    stub_wrapper<GetLinearVelocityRequest>(
-        this, response, extra, &MovementSensorClient::Stub::GetLinearVelocity);
-    return Vector3::from_proto(response.linear_velocity());
+    return make_client_helper(this, *stub_, &MovementSensorClient::Stub::GetLinearVelocity)
+        .with(extra)
+        .invoke([](auto& response) { return Vector3::from_proto(response.linear_velocity()); });
 }
 
 Vector3 MovementSensorClient::get_angular_velocity(const AttributeMap& extra) {
-    GetAngularVelocityResponse response;
-    stub_wrapper<GetAngularVelocityRequest>(
-        this, response, extra, &MovementSensorClient::Stub::GetAngularVelocity);
-    return Vector3::from_proto(response.angular_velocity());
+    return make_client_helper(this, *stub_, &MovementSensorClient::Stub::GetAngularVelocity)
+        .with(extra)
+        .invoke([](auto& response) { return Vector3::from_proto(response.angular_velocity()); });
 }
 
 MovementSensor::compassheading MovementSensorClient::get_compass_heading(
     const AttributeMap& extra) {
-    GetCompassHeadingResponse response;
-    stub_wrapper<GetCompassHeadingRequest>(
-        this, response, extra, &MovementSensorClient::Stub::GetCompassHeading);
-    return from_proto(response);
+    return make_client_helper(this, *stub_, &MovementSensorClient::Stub::GetCompassHeading)
+        .with(extra)
+        .invoke([](auto& response) { return from_proto(response); });
 }
 
 MovementSensor::orientation MovementSensorClient::get_orientation(const AttributeMap& extra) {
-    GetOrientationResponse response;
-    stub_wrapper<GetOrientationRequest>(
-        this, response, extra, &MovementSensorClient::Stub::GetOrientation);
-    return from_proto(response.orientation());
+    return make_client_helper(this, *stub_, &MovementSensorClient::Stub::GetOrientation)
+        .with(extra)
+        .invoke([](auto& response) { return from_proto(response.orientation()); });
 }
 
 MovementSensor::position MovementSensorClient::get_position(const AttributeMap& extra) {
-    GetPositionResponse response;
-    stub_wrapper<GetPositionRequest>(
-        this, response, extra, &MovementSensorClient::Stub::GetPosition);
-    return from_proto(response);
+    return make_client_helper(this, *stub_, &MovementSensorClient::Stub::GetPosition)
+        .with(extra)
+        .invoke([](auto& response) { return from_proto(response); });
 }
 
 MovementSensor::properties MovementSensorClient::get_properties(const AttributeMap& extra) {
-    GetPropertiesResponse response;
-    stub_wrapper<GetPropertiesRequest>(
-        this, response, extra, &MovementSensorClient::Stub::GetProperties);
-    return from_proto(response);
+    return make_client_helper(this, *stub_, &MovementSensorClient::Stub::GetProperties)
+        .with(extra)
+        .invoke([](auto& response) { return from_proto(response); });
 }
 
 std::unordered_map<std::string, float> MovementSensorClient::get_accuracy(
     const AttributeMap& extra) {
-    GetAccuracyResponse response;
-    stub_wrapper<GetAccuracyRequest>(
-        this, response, extra, &MovementSensorClient::Stub::GetAccuracy);
-    std::unordered_map<std::string, float> result;
-
-    for (const auto& i : response.accuracy()) {
-        result.emplace(i.first, i.second);
-    }
-    return result;
+    return make_client_helper(this, *stub_, &MovementSensorClient::Stub::GetAccuracy)
+        .with(extra)
+        .invoke([](auto& response) {
+            std::unordered_map<std::string, float> result;
+            for (const auto& i : response.accuracy()) {
+                result.emplace(i.first, i.second);
+            }
+            return result;
+        });
 }
 
 Vector3 MovementSensorClient::get_linear_acceleration(const AttributeMap& extra) {
-    GetLinearAccelerationResponse response;
-    stub_wrapper<GetLinearAccelerationRequest>(
-        this, response, extra, &MovementSensorClient::Stub::GetLinearAcceleration);
-    return Vector3::from_proto(response.linear_acceleration());
+    return make_client_helper(this, *stub_, &MovementSensorClient::Stub::GetLinearAcceleration)
+        .with(extra)
+        .invoke([](auto& response) { return Vector3::from_proto(response.linear_acceleration()); });
 }
 
 AttributeMap MovementSensorClient::do_command(const AttributeMap& command) {
-    viam::common::v1::DoCommandRequest request;
-    viam::common::v1::DoCommandResponse response;
-
-    grpc::ClientContext ctx;
-
-    const google::protobuf::Struct proto_command = map_to_struct(command);
-    *request.mutable_command() = proto_command;
-    *request.mutable_name() = this->name();
-
-    const auto status = stub_->DoCommand(&ctx, request, &response);
-    if (!status.ok()) {
-        throw std::runtime_error(status.error_message());
-    }
-    return struct_to_map(response.result());
+    return make_client_helper(this, *stub_, &MovementSensorClient::Stub::DoCommand)
+        .with([&](auto& request) { *request.mutable_command() = map_to_struct(command); })
+        .invoke([](auto& response) { return struct_to_map(response.result()); });
 }
 
 std::vector<GeometryConfig> MovementSensorClient::get_geometries(const AttributeMap& extra) {
-    viam::common::v1::GetGeometriesResponse resp;
-    stub_wrapper<viam::common::v1::GetGeometriesRequest>(
-        this, resp, extra, &MovementSensorClient::Stub::GetGeometries);
-    return GeometryConfig::from_proto(resp);
+    return make_client_helper(this, *stub_, &MovementSensorClient::Stub::GetGeometries)
+        .with(extra)
+        .invoke([](auto& response) { return GeometryConfig::from_proto(response); });
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/components/movement_sensor/client.hpp
+++ b/src/viam/sdk/components/movement_sensor/client.hpp
@@ -46,23 +46,6 @@ class MovementSensorClient : public MovementSensor {
     typedef viam::component::movementsensor::v1::MovementSensorService::StubInterface Stub;
 
    private:
-    // template to wrap a stub
-    template <typename Request, typename Response, typename Cls>
-    void stub_wrapper(Cls* self,
-                      Response& resp,
-                      const AttributeMap& extra,
-                      ::grpc::Status (Cls::Stub::*method)(::grpc::ClientContext*,
-                                                          const Request&,
-                                                          Response*)) {
-        Request request;
-        grpc::ClientContext ctx;
-        *request.mutable_name() = self->name();
-        *request.mutable_extra() = map_to_struct(extra);
-        const auto status = (*(self->stub_).*method)(&ctx, request, &resp);
-        if (!status.ok()) {
-            throw std::runtime_error(status.error_message());
-        }
-    }
     std::unique_ptr<Stub> stub_;
     std::shared_ptr<grpc::Channel> channel_;
 };

--- a/src/viam/sdk/components/power_sensor/client.cpp
+++ b/src/viam/sdk/components/power_sensor/client.cpp
@@ -57,7 +57,7 @@ AttributeMap PowerSensorClient::get_readings(const AttributeMap& extra) {
 }
 
 AttributeMap PowerSensorClient::do_command(const AttributeMap& command) {
-    return make_client_helper(this, *stub_, &PowerSensorClient::DoCommand)
+    return make_client_helper(this, *stub_, &PowerSensorClient::Stub::DoCommand)
         .with([&](auto& request) { *request.mutable_command() = map_to_struct(command); })
         .invoke([](auto& response) { return struct_to_map(response.result()); });
 }

--- a/src/viam/sdk/components/power_sensor/client.cpp
+++ b/src/viam/sdk/components/power_sensor/client.cpp
@@ -9,6 +9,7 @@
 #include <viam/api/common/v1/common.pb.h>
 #include <viam/api/component/powersensor/v1/powersensor.grpc.pb.h>
 
+#include <viam/sdk/common/client_helper.hpp>
 #include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/components/power_sensor/power_sensor.hpp>
 #include <viam/sdk/config/resource.hpp>
@@ -25,51 +26,40 @@ PowerSensorClient::PowerSensorClient(std::string name, std::shared_ptr<grpc::Cha
       channel_(std::move(channel)){};
 
 PowerSensor::voltage PowerSensorClient::get_voltage(const AttributeMap& extra) {
-    GetVoltageResponse resp;
-    stub_wrapper<GetVoltageRequest>(this, resp, extra, &PowerSensorClient::Stub::GetVoltage);
-    return from_proto(resp);
+    return make_client_helper(this, *stub_, &PowerSensorClient::Stub::GetVoltage)
+        .with(extra)
+        .invoke([](auto& response) { return from_proto(response); });
 }
 
 PowerSensor::current PowerSensorClient::get_current(const AttributeMap& extra) {
-    GetCurrentResponse resp;
-    stub_wrapper<GetCurrentRequest>(this, resp, extra, &PowerSensorClient::Stub::GetCurrent);
-    return from_proto(resp);
+    return make_client_helper(this, *stub_, &PowerSensorClient::Stub::GetCurrent)
+        .with(extra)
+        .invoke([](auto& response) { return from_proto(response); });
 }
 
 double PowerSensorClient::get_power(const AttributeMap& extra) {
-    GetPowerResponse resp;
-    stub_wrapper<GetPowerRequest>(this, resp, extra, &PowerSensorClient::Stub::GetPower);
-    return resp.watts();
+    return make_client_helper(this, *stub_, &PowerSensorClient::Stub::GetPower)
+        .with(extra)
+        .invoke([](auto& response) { return response.watts(); });
 }
 
 AttributeMap PowerSensorClient::get_readings(const AttributeMap& extra) {
-    viam::common::v1::GetReadingsResponse response;
-    stub_wrapper<viam::common::v1::GetReadingsRequest>(
-        this, response, {}, &PowerSensorClient::Stub::GetReadings);
-
-    AttributeMap result =
-        std::make_shared<std::unordered_map<std::string, std::shared_ptr<ProtoType>>>();
-    for (const auto& r : response.readings()) {
-        result->emplace(r.first, std::make_shared<ProtoType>(r.second));
-    }
-    return result;
+    return make_client_helper(this, *stub_, &PowerSensorClient::Stub::GetReadings)
+        .with(extra)
+        .invoke([](auto& response) {
+            AttributeMap result =
+                std::make_shared<std::unordered_map<std::string, std::shared_ptr<ProtoType>>>();
+            for (const auto& r : response.readings()) {
+                result->emplace(r.first, std::make_shared<ProtoType>(r.second));
+            }
+            return result;
+        });
 }
 
 AttributeMap PowerSensorClient::do_command(const AttributeMap& command) {
-    viam::common::v1::DoCommandRequest request;
-    viam::common::v1::DoCommandResponse response;
-
-    grpc::ClientContext ctx;
-
-    const google::protobuf::Struct proto_command = map_to_struct(command);
-    *request.mutable_command() = proto_command;
-    *request.mutable_name() = this->name();
-
-    const auto status = stub_->DoCommand(&ctx, request, &response);
-    if (!status.ok()) {
-        throw std::runtime_error(status.error_message());
-    }
-    return struct_to_map(response.result());
+    return make_client_helper(this, *stub_, &PowerSensorClient::DoCommand)
+        .with([&](auto& request) { *request.mutable_command() = map_to_struct(command); })
+        .invoke([](auto& response) { return struct_to_map(response.result()); });
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/components/power_sensor/client.hpp
+++ b/src/viam/sdk/components/power_sensor/client.hpp
@@ -35,23 +35,6 @@ class PowerSensorClient : public PowerSensor {
     typedef viam::component::powersensor::v1::PowerSensorService::StubInterface Stub;
 
    private:
-    // template to wrap a stub
-    template <typename Request, typename Response, typename Cls>
-    void stub_wrapper(Cls* self,
-                      Response& resp,
-                      const AttributeMap& extra,
-                      ::grpc::Status (Cls::Stub::*method)(::grpc::ClientContext*,
-                                                          const Request&,
-                                                          Response*)) {
-        Request request;
-        grpc::ClientContext ctx;
-        *request.mutable_name() = self->name();
-        *request.mutable_extra() = map_to_struct(extra);
-        const auto status = (*(self->stub_).*method)(&ctx, request, &resp);
-        if (!status.ok()) {
-            throw std::runtime_error(status.error_message());
-        }
-    }
     std::unique_ptr<Stub> stub_;
     std::shared_ptr<grpc::Channel> channel_;
 };

--- a/src/viam/sdk/components/sensor/client.cpp
+++ b/src/viam/sdk/components/sensor/client.cpp
@@ -9,6 +9,7 @@
 #include <viam/api/common/v1/common.pb.h>
 #include <viam/api/component/sensor/v1/sensor.grpc.pb.h>
 
+#include <viam/sdk/common/client_helper.hpp>
 #include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/components/sensor/sensor.hpp>
 #include <viam/sdk/config/resource.hpp>
@@ -24,38 +25,28 @@ SensorClient::SensorClient(std::string name, std::shared_ptr<grpc::Channel> chan
 using namespace viam::common::v1;
 
 AttributeMap SensorClient::get_readings(const AttributeMap& extra) {
-    GetReadingsResponse response;
-    stub_wrapper<GetReadingsRequest>(this, response, {}, &SensorClient::Stub::GetReadings);
-
-    AttributeMap result =
-        std::make_shared<std::unordered_map<std::string, std::shared_ptr<ProtoType>>>();
-    for (const auto& r : response.readings()) {
-        result->emplace(std::move(r.first), std::make_shared<ProtoType>(r.second));
-    }
-    return result;
+    return make_client_helper(this, *stub_, &SensorClient::Stub::GetReadings)
+        .with(extra)
+        .invoke([](auto& response) {
+            AttributeMap result =
+                std::make_shared<std::unordered_map<std::string, std::shared_ptr<ProtoType>>>();
+            for (const auto& r : response.readings()) {
+                result->emplace(std::move(r.first), std::make_shared<ProtoType>(r.second));
+            }
+            return result;
+        });
 }
 
 AttributeMap SensorClient::do_command(const AttributeMap& command) {
-    DoCommandRequest request;
-    DoCommandResponse response;
-
-    grpc::ClientContext ctx;
-
-    const google::protobuf::Struct proto_command = map_to_struct(command);
-    *request.mutable_command() = proto_command;
-    *request.mutable_name() = this->name();
-
-    const auto status = stub_->DoCommand(&ctx, request, &response);
-    if (!status.ok()) {
-        throw std::runtime_error(status.error_message());
-    }
-    return struct_to_map(response.result());
+    return make_client_helper(this, *stub_, &SensorClient::Stub::DoCommand)
+        .with([&](auto& request) { *request.mutable_command() = map_to_struct(command); })
+        .invoke([](auto& response) { return struct_to_map(response.result()); });
 }
 
 std::vector<GeometryConfig> SensorClient::get_geometries(const AttributeMap& extra) {
-    GetGeometriesResponse resp;
-    stub_wrapper<GetGeometriesRequest>(this, resp, extra, &SensorClient::Stub::GetGeometries);
-    return GeometryConfig::from_proto(resp);
+    return make_client_helper(this, *stub_, &SensorClient::Stub::GetGeometries)
+        .with(extra)
+        .invoke([](auto& response) { return GeometryConfig::from_proto(response); });
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/components/sensor/client.hpp
+++ b/src/viam/sdk/components/sensor/client.hpp
@@ -30,23 +30,6 @@ class SensorClient : public Sensor {
     typedef viam::component::sensor::v1::SensorService::StubInterface Stub;
 
    private:
-    // template to wrap a stub
-    template <typename Request, typename Response, typename Cls>
-    void stub_wrapper(Cls* self,
-                      Response& resp,
-                      const AttributeMap& extra,
-                      ::grpc::Status (Cls::Stub::*method)(::grpc::ClientContext*,
-                                                          const Request&,
-                                                          Response*)) {
-        Request request;
-        grpc::ClientContext ctx;
-        *request.mutable_name() = self->name();
-        *request.mutable_extra() = map_to_struct(extra);
-        const auto status = (*(self->stub_).*method)(&ctx, request, &resp);
-        if (!status.ok()) {
-            throw std::runtime_error(status.error_message());
-        }
-    }
     std::unique_ptr<Stub> stub_;
     std::shared_ptr<grpc::Channel> channel_;
 };


### PR DESCRIPTION
Sorry this took a little longer than expected, I ended up trying several different designs before settling on this one. This is the client side analogue of #178.

@stuqdog and @benjirewis - For main review
CC @zaporter-work and @abe-winter for interest.

Thanks to @abe-winter for starting with `stub_wrapper` which pointed to deriving most of the needed info from the pointer-to-member on the stub type.