### PR TITLE
RSDK-5233 - implement missing methods

### DIFF
--- a/src/viam/sdk/common/utils.cpp
+++ b/src/viam/sdk/common/utils.cpp
@@ -58,16 +58,14 @@ std::string bytes_to_string(const std::vector<unsigned char>& b) {
     return img_string;
 };
 
-std::chrono::time_point<long long, std::chrono::nanoseconds> timestamp_to_time_pt(
-    const google::protobuf::Timestamp& timestamp) {
+time_pt timestamp_to_time_pt(const google::protobuf::Timestamp& timestamp) {
     const std::chrono::seconds seconds(timestamp.seconds());
     const std::chrono::nanoseconds nanos(timestamp.nanos());
-    return std::chrono::time_point<long long, std::chrono::nanoseconds>(
-        std::chrono::duration_cast<std::chrono::system_clock::duration>(seconds) + nanos);
+    return time_pt(std::chrono::duration_cast<std::chrono::system_clock::duration>(seconds) +
+                   nanos);
 }
 
-google::protobuf::Timestamp time_pt_to_timestamp(
-    const std::chrono::time_point<long long, std::chrono::nanoseconds>& time_pt) {
+google::protobuf::Timestamp time_pt_to_timestamp(const time_pt& time_pt) {
     const std::chrono::seconds duration_s =
         std::chrono::duration_cast<std::chrono::seconds>(time_pt.time_since_epoch());
     const std::chrono::nanoseconds duration_ns = time_pt.time_since_epoch() - duration_s;

--- a/src/viam/sdk/common/utils.hpp
+++ b/src/viam/sdk/common/utils.hpp
@@ -23,6 +23,8 @@ const std::string kService = "service";
 const std::string kRDK = "rdk";
 const std::string kBuiltin = "builtin";
 
+using time_pt = std::chrono::time_point<long long, std::chrono::nanoseconds>;
+
 std::vector<viam::common::v1::ResourceName> resource_names_for_resource(
     const std::shared_ptr<Resource>& resource);
 
@@ -43,7 +45,7 @@ class ResourceNameEqual {
 };
 
 struct response_metadata {
-    std::chrono::time_point<long long, std::chrono::nanoseconds> captured_at;
+    time_pt captured_at;
 
     static response_metadata from_proto(const viam::common::v1::ResponseMetadata& proto);
     static viam::common::v1::ResponseMetadata to_proto(const response_metadata& metadata);
@@ -51,15 +53,11 @@ struct response_metadata {
 
 bool operator==(const response_metadata& lhs, const response_metadata& rhs);
 
-/// @brief convert a google::protobuf::Timestamp to std::chrono::time_point<long long,
-/// std::chrono::nanoseconds>.
-std::chrono::time_point<long long, std::chrono::nanoseconds> timestamp_to_time_pt(
-    const google::protobuf::Timestamp& timestamp);
+/// @brief convert a google::protobuf::Timestamp to time_pt
+time_pt timestamp_to_time_pt(const google::protobuf::Timestamp& timestamp);
 
-/// @brief convert a std::chrono::time_point<long long, std::chrono::nanoseconds> to a
-/// google::protobuf::Timestamp.
-google::protobuf::Timestamp time_pt_to_timestamp(
-    const std::chrono::time_point<long long, std::chrono::nanoseconds>& time_pt);
+/// @brief convert a time_pt to a google::protobuf::Timestamp.
+google::protobuf::Timestamp time_pt_to_timestamp(const time_pt& time_pt);
 
 std::vector<unsigned char> string_to_bytes(std::string const& s);
 std::string bytes_to_string(std::vector<unsigned char> const& b);

--- a/src/viam/sdk/components/board/board.hpp
+++ b/src/viam/sdk/components/board/board.hpp
@@ -213,8 +213,21 @@ class Board : public Component {
     virtual analog_value read_analog(const std::string& analog_reader_name,
                                      const AttributeMap& extra) = 0;
 
-    /// @brief Returns the current value of the interrupt which is based on the type of interrupt.
-    /// Consult Viam's `Board` docs for more information.
+    /// @brief Writes the value to the analog writer of the board.
+    /// @param pin the pin to write to
+    /// @param value the value to set the pin to
+    inline void write_analog(const std::string& pin, int value) {
+        return write_analog(pin, value, {});
+    }
+
+    /// @brief Writes the value to the analog writer of the board.
+    /// @param pin the pin to write to
+    /// @param value the value to set the pin to
+    /// @param extra any additional arguments to the method
+    virtual void write_analog(const std::string& pin, int value, const AttributeMap& extra) = 0;
+
+    /// @brief Returns the current value of the interrupt which is based on the type of
+    /// interrupt. Consult Viam's `Board` docs for more information.
     /// @param digital_interrupt_name digital interrupt to check
     inline digital_value read_digital_interrupt(const std::string& digital_interrupt_name) {
         return read_digital_interrupt(digital_interrupt_name, {});

--- a/src/viam/sdk/components/board/client.cpp
+++ b/src/viam/sdk/components/board/client.cpp
@@ -1,3 +1,4 @@
+#include "component/board/v1/board.pb.h"
 #include <viam/sdk/components/board/client.hpp>
 
 #include <algorithm>
@@ -185,6 +186,24 @@ Board::analog_value BoardClient::read_analog(const std::string& analog_reader_na
         throw std::runtime_error(status.error_message());
     }
     return response.value();
+}
+
+void BoardClient::write_analog(const std::string& pin, int value, const AttributeMap& extra) {
+    component::board::v1::WriteAnalogRequest request;
+    component::board::v1::WriteAnalogResponse response;
+
+    grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
+
+    request.set_name(this->name());
+    request.set_pin(std::move(pin));
+    request.set_value(value);
+    *request.mutable_extra() = map_to_struct(extra);
+
+    const grpc::Status status = stub_->WriteAnalog(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
 }
 
 Board::digital_value BoardClient::read_digital_interrupt(const std::string& digital_interrupt_name,

--- a/src/viam/sdk/components/board/client.cpp
+++ b/src/viam/sdk/components/board/client.cpp
@@ -1,4 +1,3 @@
-#include "component/board/v1/board.pb.h"
 #include <viam/sdk/components/board/client.hpp>
 
 #include <algorithm>

--- a/src/viam/sdk/components/board/client.hpp
+++ b/src/viam/sdk/components/board/client.hpp
@@ -35,11 +35,12 @@ class BoardClient : public Board {
                            const AttributeMap& extra) override;
     analog_value read_analog(const std::string& analog_reader_name,
                              const AttributeMap& extra) override;
+    void write_analog(const std::string& pin, int value, const AttributeMap& extra) override;
     digital_value read_digital_interrupt(const std::string& digital_interrupt_name,
                                          const AttributeMap& extra) override;
     void set_power_mode(power_mode power_mode,
                         const AttributeMap& extra,
-                        const boost::optional<std::chrono::microseconds>& duration) override;
+                        const boost::optional<std::chrono::microseconds>& duration = {}) override;
     std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) override;
 
     // the `extra` param is frequently unnecessary but needs to be supported. Ideally, we'd
@@ -62,6 +63,7 @@ class BoardClient : public Board {
     using Board::set_power_mode;
     using Board::set_pwm_duty_cycle;
     using Board::set_pwm_frequency;
+    using Board::write_analog;
 
    private:
     std::unique_ptr<viam::component::board::v1::BoardService::StubInterface> stub_;

--- a/src/viam/sdk/components/board/server.cpp
+++ b/src/viam/sdk/components/board/server.cpp
@@ -1,4 +1,3 @@
-#include "component/board/v1/board.pb.h"
 #include <viam/sdk/components/board/server.hpp>
 
 #include <viam/sdk/common/utils.hpp>

--- a/src/viam/sdk/components/board/server.hpp
+++ b/src/viam/sdk/components/board/server.hpp
@@ -3,6 +3,7 @@
 /// @brief Implements a gRPC server for the `Board` component.
 #pragma once
 
+#include "component/board/v1/board.pb.h"
 #include <viam/api/common/v1/common.pb.h>
 #include <viam/api/component/board/v1/board.grpc.pb.h>
 
@@ -59,6 +60,10 @@ class BoardServer : public ResourceServer,
         ::grpc::ServerContext* context,
         const ::viam::component::board::v1::ReadAnalogReaderRequest* request,
         ::viam::component::board::v1::ReadAnalogReaderResponse* response) override;
+
+    ::grpc::Status WriteAnalog(::grpc::ServerContext* context,
+                               const component::board::v1::WriteAnalogRequest* request,
+                               component::board::v1::WriteAnalogResponse* response) override;
 
     ::grpc::Status GetDigitalInterruptValue(
         ::grpc::ServerContext* context,

--- a/src/viam/sdk/components/board/server.hpp
+++ b/src/viam/sdk/components/board/server.hpp
@@ -3,7 +3,6 @@
 /// @brief Implements a gRPC server for the `Board` component.
 #pragma once
 
-#include "component/board/v1/board.pb.h"
 #include <viam/api/common/v1/common.pb.h>
 #include <viam/api/component/board/v1/board.grpc.pb.h>
 

--- a/src/viam/sdk/components/encoder/client.hpp
+++ b/src/viam/sdk/components/encoder/client.hpp
@@ -21,7 +21,8 @@ namespace sdk {
 class EncoderClient : public Encoder {
    public:
     EncoderClient(std::string name, std::shared_ptr<grpc::Channel> channel);
-    position get_position(const AttributeMap& extra, position_type position_type) override;
+    position get_position(const AttributeMap& extra,
+                          position_type position_type = position_type::unspecified) override;
     void reset_position(const AttributeMap& extra) override;
     properties get_properties(const AttributeMap& extra) override;
     std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) override;

--- a/src/viam/sdk/resource/resource_api.cpp
+++ b/src/viam/sdk/resource/resource_api.cpp
@@ -97,7 +97,7 @@ const std::string& Name::remote_name() const {
 }
 
 std::string Name::to_string() const {
-    if (remote_name_.empty()) {
+    if (remote_name_.empty() || remote_name_ == ":") {
         return api_.to_string() + "/" + name_;
     }
     return api_.to_string() + "/" + remote_name_ + ":" + name_;

--- a/src/viam/sdk/services/motion/client.cpp
+++ b/src/viam/sdk/services/motion/client.cpp
@@ -135,6 +135,71 @@ pose_in_frame MotionClient::get_pose(
     return pose_in_frame::from_proto(response.pose());
 }
 
+void MotionClient::stop_plan(const Name& name, const AttributeMap& extra) {
+    service::motion::v1::StopPlanRequest request;
+    service::motion::v1::StopPlanResponse response;
+    grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
+
+    *request.mutable_name() = this->name();
+    *request.mutable_extra() = map_to_struct(std::move(extra));
+
+    const grpc::Status status = stub_->StopPlan(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
+}
+
+std::pair<Motion::plan_with_status, std::vector<Motion::plan_with_status>> MotionClient::get_plan(
+    const Name& name,
+    const AttributeMap& extra,
+    bool last_plan_only,
+    boost::optional<std::string> execution_id) {
+    service::motion::v1::GetPlanRequest request;
+    service::motion::v1::GetPlanResponse response;
+    grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
+
+    *request.mutable_name() = this->name();
+    *request.mutable_extra() = map_to_struct(std::move(extra));
+    request.set_last_plan_only(last_plan_only);
+    if (execution_id) {
+        *request.mutable_execution_id() = *execution_id;
+    }
+
+    const grpc::Status status = stub_->GetPlan(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
+
+    return {Motion::plan_with_status::from_proto(response.current_plan_with_status()),
+            Motion::plan_with_status::from_proto(response.replan_history())};
+}
+
+std::vector<Motion::plan_status_with_id> MotionClient::list_plan_statuses(const AttributeMap& extra,
+                                                                          bool only_active_plans) {
+    service::motion::v1::ListPlanStatusesRequest request;
+    service::motion::v1::ListPlanStatusesResponse response;
+    grpc::ClientContext ctx;
+    set_client_ctx_authority(ctx);
+
+    *request.mutable_name() = this->name();
+    *request.mutable_extra() = map_to_struct(std::move(extra));
+    request.set_only_active_plans(only_active_plans);
+
+    const grpc::Status status = stub_->ListPlanStatuses(&ctx, request, &response);
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
+
+    std::vector<Motion::plan_status_with_id> statuses;
+    for (const auto& proto : response.plan_statuses_with_ids()) {
+        statuses.push_back(Motion::plan_status_with_id::from_proto(proto));
+    }
+
+    return statuses;
+}
+
 AttributeMap MotionClient::do_command(const AttributeMap& command) {
     viam::common::v1::DoCommandRequest request;
     viam::common::v1::DoCommandResponse response;

--- a/src/viam/sdk/services/motion/client.hpp
+++ b/src/viam/sdk/services/motion/client.hpp
@@ -40,6 +40,17 @@ class MotionClient : public Motion {
                            const std::vector<WorldState::transform>& supplemental_transforms,
                            const AttributeMap& extra) override;
 
+    void stop_plan(const Name& component_name, const AttributeMap& extra) override;
+
+    std::pair<Motion::plan_with_status, std::vector<Motion::plan_with_status>> get_plan(
+        const Name& component_name,
+        const AttributeMap& extra,
+        bool last_plan_only = false,
+        boost::optional<std::string> execution_id = {}) override;
+
+    std::vector<Motion::plan_status_with_id> list_plan_statuses(
+        const AttributeMap& extra, bool only_active_plans = false) override;
+
     AttributeMap do_command(const AttributeMap& command) override;
 
     // the `extra` param is frequently unnecessary but needs to be supported. Ideally, we'd
@@ -51,10 +62,13 @@ class MotionClient : public Motion {
     // that calls the virtual method and passes a `nullptr` by default in place of the `extra`
     // param. In order to access these versions of the methods within the client code, however,
     // we need to include these `using` lines.
+    using Motion::get_plan;
     using Motion::get_pose;
+    using Motion::list_plan_statuses;
     using Motion::move;
     using Motion::move_on_globe;
     using Motion::move_on_map;
+    using Motion::stop_plan;
 
    private:
     std::unique_ptr<service::motion::v1::MotionService::StubInterface> stub_;

--- a/src/viam/sdk/services/motion/motion.cpp
+++ b/src/viam/sdk/services/motion/motion.cpp
@@ -133,6 +133,29 @@ bool operator==(const obstacle_detector& lhs, const obstacle_detector& rhs) {
     return lhs.vision_service == rhs.vision_service && lhs.camera == rhs.camera;
 }
 
+bool operator==(const Motion::steps& lhs, const Motion::steps& rhs) {
+    return lhs.steps == rhs.steps;
+}
+
+bool operator==(const Motion::plan_status& lhs, const Motion::plan_status& rhs) {
+    return lhs.reason == rhs.reason && lhs.state == rhs.state && lhs.timestamp == rhs.timestamp;
+}
+
+bool operator==(const Motion::plan_status_with_id& lhs, const Motion::plan_status_with_id& rhs) {
+    return lhs.execution_id == rhs.execution_id && lhs.component_name == rhs.component_name &&
+           lhs.status == rhs.status && lhs.plan_id == rhs.plan_id;
+}
+
+bool operator==(const Motion::plan& lhs, const Motion::plan& rhs) {
+    return lhs.component_name == rhs.component_name && lhs.execution_id == rhs.execution_id &&
+           lhs.steps == rhs.steps && lhs.id == rhs.id;
+}
+
+bool operator==(const Motion::plan_with_status& lhs, const Motion::plan_with_status& rhs) {
+    return lhs.plan == rhs.plan && lhs.status == rhs.status &&
+           lhs.status_history == rhs.status_history;
+}
+
 std::ostream& operator<<(std::ostream& os, const obstacle_detector& v) {
     os << "{ ";
     os << "\tvision_service: " << v.vision_service << std::endl;
@@ -238,6 +261,172 @@ std::ostream& operator<<(std::ostream& os, const motion_configuration& v) {
     os << "}";
 
     return os;
+}
+
+Motion::PlanState Motion::from_proto(const service::motion::v1::PlanState& proto) {
+    switch (proto) {
+        case service::motion::v1::PLAN_STATE_FAILED: {
+            return Motion::PlanState::failed;
+        }
+        case service::motion::v1::PLAN_STATE_SUCCEEDED: {
+            return Motion::PlanState::succeeded;
+        }
+        case service::motion::v1::PLAN_STATE_IN_PROGRESS: {
+            return Motion::PlanState::in_progress;
+        }
+        case service::motion::v1::PLAN_STATE_STOPPED: {
+            return Motion::PlanState::stopped;
+        }
+        default: {
+            throw std::runtime_error("Invalid proto PlanState to encode");
+        }
+    }
+}
+
+service::motion::v1::PlanState Motion::to_proto(const Motion::PlanState& state) {
+    switch (state) {
+        case Motion::PlanState::failed: {
+            return service::motion::v1::PLAN_STATE_FAILED;
+        }
+        case Motion::PlanState::succeeded: {
+            return service::motion::v1::PLAN_STATE_SUCCEEDED;
+        }
+        case Motion::PlanState::in_progress: {
+            return service::motion::v1::PLAN_STATE_IN_PROGRESS;
+        }
+        case Motion::PlanState::stopped: {
+            return service::motion::v1::PLAN_STATE_STOPPED;
+        }
+    }
+}
+
+Motion::plan_status Motion::plan_status::from_proto(const service::motion::v1::PlanStatus& proto) {
+    plan_status mps;
+    mps.state = Motion::from_proto(proto.state());
+    if (proto.has_reason()) {
+        mps.reason = proto.reason();
+    }
+    mps.timestamp = timestamp_to_time_pt(proto.timestamp());
+
+    return mps;
+}
+
+std::vector<Motion::plan_status> Motion::plan_status::from_proto(
+    const gp::RepeatedPtrField<service::motion::v1::PlanStatus>& proto) {
+    std::vector<Motion::plan_status> pss;
+    for (const auto& ps : proto) {
+        pss.push_back(Motion::plan_status::from_proto(ps));
+    }
+
+    return pss;
+}
+service::motion::v1::PlanStatus Motion::plan_status::to_proto() const {
+    service::motion::v1::PlanStatus proto;
+    *proto.mutable_timestamp() = time_pt_to_timestamp(timestamp);
+    if (reason) {
+        *proto.mutable_reason() = *reason;
+    }
+    proto.set_state(Motion::to_proto(state));
+
+    return proto;
+}
+
+Motion::steps Motion::steps::from_proto(
+    const gp::RepeatedPtrField<service::motion::v1::PlanStep>& proto) {
+    std::vector<step> steps;
+    for (const auto& ps : proto) {
+        step step;
+        for (const auto& component : ps.step()) {
+            step.emplace(component.first, pose::from_proto(component.second.pose()));
+        }
+        steps.push_back(step);
+    }
+
+    return {steps};
+}
+
+service::motion::v1::PlanStep Motion::steps::to_proto(const Motion::steps::step& step) {
+    service::motion::v1::PlanStep proto;
+    for (const auto& kv : step) {
+        service::motion::v1::ComponentState cs;
+        *cs.mutable_pose() = kv.second.to_proto();
+        proto.mutable_step()->insert({kv.first, cs});
+    }
+
+    return proto;
+}
+
+Motion::plan Motion::plan::from_proto(const service::motion::v1::Plan& proto) {
+    Motion::plan plan;
+    plan.id = proto.id();
+    plan.execution_id = proto.execution_id();
+    plan.component_name = Name::from_proto(proto.component_name());
+    plan.steps = Motion::steps::from_proto(proto.steps());
+    return plan;
+}
+
+service::motion::v1::Plan Motion::plan::to_proto() const {
+    service::motion::v1::Plan proto;
+    *proto.mutable_id() = id;
+    *proto.mutable_component_name() = component_name.to_proto();
+    *proto.mutable_execution_id() = execution_id;
+    for (const auto& step : steps.steps) {
+        *proto.mutable_steps()->Add() = Motion::steps::to_proto(step);
+    }
+
+    return proto;
+}
+
+Motion::plan_with_status Motion::plan_with_status::from_proto(
+    const service::motion::v1::PlanWithStatus& proto) {
+    Motion::plan_with_status pws;
+    pws.plan = Motion::plan::from_proto(proto.plan());
+    pws.status = Motion::plan_status::from_proto(proto.status());
+    pws.status_history = Motion::plan_status::from_proto(proto.status_history());
+
+    return pws;
+}
+
+std::vector<Motion::plan_with_status> Motion::plan_with_status::from_proto(
+    const gp::RepeatedPtrField<service::motion::v1::PlanWithStatus>& proto) {
+    std::vector<Motion::plan_with_status> plans;
+    for (const auto& plan : proto) {
+        plans.push_back(Motion::plan_with_status::from_proto(plan));
+    }
+    return plans;
+}
+
+service::motion::v1::PlanWithStatus Motion::plan_with_status::to_proto() const {
+    service::motion::v1::PlanWithStatus proto;
+    *proto.mutable_plan() = plan.to_proto();
+    *proto.mutable_status() = status.to_proto();
+    for (const auto& sh : status_history) {
+        *proto.mutable_status_history()->Add() = sh.to_proto();
+    }
+
+    return proto;
+}
+
+Motion::plan_status_with_id Motion::plan_status_with_id::from_proto(
+    const service::motion::v1::PlanStatusWithID& proto) {
+    Motion::plan_status_with_id pswi;
+    pswi.execution_id = proto.execution_id();
+    pswi.component_name = Name::from_proto(proto.component_name());
+    pswi.plan_id = proto.plan_id();
+    pswi.status = Motion::plan_status::from_proto(proto.status());
+
+    return pswi;
+}
+
+service::motion::v1::PlanStatusWithID Motion::plan_status_with_id::to_proto() const {
+    service::motion::v1::PlanStatusWithID proto;
+
+    *proto.mutable_execution_id() = execution_id;
+    *proto.mutable_component_name() = component_name.to_proto();
+    *proto.mutable_plan_id() = plan_id;
+    *proto.mutable_status() = status.to_proto();
+
+    return proto;
 }
 
 namespace {

--- a/src/viam/sdk/services/motion/motion.hpp
+++ b/src/viam/sdk/services/motion/motion.hpp
@@ -9,6 +9,7 @@
 
 #include <viam/sdk/common/pose.hpp>
 #include <viam/sdk/common/proto_type.hpp>
+#include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/common/world_state.hpp>
 #include <viam/sdk/registry/registry.hpp>
 #include <viam/sdk/resource/resource_api.hpp>
@@ -18,6 +19,8 @@
 namespace viam {
 namespace sdk {
 
+namespace gp = google::protobuf;
+
 /// @defgroup Motion Classes related to the Motion service.
 
 /// @class MotionRegistration
@@ -25,7 +28,7 @@ namespace sdk {
 /// @ingroup Motion
 class MotionRegistration : public ResourceRegistration {
    public:
-    explicit MotionRegistration(const google::protobuf::ServiceDescriptor* service_descriptor);
+    explicit MotionRegistration(const gp::ServiceDescriptor* service_descriptor);
     std::shared_ptr<ResourceServer> create_resource_server(
         std::shared_ptr<ResourceManager> manager) override;
     std::shared_ptr<Resource> create_rpc_client(std::string name,
@@ -87,6 +90,122 @@ struct motion_configuration {
 /// specific motion implementations. This class cannot be used on its own.
 class Motion : public Service {
    public:
+    /// @enum PlanState
+    /// @brief Describes the possible states a plan can be in.
+    /// @ingroup Motion
+    enum class PlanState : uint8_t {
+        in_progress = 0,
+        stopped = 1,
+        succeeded = 2,
+        failed = 3,
+    };
+
+    static PlanState from_proto(const service::motion::v1::PlanState& proto);
+    static service::motion::v1::PlanState to_proto(const PlanState& state);
+
+    /// @struct plan_status
+    /// @brief Describes the state of a given plan at a point in time.
+    /// @ingroup Motion
+    struct plan_status {
+        /// @brief The state of the plan execution
+        PlanState state;
+
+        /// @brief The time the executing plan transitioned to the state.
+        time_pt timestamp;
+
+        /// @brief The reason for the state change. The error message if the plan failed, or the
+        /// re-plan reason if re-planning was necessary.
+        boost::optional<std::string> reason;
+
+        static plan_status from_proto(const service::motion::v1::PlanStatus& proto);
+        static std::vector<plan_status> from_proto(
+            const gp::RepeatedPtrField<service::motion::v1::PlanStatus>& proto);
+        service::motion::v1::PlanStatus to_proto() const;
+        friend bool operator==(const plan_status& lhs, const plan_status& rhs);
+    };
+
+    /// @struct plan_status_with_id
+    /// @brief The motion plan status, plus plan ID, component name, and execution ID.
+    /// @ingroup Motion
+    struct plan_status_with_id {
+        /// @brief The unique ID of the plan
+        std::string plan_id;
+
+        /// @brief The component to be moved. Used for tracking and stopping.
+        Name component_name;
+
+        /// @brief The unique ID which identifies the plan execution.
+        std::string execution_id;
+
+        /// @brief The plan status.
+        plan_status status;
+
+        static plan_status_with_id from_proto(const service::motion::v1::PlanStatusWithID& proto);
+        service::motion::v1::PlanStatusWithID to_proto() const;
+        friend bool operator==(const plan_status_with_id& lhs, const plan_status_with_id& rhs);
+    };
+
+    /// @struct steps
+    /// @brief An ordered list of plan steps.
+    /// @ingroup Motion
+    struct steps {
+        /// @brief An individual "step", representing the state each component (keyed as a fully
+        /// qualified component name) should reach while executing that step of the plan.
+        typedef std::unordered_map<std::string, pose> step;
+
+        /// @brief The ordered list of steps.
+        std::vector<step> steps;
+
+        static struct steps from_proto(
+            const gp::RepeatedPtrField<service::motion::v1::PlanStep>& proto);
+
+        static service::motion::v1::PlanStep to_proto(const step& step);
+        friend bool operator==(const struct steps& lhs, const struct steps& rhs);
+    };
+
+    /// @struct plan
+    /// @brief Describes a motion plan.
+    /// @ingroup Motion
+    struct plan {
+        /// @brief The plan's unique ID.
+        std::string id;
+
+        /// @brief The component requested to be moved. Used for tracking and stopping.
+        Name component_name;
+
+        /// @brief The unique ID which identifies the execution.
+        /// Multiple plans can share the same execution_id if they were generated due to replanning.
+        std::string execution_id;
+
+        /// @brief An ordered list of plan steps.
+        steps steps;
+
+        static plan from_proto(const service::motion::v1::Plan& proto);
+        service::motion::v1::Plan to_proto() const;
+        friend bool operator==(const plan& lhs, const plan& rhs);
+    };
+
+    /// @struct plan_with_status
+    /// @brief Describes a plan, its current status, and all status changes that have occurred
+    /// previously on that plan.
+    /// @ingroup Motion
+    struct plan_with_status {
+        /// @brief The plan.
+        plan plan;
+
+        /// @brief The current status of the plan.
+        plan_status status;
+
+        /// @brief The prior status changes that have happened during plan execution.
+        std::vector<plan_status> status_history;
+
+        static plan_with_status from_proto(const service::motion::v1::PlanWithStatus& proto);
+        static std::vector<plan_with_status> from_proto(
+            const gp::RepeatedPtrField<service::motion::v1::PlanWithStatus>& proto);
+        service::motion::v1::PlanWithStatus to_proto() const;
+        friend bool operator==(const plan_with_status& lhs, const plan_with_status& rhs);
+    };
+
     /// @struct linear_constraint
     /// @brief Specifies that the component being moved should move linearly to its goal.
     struct linear_constraint {
@@ -246,6 +365,61 @@ class Motion : public Service {
         const std::string& destination_frame,
         const std::vector<WorldState::transform>& supplemental_transforms,
         const AttributeMap& extra) = 0;
+
+    /// @brief Stop a currently executing motion plan.
+    /// @param component_name the component of the currently executing plan to stop.
+    inline void stop_plan(const Name& component_name) {
+        return stop_plan(component_name, {});
+    }
+
+    /// @brief Stop a currently executing motion plan.
+    /// @param component_name the component of the currently executing plan to stop.
+    /// @param extra Any additional arguments to the method.
+    virtual void stop_plan(const Name& component_name, const AttributeMap& extra) = 0;
+
+    /// @brief Returns the plan and state history of the most recent execution to move a component.
+    /// Returns a result if the last execution is still executing, or changed state within the last
+    /// 24 hours without an intervening robot reinitialization.
+    /// @param component_name The name of the component which the MoveOnGlobe request asked to move.
+    /// @param last_plan_only If true, causes only the last plan for the component/execution to be
+    /// returned. Defaults to false.
+    /// @param execution_id Optional execution id of a previous plan, if you want to know about it.
+    inline std::pair<plan_with_status, std::vector<plan_with_status>> get_plan(
+        Name component_name, bool last_plan_only, boost::optional<std::string> execution_id) {
+        return get_plan(component_name, {}, last_plan_only = false, execution_id = {});
+    }
+
+    /// @brief Returns the plan and state history of the most recent execution to move a component.
+    /// Returns a result if the last execution is still executing, or changed state within the last
+    /// 24 hours without an intervening robot reinitialization.
+    /// @param component_name The name of the component which the MoveOnGlobe request asked to move.
+    /// @param last_plan_only If true, causes only the last plan for the component/execution to be
+    /// returned.
+    /// @param execution_id Optional execution id of a previous plan, if you want to know about it.
+    /// @param extra Any additional arguments to the method.
+    virtual std::pair<plan_with_status, std::vector<plan_with_status>> get_plan(
+        const Name& component_name,
+        const AttributeMap& extra,
+        bool last_plan_only = false,
+        boost::optional<std::string> execution_id = {}) = 0;
+
+    /// @brief Returns the status of plans created by MoveOnGlobe requests.
+    /// Includes statuses of plans that are executing, or are part of an executing that changed
+    /// its state within the last 24 hours.
+    /// @param only_active_plans If true, filters returned plans to only those currently active.
+    /// Defaults to false.
+    inline std::vector<plan_status_with_id> list_plan_statuses(bool only_active_plans = false) {
+        return list_plan_statuses({}, only_active_plans);
+    }
+
+    /// @brief Returns the status of plans created by MoveOnGlobe requests.
+    /// Includes statuses of plans that are executing, or are part of an executing that changed
+    /// its state within the last 24 hours.
+    /// @param only_active_plans If true, filters returned plans to only those currently active.
+    /// Defaults to false.
+    /// @param extra Any additional arguments to the method.
+    virtual std::vector<plan_status_with_id> list_plan_statuses(const AttributeMap& extra,
+                                                                bool only_active_plans = false) = 0;
 
     /// @brief Send/receive arbitrary commands to the resource.
     /// @param Command the command to execute.

--- a/src/viam/sdk/services/motion/server.hpp
+++ b/src/viam/sdk/services/motion/server.hpp
@@ -35,6 +35,16 @@ class MotionServer : public ResourceServer,
     ::grpc::Status GetPose(::grpc::ServerContext* context,
                            const ::viam::service::motion::v1::GetPoseRequest* request,
                            ::viam::service::motion::v1::GetPoseResponse* response) override;
+    ::grpc::Status GetPlan(::grpc::ServerContext* context,
+                           const ::viam::service::motion::v1::GetPlanRequest* request,
+                           ::viam::service::motion::v1::GetPlanResponse* response) override;
+    ::grpc::Status ListPlanStatuses(
+        ::grpc::ServerContext* context,
+        const ::viam::service::motion::v1::ListPlanStatusesRequest* request,
+        ::viam::service::motion::v1::ListPlanStatusesResponse* response) override;
+    ::grpc::Status StopPlan(::grpc::ServerContext* context,
+                            const ::viam::service::motion::v1::StopPlanRequest* request,
+                            ::viam::service::motion::v1::StopPlanResponse* response) override;
     ::grpc::Status DoCommand(::grpc::ServerContext* context,
                              const ::viam::common::v1::DoCommandRequest* request,
                              ::viam::common::v1::DoCommandResponse* response) override;

--- a/src/viam/sdk/tests/mocks/camera_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.cpp
@@ -61,8 +61,8 @@ Camera::image_collection fake_raw_images() {
     std::chrono::seconds seconds(12345);
     std::chrono::nanoseconds nanos(0);
     collection.images = images;
-    collection.metadata.captured_at = std::chrono::time_point<long long, std::chrono::nanoseconds>(
-        std::chrono::duration_cast<std::chrono::system_clock::duration>(seconds) + nanos);
+    collection.metadata.captured_at =
+        time_pt(std::chrono::duration_cast<std::chrono::system_clock::duration>(seconds) + nanos);
     return collection;
 }
 

--- a/src/viam/sdk/tests/mocks/mock_board.cpp
+++ b/src/viam/sdk/tests/mocks/mock_board.cpp
@@ -65,6 +65,11 @@ Board::analog_value MockBoard::read_analog(const std::string& analog_reader_name
     return this->peek_read_analog_ret;
 }
 
+void MockBoard::write_analog(const std::string& pin, int value, const AttributeMap& extra) {
+    this->peek_pin = pin;
+    this->peek_pin_value = value;
+}
+
 Board::digital_value MockBoard::read_digital_interrupt(const std::string& digital_interrupt_name,
                                                        const AttributeMap& extra) {
     this->peek_digital_interrupt_name = digital_interrupt_name;

--- a/src/viam/sdk/tests/mocks/mock_board.hpp
+++ b/src/viam/sdk/tests/mocks/mock_board.hpp
@@ -30,6 +30,7 @@ class MockBoard : public viam::sdk::Board {
     viam::sdk::AttributeMap do_command(const viam::sdk::AttributeMap& command) override;
     Board::analog_value read_analog(const std::string& analog_reader_name,
                                     const sdk::AttributeMap& extra) override;
+    void write_analog(const std::string& pin, int value, const sdk::AttributeMap& extra) override;
     Board::digital_value read_digital_interrupt(const std::string& digital_interrupt_name,
                                                 const sdk::AttributeMap& extra) override;
     void set_power_mode(power_mode power_mode,
@@ -38,6 +39,7 @@ class MockBoard : public viam::sdk::Board {
     std::vector<sdk::GeometryConfig> get_geometries(const sdk::AttributeMap& extra) override;
 
     std::string peek_pin, peek_analog_reader_name, peek_digital_interrupt_name;
+    int peek_pin_value;
     Board::status peek_get_status_ret;
     bool peek_set_gpio_high;
     bool peek_get_gpio_ret;

--- a/src/viam/sdk/tests/mocks/mock_motion.cpp
+++ b/src/viam/sdk/tests/mocks/mock_motion.cpp
@@ -1,5 +1,8 @@
+#include "viam/sdk/services/motion/motion.hpp"
+#include <chrono>
 #include <viam/sdk/tests/mocks/mock_motion.hpp>
 
+#include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/spatialmath/geometry.hpp>
 #include <viam/sdk/spatialmath/orientation_types.hpp>
 #include <viam/sdk/tests/test_utils.hpp>
@@ -59,20 +62,53 @@ pose_in_frame MockMotion::get_pose(
     return current_location;
 }
 
-AttributeMap MockMotion::do_command(const AttributeMap& _command) {
-    return peek_map;
+std::pair<Motion::plan_with_status, std::vector<Motion::plan_with_status>> MockMotion::get_plan(
+    const sdk::Name& component_name,
+    const sdk::AttributeMap& extra,
+    bool last_plan_only,
+    boost::optional<std::string> execution_id) {
+    return {fake_plan_with_status(), {fake_plan_with_status()}};
+}
+
+std::vector<Motion::plan_status_with_id> MockMotion::list_plan_statuses(
+    const sdk::AttributeMap& extra, bool only_active_plans) {
+    return {fake_plan_status_with_id()};
+}
+
+void MockMotion::stop_plan(const sdk::Name& name, const sdk::AttributeMap& extra) {
+    this->peek_stop_plan_called = true;
+}
+
+AttributeMap MockMotion::do_command(const AttributeMap& command) {
+    return command;
 };
 
 std::shared_ptr<MockMotion> MockMotion::get_mock_motion() {
     auto motion = std::make_shared<MockMotion>("mock_motion");
     motion->current_location = init_fake_pose();
-    motion->peek_map = fake_map();
 
     return motion;
 };
 
+Motion::plan_with_status MockMotion::fake_plan_with_status() {
+    plan_with_status pws;
+    pws.plan = {"id", fake_component_name(), "exec-id", {}};
+    pws.status = fake_plan_status();
+    pws.status_history = {fake_plan_status()};
+
+    return pws;
+}
+
 pose_in_frame fake_pose() {
     return pose_in_frame("fake-reference-frame", {{0, 1, 2}, {3, 4, 5}, 6});
+}
+
+Motion::plan_status MockMotion::fake_plan_status() {
+    return {Motion::PlanState::succeeded, time_pt::max(), boost::optional<std::string>("reason")};
+}
+
+Motion::plan_status_with_id MockMotion::fake_plan_status_with_id() {
+    return {"plan_id", fake_component_name(), "execution_id", fake_plan_status()};
 }
 
 pose_in_frame init_fake_pose() {

--- a/src/viam/sdk/tests/mocks/mock_motion.cpp
+++ b/src/viam/sdk/tests/mocks/mock_motion.cpp
@@ -1,6 +1,6 @@
-#include "viam/sdk/services/motion/motion.hpp"
-#include <chrono>
 #include <viam/sdk/tests/mocks/mock_motion.hpp>
+
+#include <chrono>
 
 #include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/spatialmath/geometry.hpp>

--- a/src/viam/sdk/tests/mocks/mock_motion.hpp
+++ b/src/viam/sdk/tests/mocks/mock_motion.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "viam/sdk/common/proto_type.hpp"
 #include <viam/sdk/common/pose.hpp>
+#include <viam/sdk/common/proto_type.hpp>
 #include <viam/sdk/resource/resource_api.hpp>
 #include <viam/sdk/services/motion/motion.hpp>
 #include <viam/sdk/spatialmath/geometry.hpp>

--- a/src/viam/sdk/tests/mocks/mock_motion.hpp
+++ b/src/viam/sdk/tests/mocks/mock_motion.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "viam/sdk/common/proto_type.hpp"
 #include <viam/sdk/common/pose.hpp>
 #include <viam/sdk/resource/resource_api.hpp>
 #include <viam/sdk/services/motion/motion.hpp>
@@ -46,8 +47,22 @@ class MockMotion : public sdk::Motion {
         const std::vector<sdk::WorldState::transform>& supplemental_transforms,
         const sdk::AttributeMap& extra) override;
 
+    std::pair<plan_with_status, std::vector<plan_with_status>> get_plan(
+        const sdk::Name& component_name,
+        const sdk::AttributeMap& extra,
+        bool last_plan_only = false,
+        boost::optional<std::string> execution_id = {}) override;
+
+    std::vector<plan_status_with_id> list_plan_statuses(const sdk::AttributeMap& extra,
+                                                        bool only_active_plans = false) override;
+
+    void stop_plan(const sdk::Name& name, const sdk::AttributeMap& extra) override;
+
     sdk::AttributeMap do_command(const sdk::AttributeMap& command) override;
     static std::shared_ptr<MockMotion> get_mock_motion();
+    static plan_status fake_plan_status();
+    static plan_with_status fake_plan_with_status();
+    static plan_status_with_id fake_plan_status_with_id();
 
     // These variables allow the testing infra to `peek` into the mock
     // and ensure that the correct values were passed
@@ -59,11 +74,11 @@ class MockMotion : public sdk::Motion {
     sdk::geo_point peek_destination;
     std::string peek_destination_frame;
     double peek_heading;
+    bool peek_stop_plan_called = false;
     std::vector<sdk::geo_obstacle> peek_obstacles;
     std::shared_ptr<constraints> peek_constraints;
     std::shared_ptr<sdk::motion_configuration> peek_motion_configuration;
     std::shared_ptr<sdk::WorldState> peek_world_state;
-    sdk::AttributeMap peek_map;
 
     MockMotion(std::string name)
         : sdk::Motion(std::move(name)), current_location(init_fake_pose()){};

--- a/src/viam/sdk/tests/test_board.cpp
+++ b/src/viam/sdk/tests/test_board.cpp
@@ -152,6 +152,16 @@ BOOST_AUTO_TEST_CASE(test_read_analog) {
     });
 }
 
+BOOST_AUTO_TEST_CASE(test_write_analog) {
+    server_to_mock_pipeline([](Board& client, std::shared_ptr<MockBoard> mock) -> void {
+        std::string pin = "pin1";
+        int value = 42;
+        client.write_analog(pin, value);
+        BOOST_CHECK_EQUAL(pin, mock->peek_pin);
+        BOOST_CHECK_EQUAL(value, mock->peek_pin_value);
+    });
+}
+
 BOOST_AUTO_TEST_CASE(test_read_digital_interrupt) {
     server_to_mock_pipeline([](Board& client, std::shared_ptr<MockBoard> mock) -> void {
         mock->peek_read_digital_interrupt_ret = 515;

--- a/src/viam/sdk/tests/test_motion.cpp
+++ b/src/viam/sdk/tests/test_motion.cpp
@@ -13,6 +13,8 @@
 
 BOOST_TEST_DONT_PRINT_LOG_VALUE(viam::sdk::WorldState)
 BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<viam::sdk::geo_obstacle>)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(viam::sdk::Motion::plan_status_with_id)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(viam::sdk::Motion::plan_with_status)
 
 namespace viam {
 namespace sdktests {
@@ -85,6 +87,29 @@ BOOST_AUTO_TEST_CASE(mock_move_on_globe) {
     BOOST_CHECK_EQUAL(*(motion->peek_motion_configuration), *(fake_motion_configuration()));
 }
 
+BOOST_AUTO_TEST_CASE(mock_get_plan) {
+    std::shared_ptr<MockMotion> mock = MockMotion::get_mock_motion();
+    auto ret = mock->get_plan(fake_component_name(), fake_map());
+
+    BOOST_CHECK_EQUAL(ret.first, mock->fake_plan_with_status());
+    BOOST_CHECK_EQUAL(ret.second.size(), 1);
+    BOOST_CHECK_EQUAL(ret.second[0], mock->fake_plan_with_status());
+}
+
+BOOST_AUTO_TEST_CASE(mock_stop_plan) {
+    std::shared_ptr<MockMotion> mock = MockMotion::get_mock_motion();
+    BOOST_CHECK(!mock->peek_stop_plan_called);
+    mock->stop_plan(fake_component_name(), fake_map());
+    BOOST_CHECK(mock->peek_stop_plan_called);
+}
+
+BOOST_AUTO_TEST_CASE(mock_list_plan_statuses) {
+    std::shared_ptr<MockMotion> mock = MockMotion::get_mock_motion();
+    std::vector<Motion::plan_status_with_id> statuses = mock->list_plan_statuses(fake_map());
+    BOOST_CHECK_EQUAL(statuses.size(), 1);
+    BOOST_CHECK_EQUAL(statuses[0], mock->fake_plan_status_with_id());
+}
+
 BOOST_AUTO_TEST_CASE(mock_do_command) {
     std::shared_ptr<MockMotion> motion = MockMotion::get_mock_motion();
     AttributeMap expected = fake_map();
@@ -124,8 +149,8 @@ BOOST_AUTO_TEST_SUITE(test_motion_client_server)
 template <typename Lambda>
 void server_to_mock_pipeline(Lambda&& func) {
     MotionServer motion_server;
-    motion_server.resource_manager()->add(std::string("mock_motion"),
-                                          MockMotion::get_mock_motion());
+    auto mock = std::make_shared<MockMotion>("mock_motion");
+    motion_server.resource_manager()->add(std::string("mock_motion"), mock);
 
     grpc::ServerBuilder builder;
     builder.RegisterService(&motion_server);
@@ -136,13 +161,13 @@ void server_to_mock_pipeline(Lambda&& func) {
     auto grpc_channel = server->InProcessChannel(args);
     MotionClient client("mock_motion", grpc_channel);
     // Run the passed test on the created stack
-    std::forward<Lambda>(func)(client);
+    std::forward<Lambda>(func)(client, mock);
     // shutdown afterwards
     server->Shutdown();
 }
 
 BOOST_AUTO_TEST_CASE(test_move_and_get_pose) {
-    server_to_mock_pipeline([](Motion& client) -> void {
+    server_to_mock_pipeline([](Motion& client, std::shared_ptr<MockMotion> mock) -> void {
         std::string destination_frame("destination");
         std::vector<WorldState::transform> transforms;
         AttributeMap extra = fake_map();
@@ -159,7 +184,7 @@ BOOST_AUTO_TEST_CASE(test_move_and_get_pose) {
 }
 
 BOOST_AUTO_TEST_CASE(test_move_on_map) {
-    server_to_mock_pipeline([](Motion& client) -> void {
+    server_to_mock_pipeline([](Motion& client, std::shared_ptr<MockMotion> mock) -> void {
         pose destination({{1, 2, 3}, {4, 5, 6}, 7});
         bool success =
             client.move_on_map(destination, fake_component_name(), fake_slam_name(), fake_map());
@@ -172,8 +197,7 @@ BOOST_AUTO_TEST_CASE(test_move_on_map) {
 }
 
 BOOST_AUTO_TEST_CASE(test_move_on_globe) {
-    BOOST_TEST(true);
-    server_to_mock_pipeline([](Motion& client) -> void {
+    server_to_mock_pipeline([](Motion& client, std::shared_ptr<MockMotion> mock) -> void {
         bool success = client.move_on_globe(fake_geo_point(),
                                             15,
                                             fake_component_name(),
@@ -186,8 +210,32 @@ BOOST_AUTO_TEST_CASE(test_move_on_globe) {
     });
 }
 
+BOOST_AUTO_TEST_CASE(test_get_plan) {
+    server_to_mock_pipeline([](Motion& client, std::shared_ptr<MockMotion> mock) -> void {
+        auto ret = client.get_plan(fake_component_name(), fake_map());
+        BOOST_CHECK_EQUAL(ret.first, MockMotion::fake_plan_with_status());
+        BOOST_CHECK_EQUAL(ret.second.size(), 1);
+        BOOST_CHECK_EQUAL(ret.second[0], MockMotion::fake_plan_with_status());
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_list_plan_statuses) {
+    server_to_mock_pipeline([](Motion& client, std::shared_ptr<MockMotion> mock) -> void {
+        std::vector<Motion::plan_status_with_id> statuses = client.list_plan_statuses(fake_map());
+        BOOST_CHECK_EQUAL(statuses.size(), 1);
+        BOOST_CHECK_EQUAL(statuses[0], MockMotion::fake_plan_status_with_id());
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_stop_plan) {
+    server_to_mock_pipeline([](Motion& client, std::shared_ptr<MockMotion> mock) -> void {
+        client.stop_plan(fake_component_name());
+        BOOST_CHECK(mock->peek_stop_plan_called);
+    });
+}
+
 BOOST_AUTO_TEST_CASE(test_do_command) {
-    server_to_mock_pipeline([](Motion& client) -> void {
+    server_to_mock_pipeline([](Motion& client, std::shared_ptr<MockMotion> mock) -> void {
         AttributeMap expected = fake_map();
 
         AttributeMap command = fake_map();


### PR DESCRIPTION
#### Major Changes
Adds missing `board` and `motion` methods.

#### Minor changes
Type aliases our commonly used  `time_point`
Fixes an issues with proto conversion of `ResourceName`
Ensures return value of `MockMotion::do_command` is reliable
Ensures propagation of a couple default arguments missing in `client` code