### PR TITLE
RSDK-5760 - change stop return to void

### DIFF
--- a/src/viam/examples/modules/complex/base/impl.cpp
+++ b/src/viam/examples/modules/complex/base/impl.cpp
@@ -65,24 +65,27 @@ bool MyBase::is_moving() {
 }
 
 void MyBase::stop(const AttributeMap& extra) {
-    std::exception* e;
+    std::string err_message;
+    bool throw_err = false;
 
     // make sure we try to stop both motors, even if the first fails.
     try {
         left_->stop(extra);
     } catch (const std::exception& err) {
-        *e = err;
+        throw_err = true;
+        err_message = err.what();
     }
 
     try {
         right_->stop(extra);
     } catch (const std::exception& err) {
-        *e = err;
+        throw_err = true;
+        err_message = err.what();
     }
 
     // if we received an err from either motor, throw it.
-    if (e) {
-        throw *e;
+    if (throw_err) {
+        throw std::runtime_error(err_message);
     }
 }
 

--- a/src/viam/examples/modules/complex/base/impl.hpp
+++ b/src/viam/examples/modules/complex/base/impl.hpp
@@ -20,7 +20,7 @@ class MyBase : public Base {
     static std::vector<std::string> validate(ResourceConfig cfg);
 
     bool is_moving() override;
-    grpc::StatusCode stop(const AttributeMap& extra) override;
+    void stop(const AttributeMap& extra) override;
     void set_power(const Vector3& linear,
                    const Vector3& angular,
                    const AttributeMap& extra) override;

--- a/src/viam/examples/modules/complex/gizmo/api.cpp
+++ b/src/viam/examples/modules/complex/gizmo/api.cpp
@@ -296,6 +296,8 @@ std::vector<bool> GizmoClient::do_one_bidi_stream(std::vector<std::string> arg1)
     return rets;
 }
 
+void GizmoClient::stop(const AttributeMap& extra) {}
+
 std::string GizmoClient::do_two(bool arg1) {
     DoTwoRequest request;
     DoTwoResponse response;

--- a/src/viam/examples/modules/complex/gizmo/api.hpp
+++ b/src/viam/examples/modules/complex/gizmo/api.hpp
@@ -54,6 +54,7 @@ class GizmoClient : public Gizmo {
     std::vector<bool> do_one_server_stream(std::string arg1) override;
     std::vector<bool> do_one_bidi_stream(std::vector<std::string> arg1) override;
     std::string do_two(bool arg1) override;
+    void stop(const AttributeMap& extra) override;
 
    private:
     std::unique_ptr<GizmoService::StubInterface> stub_;

--- a/src/viam/examples/modules/complex/summation/api.cpp
+++ b/src/viam/examples/modules/complex/summation/api.cpp
@@ -111,3 +111,5 @@ double SummationClient::sum(std::vector<double> numbers) {
 
     return response.sum();
 }
+
+void SummationClient::stop(const AttributeMap& extra) {}

--- a/src/viam/examples/modules/complex/summation/api.hpp
+++ b/src/viam/examples/modules/complex/summation/api.hpp
@@ -49,6 +49,7 @@ class SummationClient : public Summation {
     SummationClient(std::string name, std::shared_ptr<grpc::Channel> channel);
 
     double sum(std::vector<double> numbers) override;
+    void stop(const AttributeMap& extra) override;
 
    private:
     std::unique_ptr<SummationService::StubInterface> stub_;

--- a/src/viam/examples/modules/tflite/main.cpp
+++ b/src/viam/examples/modules/tflite/main.cpp
@@ -73,12 +73,12 @@ class MLModelServiceTFLite : public vsdk::MLModelService {
         // drain.
     }
 
-    grpc::StatusCode stop(vsdk::AttributeMap extra) noexcept final {
+    void stop(const vsdk::AttributeMap& extra) noexcept final {
         return stop();
     }
 
     /// @brief Stops a resource from running.
-    grpc::StatusCode stop() noexcept final {
+    void stop() noexcept {
         using std::swap;
         try {
             std::lock_guard<std::mutex> lock(state_lock_);
@@ -90,7 +90,6 @@ class MLModelServiceTFLite : public vsdk::MLModelService {
             }
         } catch (...) {
         }
-        return grpc::StatusCode::OK;
     }
 
     void reconfigure(vsdk::Dependencies dependencies, vsdk::ResourceConfig configuration) final

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -120,13 +120,13 @@ class Base : public Component {
                               const AttributeMap& extra) = 0;
 
     /// @brief Stops a robot's base
-    inline grpc::StatusCode stop() {
+    inline void stop() {
         return stop({});
     }
 
     /// @brief Stops a robot's base
     /// @param extra Any additional arguments to the method
-    virtual grpc::StatusCode stop(const AttributeMap& extra) override = 0;
+    virtual void stop(const AttributeMap& extra) override = 0;
 
     /// @brief Reports if the base is in motion
     virtual bool is_moving() = 0;

--- a/src/viam/sdk/components/base/client.cpp
+++ b/src/viam/sdk/components/base/client.cpp
@@ -101,7 +101,7 @@ void BaseClient::set_velocity(const Vector3& linear,
     }
 }
 
-grpc::StatusCode BaseClient::stop(const AttributeMap& extra) {
+void BaseClient::stop(const AttributeMap& extra) {
     viam::component::base::v1::StopRequest request;
     viam::component::base::v1::StopResponse response;
 
@@ -115,7 +115,6 @@ grpc::StatusCode BaseClient::stop(const AttributeMap& extra) {
     if (!status.ok()) {
         throw std::runtime_error(status.error_message());
     }
-    return status.error_code();
 }
 
 bool BaseClient::is_moving() {

--- a/src/viam/sdk/components/base/client.hpp
+++ b/src/viam/sdk/components/base/client.hpp
@@ -31,7 +31,7 @@ class BaseClient : public Base {
     void set_velocity(const Vector3& linear,
                       const Vector3& angular,
                       const AttributeMap& extra) override;
-    grpc::StatusCode stop(const AttributeMap& extra) override;
+    void stop(const AttributeMap& extra) override;
     std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) override;
     properties get_properties(const AttributeMap& extra) override;
     bool is_moving() override;

--- a/src/viam/sdk/components/board/client.cpp
+++ b/src/viam/sdk/components/board/client.cpp
@@ -56,6 +56,8 @@ void BoardClient::set_gpio(const std::string& pin, bool high, const AttributeMap
     }
 }
 
+void BoardClient::stop(const AttributeMap& extra) {}
+
 bool BoardClient::get_gpio(const std::string& pin, const AttributeMap& extra) {
     viam::component::board::v1::GetGPIORequest request;
     viam::component::board::v1::GetGPIOResponse response;

--- a/src/viam/sdk/components/board/client.hpp
+++ b/src/viam/sdk/components/board/client.hpp
@@ -21,6 +21,7 @@ namespace sdk {
 class BoardClient : public Board {
    public:
     BoardClient(std::string name, std::shared_ptr<grpc::Channel> channel);
+    void stop(const AttributeMap& extra) override;
     AttributeMap do_command(const AttributeMap& command) override;
     status get_status(const AttributeMap& extra) override;
     void set_gpio(const std::string& pin, bool high, const AttributeMap& extra) override;

--- a/src/viam/sdk/components/camera/client.cpp
+++ b/src/viam/sdk/components/camera/client.cpp
@@ -102,5 +102,7 @@ Camera::properties CameraClient::get_properties() {
     return from_proto(resp);
 };
 
+void CameraClient::stop(const AttributeMap& extra) {}
+
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/camera/client.hpp
+++ b/src/viam/sdk/components/camera/client.hpp
@@ -21,6 +21,7 @@ namespace sdk {
 /// @ingroup Camera
 class CameraClient : public Camera {
    public:
+    void stop(const AttributeMap& extra) override;
     CameraClient(std::string name, std::shared_ptr<grpc::Channel> channel);
     AttributeMap do_command(AttributeMap command) override;
     raw_image get_image(std::string mime_type, const AttributeMap& extra) override;

--- a/src/viam/sdk/components/encoder/client.cpp
+++ b/src/viam/sdk/components/encoder/client.cpp
@@ -105,5 +105,7 @@ AttributeMap EncoderClient::do_command(AttributeMap command) {
     return struct_to_map(response.result());
 }
 
+void EncoderClient::stop(const AttributeMap& extra) {}
+
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/encoder/client.hpp
+++ b/src/viam/sdk/components/encoder/client.hpp
@@ -21,6 +21,7 @@ namespace sdk {
 class EncoderClient : public Encoder {
    public:
     EncoderClient(std::string name, std::shared_ptr<grpc::Channel> channel);
+    void stop(const AttributeMap& extra) override;
     position get_position(const AttributeMap& extra, position_type position_type) override;
     void reset_position(const AttributeMap& extra) override;
     properties get_properties(const AttributeMap& extra) override;

--- a/src/viam/sdk/components/generic/client.cpp
+++ b/src/viam/sdk/components/generic/client.cpp
@@ -29,7 +29,10 @@ AttributeMap GenericClient::do_command(AttributeMap command) {
     *req.mutable_name() = this->name();
     stub_->DoCommand(&ctx, req, &resp);
     return struct_to_map(resp.result());
-};
+}
+
+void GenericClient::stop(const AttributeMap& extra) {}
+
 std::vector<GeometryConfig> GenericClient::get_geometries() {
     viam::common::v1::GetGeometriesRequest req;
     viam::common::v1::GetGeometriesResponse resp;
@@ -40,7 +43,7 @@ std::vector<GeometryConfig> GenericClient::get_geometries() {
 
     stub_->GetGeometries(&ctx, req, &resp);
     return GeometryConfig::from_proto(resp);
-};
+}
 
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/generic/client.hpp
+++ b/src/viam/sdk/components/generic/client.hpp
@@ -18,6 +18,7 @@ namespace sdk {
 /// @ingroup Generic
 class GenericClient : public Generic {
    public:
+    void stop(const AttributeMap& extra) override;
     GenericClient(std::string name, std::shared_ptr<grpc::Channel> channel);
     AttributeMap do_command(AttributeMap command) override;
     std::vector<GeometryConfig> get_geometries() override;

--- a/src/viam/sdk/components/motor/client.cpp
+++ b/src/viam/sdk/components/motor/client.cpp
@@ -66,7 +66,7 @@ Motor::properties MotorClient::get_properties(const AttributeMap& extra) {
         .invoke([](auto& response) { return from_proto(response); });
 }
 
-grpc::StatusCode MotorClient::stop(const AttributeMap& extra) {
+void MotorClient::stop(const AttributeMap& extra) {
     viam::component::motor::v1::StopRequest request;
     viam::component::motor::v1::StopResponse response;
 
@@ -77,7 +77,9 @@ grpc::StatusCode MotorClient::stop(const AttributeMap& extra) {
     *request.mutable_extra() = map_to_struct(extra);
 
     const grpc::Status status = stub_->Stop(&ctx, request, &response);
-    return status.error_code();
+    if (!status.ok()) {
+        throw std::runtime_error(status.error_message());
+    }
 }
 
 Motor::power_status MotorClient::get_power_status(const AttributeMap& extra) {

--- a/src/viam/sdk/components/motor/client.hpp
+++ b/src/viam/sdk/components/motor/client.hpp
@@ -27,7 +27,7 @@ class MotorClient : public Motor {
     void reset_zero_position(double offset, const AttributeMap& extra) override;
     position get_position(const AttributeMap& extra) override;
     properties get_properties(const AttributeMap& extra) override;
-    grpc::StatusCode stop(const AttributeMap& extra) override;
+    void stop(const AttributeMap& extra) override;
     power_status get_power_status(const AttributeMap& extra) override;
     std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) override;
     bool is_moving() override;

--- a/src/viam/sdk/components/motor/motor.hpp
+++ b/src/viam/sdk/components/motor/motor.hpp
@@ -183,13 +183,13 @@ class Motor : public Component {
     virtual bool is_moving() = 0;
 
     /// @brief Stops a resource from running.
-    inline grpc::StatusCode stop() {
+    inline void stop() {
         return stop({});
     }
 
     /// @brief Stops a resource from running.
     /// @param extra Extra arguments to pass to the resource's `stop` method.
-    grpc::StatusCode stop(const AttributeMap& extra) override = 0;
+    void stop(const AttributeMap& extra) override = 0;
 
     /// @brief Send/receive arbitrary commands to the resource.
     /// @param Command the command to execute.

--- a/src/viam/sdk/components/movement_sensor/client.cpp
+++ b/src/viam/sdk/components/movement_sensor/client.cpp
@@ -94,5 +94,7 @@ std::vector<GeometryConfig> MovementSensorClient::get_geometries(const Attribute
         .invoke([](auto& response) { return GeometryConfig::from_proto(response); });
 }
 
+void MovementSensorClient::stop(const AttributeMap& extra) {}
+
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/movement_sensor/client.hpp
+++ b/src/viam/sdk/components/movement_sensor/client.hpp
@@ -22,6 +22,7 @@ namespace sdk {
 class MovementSensorClient : public MovementSensor {
    public:
     MovementSensorClient(std::string name, std::shared_ptr<grpc::Channel> channel);
+    void stop(const AttributeMap& extra) override;
     Vector3 get_linear_velocity(const AttributeMap& extra) override;
     Vector3 get_angular_velocity(const AttributeMap& extra) override;
     compassheading get_compass_heading(const AttributeMap& extra) override;

--- a/src/viam/sdk/components/power_sensor/client.cpp
+++ b/src/viam/sdk/components/power_sensor/client.cpp
@@ -62,5 +62,7 @@ AttributeMap PowerSensorClient::do_command(const AttributeMap& command) {
         .invoke([](auto& response) { return struct_to_map(response.result()); });
 }
 
+void PowerSensorClient::stop(const AttributeMap& extra) {}
+
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/power_sensor/client.hpp
+++ b/src/viam/sdk/components/power_sensor/client.hpp
@@ -20,6 +20,7 @@ namespace sdk {
 /// @ingroup PowerSensor
 class PowerSensorClient : public PowerSensor {
    public:
+    void stop(const AttributeMap& extra) override;
     PowerSensorClient(std::string name, std::shared_ptr<grpc::Channel> channel);
     voltage get_voltage(const AttributeMap& extra) override;
     current get_current(const AttributeMap& extra) override;

--- a/src/viam/sdk/components/sensor/client.cpp
+++ b/src/viam/sdk/components/sensor/client.cpp
@@ -49,5 +49,7 @@ std::vector<GeometryConfig> SensorClient::get_geometries(const AttributeMap& ext
         .invoke([](auto& response) { return GeometryConfig::from_proto(response); });
 }
 
+void SensorClient::stop(const AttributeMap& extra) {}
+
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/sensor/client.hpp
+++ b/src/viam/sdk/components/sensor/client.hpp
@@ -19,6 +19,7 @@ namespace sdk {
 /// @ingroup Sensor
 class SensorClient : public Sensor {
    public:
+    void stop(const AttributeMap& extra) override;
     SensorClient(std::string name, std::shared_ptr<grpc::Channel> channel);
     AttributeMap get_readings(const AttributeMap& extra) override;
     AttributeMap do_command(const AttributeMap& command) override;

--- a/src/viam/sdk/resource/resource.cpp
+++ b/src/viam/sdk/resource/resource.cpp
@@ -14,10 +14,6 @@ namespace sdk {
 
 Resource::~Resource() = default;
 
-void Resource::stop(const AttributeMap& extra) {
-    throw std::runtime_error("Unimplemented");
-}
-
 std::string Resource::name() const {
     return name_;
 }

--- a/src/viam/sdk/resource/resource.cpp
+++ b/src/viam/sdk/resource/resource.cpp
@@ -1,5 +1,6 @@
 #include <viam/sdk/resource/resource.hpp>
 
+#include <stdexcept>
 #include <unordered_map>
 
 #include <grpcpp/support/status.h>
@@ -13,8 +14,8 @@ namespace sdk {
 
 Resource::~Resource() = default;
 
-grpc::StatusCode Resource::stop(const AttributeMap& extra) {
-    return grpc::StatusCode::UNIMPLEMENTED;
+void Resource::stop(const AttributeMap& extra) {
+    throw std::runtime_error("Unimplemented");
 }
 
 std::string Resource::name() const {

--- a/src/viam/sdk/resource/resource.hpp
+++ b/src/viam/sdk/resource/resource.hpp
@@ -29,10 +29,10 @@ class Resource {
 
     /// @brief Stops a resource from running.
     /// @param extra Extra arguments to pass to the resource's `stop` method.
-    virtual grpc::StatusCode stop(const AttributeMap& extra);
+    virtual void stop(const AttributeMap& extra);
 
     /// @brief Stops a resource from running.
-    inline grpc::StatusCode stop() {
+    inline void stop() {
         return stop({});
     }
 

--- a/src/viam/sdk/resource/resource.hpp
+++ b/src/viam/sdk/resource/resource.hpp
@@ -29,7 +29,7 @@ class Resource {
 
     /// @brief Stops a resource from running.
     /// @param extra Extra arguments to pass to the resource's `stop` method.
-    virtual void stop(const AttributeMap& extra);
+    virtual void stop(const AttributeMap& extra) = 0;
 
     /// @brief Stops a resource from running.
     inline void stop() {

--- a/src/viam/sdk/robot/service.cpp
+++ b/src/viam/sdk/robot/service.cpp
@@ -160,14 +160,23 @@ void RobotService_::stream_status(
         const ResourceName rn = resource->get_resource_name(resource->name());
         const std::string rn_ = rn.SerializeAsString();
         if (extra.find(rn_) != extra.end()) {
-            grpc::StatusCode status = resource->stop(extra.at(rn_));
-            if (status != grpc::StatusCode::OK) {
-                // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-                status = resource->stop();
+            try {
+                resource->stop(extra.at(rn_));
+            } catch (...) {
+                try {
+                    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
+                    resource->stop();
+                } catch (...) {
+                    status = grpc::UNKNOWN;
+                }
             }
         } else {
-            // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-            status = resource->stop();
+            try {
+                // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
+                resource->stop();
+            } catch (...) {
+                status = grpc::UNKNOWN;
+            }
         }
     }
 

--- a/src/viam/sdk/robot/service.cpp
+++ b/src/viam/sdk/robot/service.cpp
@@ -168,19 +168,23 @@ void RobotService_::stream_status(
             } catch (const std::runtime_error& err) {
                 try {
                     status_message = err.what();
-                    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
                     resource->stop();
                 } catch (std::runtime_error& err) {
                     status_message = err.what();
+                    status = grpc::UNKNOWN;
+                } catch (...) {
+                    status_message = "unknown error";
                     status = grpc::UNKNOWN;
                 }
             }
         } else {
             try {
-                // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
                 resource->stop();
             } catch (std::runtime_error& err) {
                 status_message = err.what();
+                status = grpc::UNKNOWN;
+            } catch (...) {
+                status_message = "unknown error";
                 status = grpc::UNKNOWN;
             }
         }

--- a/src/viam/sdk/services/mlmodel/client.cpp
+++ b/src/viam/sdk/services/mlmodel/client.cpp
@@ -148,5 +148,7 @@ struct MLModelService::metadata MLModelServiceClient::metadata(const AttributeMa
     return result;
 }
 
+void MLModelServiceClient::stop(const AttributeMap& extra) {}
+
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/services/mlmodel/client.hpp
+++ b/src/viam/sdk/services/mlmodel/client.hpp
@@ -35,6 +35,7 @@ class MLModelServiceClient : public MLModelService {
     std::shared_ptr<named_tensor_views> infer(const named_tensor_views& inputs,
                                               const AttributeMap& extra) override;
     struct metadata metadata(const AttributeMap& extra) override;
+    void stop(const AttributeMap& extra) override;
 
     // the `extra` param is frequently unnecessary but needs to be supported. Ideally, we'd
     // like to live in a world where implementers of derived classes don't need to go out of

--- a/src/viam/sdk/services/motion/client.cpp
+++ b/src/viam/sdk/services/motion/client.cpp
@@ -151,5 +151,7 @@ AttributeMap MotionClient::do_command(const AttributeMap& command) {
     return struct_to_map(response.result());
 }
 
+void MotionClient::stop(const AttributeMap& extra) {}
+
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/services/motion/client.hpp
+++ b/src/viam/sdk/services/motion/client.hpp
@@ -16,6 +16,7 @@ namespace sdk {
 class MotionClient : public Motion {
    public:
     MotionClient(std::string name, std::shared_ptr<grpc::Channel> channel);
+    void stop(const AttributeMap& extra) override;
     bool move(const pose_in_frame& destination,
               const Name& component_name,
               std::shared_ptr<WorldState> world_state,

--- a/src/viam/sdk/tests/mocks/mock_base.cpp
+++ b/src/viam/sdk/tests/mocks/mock_base.cpp
@@ -38,9 +38,8 @@ void MockBase::set_velocity(const Vector3& linear,
     this->peek_set_velocity_linear = linear;
     this->peek_set_velocity_angular = angular;
 }
-grpc::StatusCode MockBase::stop(const AttributeMap& extra) {
+void MockBase::stop(const AttributeMap& extra) {
     this->peek_stop_called = true;
-    return grpc::StatusCode::OK;
 }
 bool MockBase::is_moving() {
     return false;

--- a/src/viam/sdk/tests/mocks/mock_base.hpp
+++ b/src/viam/sdk/tests/mocks/mock_base.hpp
@@ -30,7 +30,7 @@ class MockBase : public sdk::Base {
     void set_velocity(const sdk::Vector3& linear,
                       const sdk::Vector3& angular,
                       const sdk::AttributeMap& extra) override;
-    grpc::StatusCode stop(const sdk::AttributeMap& extra) override;
+    void stop(const sdk::AttributeMap& extra) override;
     bool is_moving() override;
     sdk::AttributeMap do_command(const sdk::AttributeMap& command) override;
     static std::shared_ptr<MockBase> get_mock_base();

--- a/src/viam/sdk/tests/mocks/mock_motor.cpp
+++ b/src/viam/sdk/tests/mocks/mock_motor.cpp
@@ -47,12 +47,11 @@ Motor::properties MockMotor::get_properties(const AttributeMap& extra) {
     return properties_;
 }
 
-grpc::StatusCode MockMotor::stop(const AttributeMap& extra) {
+void MockMotor::stop(const AttributeMap& extra) {
     // None of these functions are async and this mock is not
     // thread-safe (Send, not Sync). The mock motor should never be
     // moving when this is called
     set_power(0.0);
-    return grpc::StatusCode();
 }
 
 Motor::power_status MockMotor::get_power_status(const AttributeMap& extra) {

--- a/src/viam/sdk/tests/mocks/mock_motor.hpp
+++ b/src/viam/sdk/tests/mocks/mock_motor.hpp
@@ -24,7 +24,7 @@ class MockMotor : public Motor {
     void reset_zero_position(double offset, const sdk::AttributeMap& extra) override;
     Motor::position get_position(const sdk::AttributeMap& extra) override;
     Motor::properties get_properties(const sdk::AttributeMap& extra) override;
-    grpc::StatusCode stop(const viam::sdk::AttributeMap& extra) override;
+    void stop(const viam::sdk::AttributeMap& extra) override;
     Motor::power_status get_power_status(const viam::sdk::AttributeMap& extra) override;
     bool is_moving() override;
     viam::sdk::AttributeMap do_command(const viam::sdk::AttributeMap& command) override;


### PR DESCRIPTION
#### Major changes

Change return type of `stop()` from `grpc::StatusCode` to `void`.

Most changes are pretty straightforward, there are two places where a bit more attention should be necessary. Will highlight those to reviewers.