### PR TITLE
RSDK-4844 Add better boilerplate for module development

### DIFF
--- a/src/viam/examples/modules/complex/main.cpp
+++ b/src/viam/examples/modules/complex/main.cpp
@@ -28,21 +28,6 @@
 using namespace viam::sdk;
 
 int main(int argc, char** argv) {
-    if (argc < 2) {
-        std::cerr << "Need socket path as command line argument" << std::endl;
-        return EXIT_FAILURE;
-    }
-    std::string socket_addr = argv[1];
-
-    // Use set_logger_severity_from_args to set the boost trivial logger's
-    // severity depending on commandline arguments.
-    set_logger_severity_from_args(argc, argv);
-    BOOST_LOG_TRIVIAL(debug) << "Starting module with debug level logging";
-
-    // C++ modules must handle SIGINT and SIGTERM. You can use the SignalManager
-    // class and its wait method to handle the correct signals.
-    SignalManager signals;
-
     API base_api = Base::static_api();
     Model mybase_model("viam", "base", "mybase");
 
@@ -52,22 +37,17 @@ int main(int argc, char** argv) {
         [](Dependencies deps, ResourceConfig cfg) { return std::make_unique<MyBase>(deps, cfg); },
         MyBase::validate);
 
-    Registry::register_model(mybase_mr);
-
     API gizmo_api = Gizmo::static_api();
     Model mygizmo_model("viam", "gizmo", "mygizmo");
     // Make sure to explicity register resources with custom APIs. Note that
     // this must be done in `main` and not in resource implementation files due
     // to order of static initialization.
     Registry::register_resource(gizmo_api, Gizmo::resource_registration());
-
     std::shared_ptr<ModelRegistration> mygizmo_mr = std::make_shared<ModelRegistration>(
         gizmo_api,
         mygizmo_model,
         [](Dependencies deps, ResourceConfig cfg) { return std::make_unique<MyGizmo>(deps, cfg); },
         MyGizmo::validate);
-
-    Registry::register_model(mygizmo_mr);
 
     API summation_api = Summation::static_api();
     Model mysummation_model("viam", "summation", "mysummation");
@@ -81,22 +61,9 @@ int main(int argc, char** argv) {
             return std::make_unique<MySummation>(deps, cfg);
         });
 
-    Registry::register_model(mysummation_mr);
+    std::vector<std::shared_ptr<ModelRegistration>> mrs = {mybase_mr, mygizmo_mr, mysummation_mr};
+    auto my_mod = std::make_shared<ModuleService>(argc, argv, mrs);
+    my_mod->serve();
 
-    // The `ModuleService_` must outlive the Server, so the declaration order
-    // here matters.
-    auto my_mod = std::make_shared<ModuleService_>(socket_addr);
-    auto server = std::make_shared<Server>();
-
-    my_mod->add_model_from_registry(server, base_api, mybase_model);
-    my_mod->add_model_from_registry(server, gizmo_api, mygizmo_model);
-    my_mod->add_model_from_registry(server, summation_api, mysummation_model);
-    my_mod->start(server);
-    BOOST_LOG_TRIVIAL(info) << "Complex example module listening on " << socket_addr;
-
-    server->start();
-    int sig = 0;
-    auto result = signals.wait(&sig);
-    server->shutdown();
     return EXIT_SUCCESS;
 };

--- a/src/viam/examples/modules/simple/main.cpp
+++ b/src/viam/examples/modules/simple/main.cpp
@@ -54,7 +54,7 @@ class Printer : public Generic {
     }
 
     static std::string find_to_print(ResourceConfig cfg) {
-        auto const& printer_name = cfg.name();
+        auto& printer_name = cfg.name();
         auto to_print = cfg.attributes()->find("to_print");
         if (to_print == cfg.attributes()->end()) {
             std::ostringstream buffer;

--- a/src/viam/examples/modules/simple/main.cpp
+++ b/src/viam/examples/modules/simple/main.cpp
@@ -21,7 +21,6 @@
 #include <viam/sdk/rpc/dial.hpp>
 #include <viam/sdk/rpc/server.hpp>
 
-using viam::component::generic::v1::GenericService;
 using namespace viam::sdk;
 
 // Printer is a modular resource that can print a to_print value to STDOUT when
@@ -55,7 +54,7 @@ class Printer : public Generic {
     }
 
     static std::string find_to_print(ResourceConfig cfg) {
-        auto printer_name = cfg.name();
+        auto const& printer_name = cfg.name();
         auto to_print = cfg.attributes()->find("to_print");
         if (to_print == cfg.attributes()->end()) {
             std::ostringstream buffer;
@@ -78,21 +77,6 @@ class Printer : public Generic {
 };
 
 int main(int argc, char** argv) {
-    if (argc < 2) {
-        std::cerr << "Need socket path as command line argument" << std::endl;
-        return EXIT_FAILURE;
-    }
-    std::string socket_addr = argv[1];
-
-    // Use set_logger_severity_from_args to set the boost trivial logger's
-    // severity depending on commandline arguments.
-    set_logger_severity_from_args(argc, argv);
-    BOOST_LOG_TRIVIAL(debug) << "Starting module with debug level logging";
-
-    // C++ modules must handle SIGINT and SIGTERM. You can use the SignalManager
-    // class and its wait method to handle the correct signals.
-    SignalManager signals;
-
     API generic = Generic::static_api();
     Model m("viam", "generic", "printer");
 
@@ -111,21 +95,9 @@ int main(int argc, char** argv) {
             return {};
         });
 
-    Registry::register_model(mr);
+    std::vector<std::shared_ptr<ModelRegistration>> mrs = {mr};
+    auto my_mod = std::make_shared<ModuleService>(argc, argv, mrs);
+    my_mod->serve();
 
-    // The `ModuleService_` must outlive the Server, so the declaration order
-    // here matters.
-    auto my_mod = std::make_shared<ModuleService_>(socket_addr);
-    auto server = std::make_shared<Server>();
-
-    my_mod->add_model_from_registry(server, generic, m);
-    my_mod->start(server);
-    BOOST_LOG_TRIVIAL(info) << "Module serving model " << m.to_string() << ", listening on "
-                            << socket_addr;
-
-    server->start();
-    int sig = 0;
-    auto result = signals.wait(&sig);
-    server->shutdown();
     return EXIT_SUCCESS;
 };

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -82,6 +82,7 @@ target_sources(viamsdk
     module/handler_map.cpp
     module/module.cpp
     module/service.cpp
+    module/signal_manager.cpp
     referenceframe/frame.cpp
     resource/resource.cpp
     resource/resource_api.cpp
@@ -146,6 +147,7 @@ target_sources(viamsdk
       ../../viam/sdk/module/handler_map.hpp
       ../../viam/sdk/module/module.hpp
       ../../viam/sdk/module/service.hpp
+      ../../viam/sdk/module/signal_manager.hpp
       ../../viam/sdk/referenceframe/frame.hpp
       ../../viam/sdk/registry/registry.hpp
       ../../viam/sdk/resource/resource.hpp

--- a/src/viam/sdk/module/handler_map.cpp
+++ b/src/viam/sdk/module/handler_map.cpp
@@ -71,9 +71,9 @@ void HandlerMap_::add_model(Model model, RPCSubtype subtype) {
 
 std::ostream& operator<<(std::ostream& os, const HandlerMap_& hm) {
     for (const auto& kv : hm.handles_) {
-        os << "API: " << kv.first.api().to_string() << std::endl;
+        os << "API: " << kv.first.api().to_string() << '\n';
         for (const Model& model : kv.second) {
-            os << "\tModel: " << model.to_string() << std::endl;
+            os << "\tModel: " << model.to_string() << '\n';
         }
     }
     return os;

--- a/src/viam/sdk/module/handler_map.cpp
+++ b/src/viam/sdk/module/handler_map.cpp
@@ -69,5 +69,15 @@ void HandlerMap_::add_model(Model model, RPCSubtype subtype) {
     handles_[subtype].push_back(model);
 }
 
+std::ostream& operator<<(std::ostream& os, const HandlerMap_& hm) {
+    for (const auto& kv : hm.handles_) {
+        os << "API: " << kv.first.api().to_string() << std::endl;
+        for (const Model& model : kv.second) {
+            os << "\tModel: " << model.to_string() << std::endl;
+        }
+    }
+    return os;
+}
+
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/module/handler_map.hpp
+++ b/src/viam/sdk/module/handler_map.hpp
@@ -14,6 +14,7 @@ class HandlerMap_ {
 
     viam::module::v1::HandlerMap to_proto() const;
     static const HandlerMap_ from_proto(viam::module::v1::HandlerMap proto);
+    friend std::ostream& operator<<(std::ostream& os, const HandlerMap_& hm);
 
    private:
     std::unordered_map<RPCSubtype, std::vector<Model>> handles_;

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -213,11 +213,10 @@ std::shared_ptr<Resource> ModuleService::get_parent_resource(Name name) {
     return grpc::Status();
 };
 
-ModuleService::ModuleService(std::string addr) {
-    module_ = std::make_shared<Module>(addr);
-    server_ = std::make_shared<Server>();
-    signal_manager_ = std::make_shared<SignalManager>();
-}
+ModuleService::ModuleService(std::string addr)
+    : module_(std::make_shared<Module>(std::move(addr))),
+      server_(std::make_shared<Server>()),
+      signal_manager_(std::make_unique<SignalManager>()) {}
 
 ModuleService::ModuleService(int argc,
                              char** argv,
@@ -227,7 +226,7 @@ ModuleService::ModuleService(int argc,
     }
     module_ = std::make_shared<Module>(argv[1]);
     server_ = std::make_shared<Server>();
-    signal_manager_ = std::make_shared<SignalManager>();
+    signal_manager_ = std::make_unique<SignalManager>();
     set_logger_severity_from_args(argc, argv);
 
     for (const std::shared_ptr<ModelRegistration>& mr : registrations) {

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -249,9 +249,8 @@ void ModuleService::serve() {
     module_->set_ready();
     server_->start();
 
-    BOOST_LOG_TRIVIAL(info) << "Module " << module_->name() << " listening on " << module_->addr();
-    BOOST_LOG_TRIVIAL(info) << "Module " << module_->name()
-                            << " handles the following API/model pairs: " << std::endl
+    BOOST_LOG_TRIVIAL(info) << "Module listening on " << module_->addr();
+    BOOST_LOG_TRIVIAL(info) << "Module handles the following API/model pairs: " << std::endl
                             << module_->handles();
 
     int sig = 0;

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -257,9 +257,9 @@ void ModuleService::serve() {
 }
 
 ModuleService::~ModuleService() {
+    // TODO(RSDK-5509): Run registered cleanup functions here.
     BOOST_LOG_TRIVIAL(info) << "Shutting down gracefully.";
     server_->shutdown();
-    // TODO(benji): custom cleanup functions
 
     if (parent_) {
         try {

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -237,7 +237,6 @@ ModuleService::ModuleService(int argc,
 }
 
 void ModuleService::serve() {
-    const std::lock_guard<std::mutex> lock(lock_);
     const mode_t old_mask = umask(0077);
     const int sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
     listen(sockfd, 10);
@@ -248,9 +247,12 @@ void ModuleService::serve() {
     server_->add_listening_port(address);
 
     module_->set_ready();
+    server_->start();
 
-    BOOST_LOG_TRIVIAL(info) << "Module listening on " << module_->addr();
-    // TODO(benji): debug log the module handler map.
+    BOOST_LOG_TRIVIAL(info) << "Module " << module_->name() << " listening on " << module_->addr();
+    BOOST_LOG_TRIVIAL(info) << "Module " << module_->name()
+                            << " handles the following API/model pairs: " << std::endl
+                            << module_->handles();
 
     int sig = 0;
     signal_manager_->wait(&sig);

--- a/src/viam/sdk/module/service.hpp
+++ b/src/viam/sdk/module/service.hpp
@@ -45,15 +45,15 @@ class ModuleService : public viam::module::v1::ModuleService::Service {
                            std::vector<std::shared_ptr<ModelRegistration>> registrations);
     ~ModuleService();
 
-    /// @brief Starts module. If module was constructed with a vector of ModelRegistration,
-    /// serve will return when SIGINT or SIGTERM is received (this happens when the RDK
-    /// shuts down).
+    /// @brief Starts module. serve will return when SIGINT or SIGTERM is received
+    /// (this happens when the RDK shuts down).
     void serve();
     /// @brief Adds an API to the module that has already been registered.
     /// @param api The API to add.
     void add_api_from_registry(API api);
     /// @brief Adds an API/model pair to the module; both the API and model should have
-    /// already been registered.
+    /// already been registered. If the ModuleService was constructed with a vector
+    /// of ModelRegistration, the passed in models will already be registered and added.
     /// @param api The API to add.
     /// @param model The model to add.
     void add_model_from_registry(API api, Model model);

--- a/src/viam/sdk/module/service.hpp
+++ b/src/viam/sdk/module/service.hpp
@@ -82,7 +82,7 @@ class ModuleService : viam::module::v1::ModuleService::Service {
     std::shared_ptr<Resource> get_parent_resource_(Name name);
 
     std::mutex lock_;
-    std::shared_ptr<Module> module_;
+    std::unique_ptr<Module> module_;
     std::shared_ptr<RobotClient> parent_;
     std::string parent_addr_;
     std::shared_ptr<Server> server_;

--- a/src/viam/sdk/module/service.hpp
+++ b/src/viam/sdk/module/service.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "viam/sdk/registry/registry.hpp"
 #include <signal.h>
 
 #include <viam/api/component/generic/v1/generic.grpc.pb.h>
@@ -12,14 +13,52 @@
 namespace viam {
 namespace sdk {
 
-class ModuleService_ : public viam::module::v1::ModuleService::Service {
-   public:
-    void start(std::shared_ptr<Server> server);
-    void close();
-    std::shared_ptr<Resource> get_parent_resource(Name name);
+/// @defgroup Module Classes related to C++ module development.
 
-    void add_api_from_registry(std::shared_ptr<Server> server, API api);
-    void add_model_from_registry(std::shared_ptr<Server> server, API api, Model model);
+/// @class SignalManager
+/// @brief Defines handling logic for SIGINT and SIGTERM required by all C++
+/// modules.
+/// @ingroup Module
+class SignalManager {
+   public:
+    explicit SignalManager();
+
+    /// @brief Wait for SignalManager to receive SIGINT or SIGTERM.
+    /// @param sig Location reference where the signal number is stored.
+    /// @return The signal number if successful, -1 if not.
+    int wait(int* sig);
+
+   private:
+    sigset_t sigset_;
+};
+
+/// @class ModuleService
+/// @brief Defines the gRPC receiving logic for a module. C++ module authors
+/// can construct a ModuleService and use its associated methods to write
+/// a working C++ module. See examples under `src/viam/examples/modules`.
+/// @ingroup Module
+class ModuleService : public viam::module::v1::ModuleService::Service {
+   public:
+    explicit ModuleService(std::string addr);
+    explicit ModuleService(int argc,
+                           char** argv,
+                           std::vector<std::shared_ptr<ModelRegistration>> registrations);
+    ~ModuleService();
+
+    /// @brief Starts module. If module was constructed with a vector of ModelRegistration,
+    /// serve will return when SIGINT or SIGTERM is received (this happens when the RDK
+    /// shuts down).
+    void serve();
+    /// @brief Adds an API to the module that has already been registered.
+    /// @param api The API to add.
+    void add_api_from_registry(API api);
+    /// @brief Adds an API/model pair to the module; both the API and model should have
+    /// already been registered.
+    /// @param api The API to add.
+    /// @param model The model to add.
+    void add_model_from_registry(API api, Model model);
+
+   private:
     ::grpc::Status AddResource(::grpc::ServerContext* context,
                                const ::viam::module::v1::AddResourceRequest* request,
                                ::viam::module::v1::AddResourceResponse* response) override;
@@ -41,36 +80,18 @@ class ModuleService_ : public viam::module::v1::ModuleService::Service {
                                   const ::viam::module::v1::ValidateConfigRequest* request,
                                   ::viam::module::v1::ValidateConfigResponse* response) override;
 
-    ModuleService_(std::string addr);
-    ~ModuleService_();
+    void add_model_from_registry_inlock_(API api, Model model, const std::lock_guard<std::mutex>&);
+    void add_api_from_registry_inlock_(API api, const std::lock_guard<std::mutex>& lock);
+    Dependencies get_dependencies(google::protobuf::RepeatedPtrField<std::string> const& proto,
+                                  std::string const& resource_name);
+    std::shared_ptr<Resource> get_parent_resource(Name name);
 
-   private:
-    void add_model_from_registry_inlock_(std::shared_ptr<Server> server,
-                                         API api,
-                                         Model model,
-                                         const std::lock_guard<std::mutex>&);
-    void add_api_from_registry_inlock_(std::shared_ptr<Server> server,
-                                       API api,
-                                       const std::lock_guard<std::mutex>& lock);
     std::mutex lock_;
     std::shared_ptr<Module> module_;
     std::shared_ptr<RobotClient> parent_;
     std::string parent_addr_;
-};
-
-// C++ modules must handle SIGINT and SIGTERM. Make sure to create a sigset
-// for SIGINT and SIGTERM that can be later awaited in a thread that cleanly
-// shuts down your module. pthread_sigmask should be called near the start of
-// main so that later threads inherit the mask. SignalManager can handle the
-// boilerplate of this functionality.
-class SignalManager {
-   public:
-    SignalManager();
-    // wait on sigset
-    int wait(int* sig);
-
-   private:
-    sigset_t sigset;
+    std::shared_ptr<Server> server_;
+    std::shared_ptr<SignalManager> signal_manager_;
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/module/service.hpp
+++ b/src/viam/sdk/module/service.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "viam/sdk/registry/registry.hpp"
 #include <signal.h>
 
 #include <viam/api/component/generic/v1/generic.grpc.pb.h>
 #include <viam/api/module/v1/module.grpc.pb.h>
 
 #include <viam/sdk/module/module.hpp>
+#include <viam/sdk/registry/registry.hpp>
 #include <viam/sdk/resource/resource.hpp>
 #include <viam/sdk/rpc/server.hpp>
 
@@ -91,7 +91,7 @@ class ModuleService : public viam::module::v1::ModuleService::Service {
     std::shared_ptr<RobotClient> parent_;
     std::string parent_addr_;
     std::shared_ptr<Server> server_;
-    std::shared_ptr<SignalManager> signal_manager_;
+    std::unique_ptr<SignalManager> signal_manager_;
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/module/signal_manager.cpp
+++ b/src/viam/sdk/module/signal_manager.cpp
@@ -1,0 +1,22 @@
+#include <viam/sdk/module/signal_manager.hpp>
+
+#include <csignal>
+#include <pthread.h>
+
+namespace viam {
+namespace sdk {
+
+SignalManager::SignalManager() {
+    sigemptyset(&sigset_);
+    sigaddset(&sigset_, SIGINT);
+    sigaddset(&sigset_, SIGTERM);
+    pthread_sigmask(SIG_BLOCK, &sigset_, NULL);
+}
+
+int SignalManager::wait() {
+    int sig = 0;
+    return sigwait(&sigset_, &sig);
+}
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/module/signal_manager.hpp
+++ b/src/viam/sdk/module/signal_manager.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <signal.h>
+
+namespace viam {
+namespace sdk {
+
+/// @class SignalManager
+/// @brief Defines handling logic for SIGINT and SIGTERM required by all C++
+/// modules.
+/// @ingroup Module
+class SignalManager {
+   public:
+    /// @brief Creates a new SignalManager.
+    explicit SignalManager();
+
+    /// @brief Wait for SignalManager to receive SIGINT or SIGTERM.
+    /// @return The signal number if successful.
+    /// @throws runtime_error if the underlying sigwait call was unsuccessful.
+    int wait();
+
+   private:
+    sigset_t sigset_;
+};
+
+}  // namespace sdk
+}  // namespace viam


### PR DESCRIPTION
[RSDK-4844](https://viam.atlassian.net/browse/RSDK-4844)

- Renames `ModuleService_` to `ModuleService`
- Adds a `std::shared_ptr<Server> server_` field to `ModuleService`
   -  `ModuleService::server_` is created (not started) in the constructor
   -  `ModuleService::server_` is shutdown in the `ModuleService` destructor
 - Removes `std::shared_ptr<Server>` param from `add_model_from_registry` and `add_api_from_registry` 
 - Adds a `SignalManager signal_manager_` field to `ModuleService`
 - Changes the `ModuleService::start(std::shared_ptr<Server>)` method to `ModuleService::serve()` and alters its behavior
   - `serve` runs the `ModuleService::server_` until the `ModuleService::signal_manager_` finishes waiting
   - `serve` logs API/model pairs the module handles
 - Creates a new "boilerplate" overloaded `ModuleService` constructor `ModuleService(int argc, char** argv, std::vector<std::shared_ptr<ModelRegistration>>)`
   - Validates the socket path is present in `argv` and sets it on the class 
   - Sets global boost logger severity based on presence of the `--log-level` flag in `argv`
   - Registers the passed in `ModelRegistration` classes' models (not APIs)
   - Adds models and custom APIs from registry to `ModuleService`
 - Adds doc comments to `SignalManager` and `ModuleService` and makes more methods private

[RSDK-4844]: https://viam.atlassian.net/browse/RSDK-4844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ