### PR TITLE
RSDK-5881 Add Stoppable class

### DIFF
--- a/src/viam/examples/modules/complex/gizmo/api.cpp
+++ b/src/viam/examples/modules/complex/gizmo/api.cpp
@@ -296,8 +296,6 @@ std::vector<bool> GizmoClient::do_one_bidi_stream(std::vector<std::string> arg1)
     return rets;
 }
 
-void GizmoClient::stop(const AttributeMap& extra) {}
-
 std::string GizmoClient::do_two(bool arg1) {
     DoTwoRequest request;
     DoTwoResponse response;

--- a/src/viam/examples/modules/complex/gizmo/api.hpp
+++ b/src/viam/examples/modules/complex/gizmo/api.hpp
@@ -54,7 +54,6 @@ class GizmoClient : public Gizmo {
     std::vector<bool> do_one_server_stream(std::string arg1) override;
     std::vector<bool> do_one_bidi_stream(std::vector<std::string> arg1) override;
     std::string do_two(bool arg1) override;
-    void stop(const AttributeMap& extra) override;
 
    private:
     std::unique_ptr<GizmoService::StubInterface> stub_;

--- a/src/viam/examples/modules/complex/proto/buf.lock
+++ b/src/viam/examples/modules/complex/proto/buf.lock
@@ -4,5 +4,5 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 28151c0d0a1641bf938a7672c500e01d
-    digest: shake256:49215edf8ef57f7863004539deff8834cfb2195113f0b890dd1f67815d9353e28e668019165b9d872395871eeafcbab3ccfdb2b5f11734d3cca95be9e8d139de
+    commit: b30c5775bfb3485d9da2e87b26590ac9
+    digest: shake256:9d0caaf056949a0e1c883b9849d8a2fa66e22f18a2a48f867d1a8c700aa22abee50ad3ef0d8171637457cadc43c584998bdf3adac55da0f9e4614c72686b057d

--- a/src/viam/examples/modules/complex/summation/api.cpp
+++ b/src/viam/examples/modules/complex/summation/api.cpp
@@ -111,5 +111,3 @@ double SummationClient::sum(std::vector<double> numbers) {
 
     return response.sum();
 }
-
-void SummationClient::stop(const AttributeMap& extra) {}

--- a/src/viam/examples/modules/complex/summation/api.hpp
+++ b/src/viam/examples/modules/complex/summation/api.hpp
@@ -49,7 +49,6 @@ class SummationClient : public Summation {
     SummationClient(std::string name, std::shared_ptr<grpc::Channel> channel);
 
     double sum(std::vector<double> numbers) override;
-    void stop(const AttributeMap& extra) override;
 
    private:
     std::unique_ptr<SummationService::StubInterface> stub_;

--- a/src/viam/examples/modules/tflite/main.cpp
+++ b/src/viam/examples/modules/tflite/main.cpp
@@ -71,19 +71,16 @@ class MLModelServiceTFLite : public vsdk::MLModelService {
         // here. It should be safe to tear down all state
         // automatically without needing to wait for anything more to
         // drain.
+        close();
     }
 
-    void stop(const vsdk::AttributeMap& extra) noexcept final {
-        return stop();
-    }
-
-    /// @brief Stops a resource from running.
-    void stop() noexcept {
+    /// @brief Closes the service.
+    void close() noexcept {
         using std::swap;
         try {
             std::lock_guard<std::mutex> lock(state_lock_);
-            if (!stopped_) {
-                stopped_ = true;
+            if (!closed_) {
+                closed_ = true;
                 std::shared_ptr<state> state;
                 swap(state_, state);
                 state_ready_.notify_all();
@@ -101,7 +98,7 @@ class MLModelServiceTFLite : public vsdk::MLModelService {
         // current state while a new configuration is built, then swap
         // in the new state. State which is in use by existing
         // invocations will remain valid until the clients drain. If
-        // reconfiguration fails, the component will `stop`.
+        // reconfiguration fails, the component will `close`.
 
         // Swap out the state_ member with nullptr. Existing
         // invocations will continue to operate against the state they
@@ -115,8 +112,8 @@ class MLModelServiceTFLite : public vsdk::MLModelService {
             // reconfigurations and so other invocations wait on a new
             // state.
             std::unique_lock<std::mutex> lock(state_lock_);
-            state_ready_.wait(lock, [this]() { return (state_ != nullptr) && !stopped_; });
-            check_stopped_inlock_();
+            state_ready_.wait(lock, [this]() { return (state_ != nullptr) && !closed_; });
+            check_closed_inlock_();
             swap(state_, state);
         }
 
@@ -127,13 +124,13 @@ class MLModelServiceTFLite : public vsdk::MLModelService {
         // reconfiguration to complete.
         {
             std::lock_guard<std::mutex> lock(state_lock_);
-            check_stopped_inlock_();
+            check_closed_inlock_();
             swap(state_, state);
         }
         state_ready_.notify_all();
     } catch (...) {
-        // If reconfiguration fails for any reason, become stopped and rethrow.
-        stop();
+        // If reconfiguration fails for any reason, become closed and rethrow.
+        close();
         throw;
     }
 
@@ -254,24 +251,24 @@ class MLModelServiceTFLite : public vsdk::MLModelService {
    private:
     struct state;
 
-    void check_stopped_inlock_() const {
-        if (stopped_) {
+    void check_closed_inlock_() const {
+        if (closed_) {
             std::ostringstream buffer;
-            buffer << service_name << ": service is stopped: ";
+            buffer << service_name << ": service is closed: ";
             throw std::runtime_error(buffer.str());
         }
     }
 
     std::shared_ptr<state> lease_state_() {
-        // Wait for our state to be valid or stopped and then obtain a
+        // Wait for our state to be valid or closed and then obtain a
         // shared_ptr to state if valid, incrementing the refcount, or
-        // throws if the service is stopped. We don't need to deal
+        // throws if the service is closed. We don't need to deal
         // with interruption or shutdown because the gRPC layer will
         // drain requests during shutdown, so it shouldn't be possible
         // for callers to get stuck here.
         std::unique_lock<std::mutex> lock(state_lock_);
-        state_ready_.wait(lock, [this]() { return (state_ != nullptr) && !stopped_; });
-        check_stopped_inlock_();
+        state_ready_.wait(lock, [this]() { return (state_ != nullptr) && !closed_; });
+        check_closed_inlock_();
         return state_;
     }
 
@@ -718,7 +715,7 @@ class MLModelServiceTFLite : public vsdk::MLModelService {
     std::mutex state_lock_;
     std::condition_variable state_ready_;
     std::shared_ptr<state> state_;
-    bool stopped_ = false;
+    bool closed_ = false;
 };
 
 int serve(const std::string& socket_path) try {

--- a/src/viam/examples/modules/tflite/main.cpp
+++ b/src/viam/examples/modules/tflite/main.cpp
@@ -73,7 +73,7 @@ class MLModelServiceTFLite : public vsdk::MLModelService {
         // drain.
     }
 
-    void stop(const vsdk::AttributeMap& extra) noexcept final override {
+    void stop(const vsdk::AttributeMap& extra) noexcept final {
         return stop();
     }
 

--- a/src/viam/examples/modules/tflite/main.cpp
+++ b/src/viam/examples/modules/tflite/main.cpp
@@ -73,7 +73,7 @@ class MLModelServiceTFLite : public vsdk::MLModelService {
         // drain.
     }
 
-    void stop(const vsdk::AttributeMap& extra) noexcept final {
+    void stop(const vsdk::AttributeMap& extra) noexcept final override {
         return stop();
     }
 

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -87,6 +87,7 @@ target_sources(viamsdk
     resource/resource_api.cpp
     resource/resource_manager.cpp
     resource/resource_server_base.cpp
+    resource/stoppable.cpp
     robot/client.cpp
     robot/service.cpp
     rpc/dial.cpp
@@ -151,6 +152,7 @@ target_sources(viamsdk
       ../../viam/sdk/resource/resource_api.hpp
       ../../viam/sdk/resource/resource_manager.hpp
       ../../viam/sdk/resource/resource_server_base.hpp
+      ../../viam/sdk/resource/stoppable.hpp
       ../../viam/sdk/robot/client.hpp
       ../../viam/sdk/robot/service.hpp
       ../../viam/sdk/rpc/dial.hpp

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -37,7 +37,7 @@ class BaseRegistration : public ResourceRegistration {
 ///
 /// This acts as an abstract parent class to be inherited from by any drivers representing
 /// specific base implementations. This class cannot be used on its own.
-class Base : public Component {
+class Base : public Component, public Stoppable {
    public:
     /// @struct properties
     /// @brief Information about the physical base

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -13,6 +13,7 @@
 #include <viam/sdk/config/resource.hpp>
 #include <viam/sdk/registry/registry.hpp>
 #include <viam/sdk/resource/resource_manager.hpp>
+#include <viam/sdk/resource/stoppable.hpp>
 
 namespace viam {
 namespace sdk {

--- a/src/viam/sdk/components/board/client.cpp
+++ b/src/viam/sdk/components/board/client.cpp
@@ -56,8 +56,6 @@ void BoardClient::set_gpio(const std::string& pin, bool high, const AttributeMap
     }
 }
 
-void BoardClient::stop(const AttributeMap& extra) {}
-
 bool BoardClient::get_gpio(const std::string& pin, const AttributeMap& extra) {
     viam::component::board::v1::GetGPIORequest request;
     viam::component::board::v1::GetGPIOResponse response;

--- a/src/viam/sdk/components/board/client.hpp
+++ b/src/viam/sdk/components/board/client.hpp
@@ -21,7 +21,6 @@ namespace sdk {
 class BoardClient : public Board {
    public:
     BoardClient(std::string name, std::shared_ptr<grpc::Channel> channel);
-    void stop(const AttributeMap& extra) override;
     AttributeMap do_command(const AttributeMap& command) override;
     status get_status(const AttributeMap& extra) override;
     void set_gpio(const std::string& pin, bool high, const AttributeMap& extra) override;

--- a/src/viam/sdk/components/camera/client.cpp
+++ b/src/viam/sdk/components/camera/client.cpp
@@ -102,7 +102,5 @@ Camera::properties CameraClient::get_properties() {
     return from_proto(resp);
 };
 
-void CameraClient::stop(const AttributeMap& extra) {}
-
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/camera/client.hpp
+++ b/src/viam/sdk/components/camera/client.hpp
@@ -21,7 +21,6 @@ namespace sdk {
 /// @ingroup Camera
 class CameraClient : public Camera {
    public:
-    void stop(const AttributeMap& extra) override;
     CameraClient(std::string name, std::shared_ptr<grpc::Channel> channel);
     AttributeMap do_command(AttributeMap command) override;
     raw_image get_image(std::string mime_type, const AttributeMap& extra) override;

--- a/src/viam/sdk/components/encoder/client.cpp
+++ b/src/viam/sdk/components/encoder/client.cpp
@@ -105,7 +105,5 @@ AttributeMap EncoderClient::do_command(AttributeMap command) {
     return struct_to_map(response.result());
 }
 
-void EncoderClient::stop(const AttributeMap& extra) {}
-
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/encoder/client.hpp
+++ b/src/viam/sdk/components/encoder/client.hpp
@@ -21,7 +21,6 @@ namespace sdk {
 class EncoderClient : public Encoder {
    public:
     EncoderClient(std::string name, std::shared_ptr<grpc::Channel> channel);
-    void stop(const AttributeMap& extra) override;
     position get_position(const AttributeMap& extra, position_type position_type) override;
     void reset_position(const AttributeMap& extra) override;
     properties get_properties(const AttributeMap& extra) override;

--- a/src/viam/sdk/components/generic/client.cpp
+++ b/src/viam/sdk/components/generic/client.cpp
@@ -31,8 +31,6 @@ AttributeMap GenericClient::do_command(AttributeMap command) {
     return struct_to_map(resp.result());
 }
 
-void GenericClient::stop(const AttributeMap& extra) {}
-
 std::vector<GeometryConfig> GenericClient::get_geometries() {
     viam::common::v1::GetGeometriesRequest req;
     viam::common::v1::GetGeometriesResponse resp;

--- a/src/viam/sdk/components/generic/client.hpp
+++ b/src/viam/sdk/components/generic/client.hpp
@@ -18,7 +18,6 @@ namespace sdk {
 /// @ingroup Generic
 class GenericClient : public Generic {
    public:
-    void stop(const AttributeMap& extra) override;
     GenericClient(std::string name, std::shared_ptr<grpc::Channel> channel);
     AttributeMap do_command(AttributeMap command) override;
     std::vector<GeometryConfig> get_geometries() override;

--- a/src/viam/sdk/components/motor/motor.hpp
+++ b/src/viam/sdk/components/motor/motor.hpp
@@ -36,7 +36,7 @@ class MotorRegistration : public ResourceRegistration {
 ///
 /// This acts as an abstract base class to be inherited from by any drivers representing
 /// specific motor implementations. This class cannot be used on its own.
-class Motor : public Component {
+class Motor : public Component, public Stoppable {
    public:
     /// @struct position
     /// @brief Current position of the motor relative to its home

--- a/src/viam/sdk/components/motor/motor.hpp
+++ b/src/viam/sdk/components/motor/motor.hpp
@@ -12,6 +12,7 @@
 #include <viam/sdk/config/resource.hpp>
 #include <viam/sdk/registry/registry.hpp>
 #include <viam/sdk/resource/resource_manager.hpp>
+#include <viam/sdk/resource/stoppable.hpp>
 
 namespace viam {
 namespace sdk {

--- a/src/viam/sdk/components/movement_sensor/client.cpp
+++ b/src/viam/sdk/components/movement_sensor/client.cpp
@@ -94,7 +94,5 @@ std::vector<GeometryConfig> MovementSensorClient::get_geometries(const Attribute
         .invoke([](auto& response) { return GeometryConfig::from_proto(response); });
 }
 
-void MovementSensorClient::stop(const AttributeMap& extra) {}
-
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/movement_sensor/client.hpp
+++ b/src/viam/sdk/components/movement_sensor/client.hpp
@@ -22,7 +22,6 @@ namespace sdk {
 class MovementSensorClient : public MovementSensor {
    public:
     MovementSensorClient(std::string name, std::shared_ptr<grpc::Channel> channel);
-    void stop(const AttributeMap& extra) override;
     Vector3 get_linear_velocity(const AttributeMap& extra) override;
     Vector3 get_angular_velocity(const AttributeMap& extra) override;
     compassheading get_compass_heading(const AttributeMap& extra) override;

--- a/src/viam/sdk/components/power_sensor/client.cpp
+++ b/src/viam/sdk/components/power_sensor/client.cpp
@@ -62,7 +62,5 @@ AttributeMap PowerSensorClient::do_command(const AttributeMap& command) {
         .invoke([](auto& response) { return struct_to_map(response.result()); });
 }
 
-void PowerSensorClient::stop(const AttributeMap& extra) {}
-
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/power_sensor/client.hpp
+++ b/src/viam/sdk/components/power_sensor/client.hpp
@@ -20,7 +20,6 @@ namespace sdk {
 /// @ingroup PowerSensor
 class PowerSensorClient : public PowerSensor {
    public:
-    void stop(const AttributeMap& extra) override;
     PowerSensorClient(std::string name, std::shared_ptr<grpc::Channel> channel);
     voltage get_voltage(const AttributeMap& extra) override;
     current get_current(const AttributeMap& extra) override;

--- a/src/viam/sdk/components/sensor/client.cpp
+++ b/src/viam/sdk/components/sensor/client.cpp
@@ -49,7 +49,5 @@ std::vector<GeometryConfig> SensorClient::get_geometries(const AttributeMap& ext
         .invoke([](auto& response) { return GeometryConfig::from_proto(response); });
 }
 
-void SensorClient::stop(const AttributeMap& extra) {}
-
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/sensor/client.hpp
+++ b/src/viam/sdk/components/sensor/client.hpp
@@ -19,7 +19,6 @@ namespace sdk {
 /// @ingroup Sensor
 class SensorClient : public Sensor {
    public:
-    void stop(const AttributeMap& extra) override;
     SensorClient(std::string name, std::shared_ptr<grpc::Channel> channel);
     AttributeMap get_readings(const AttributeMap& extra) override;
     AttributeMap do_command(const AttributeMap& command) override;

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -133,7 +133,7 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
 
     // if the type isn't reconfigurable by default, replace it
     try {
-        res->stop();
+        stop_resource_if_stoppable(res);
     } catch (const std::exception& err) {
         BOOST_LOG_TRIVIAL(error) << "unable to stop resource: " << err.what();
     }
@@ -194,7 +194,7 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
     }
 
     try {
-        res->stop();
+        stop_resource_if_stoppable(res);
     } catch (const std::exception& err) {
         BOOST_LOG_TRIVIAL(error) << "unable to stop resource: " << err.what();
     }

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -37,6 +37,7 @@
 #include <viam/sdk/resource/resource.hpp>
 #include <viam/sdk/resource/resource_api.hpp>
 #include <viam/sdk/resource/resource_manager.hpp>
+#include <viam/sdk/resource/stoppable.hpp>
 #include <viam/sdk/robot/client.hpp>
 #include <viam/sdk/robot/service.hpp>
 #include <viam/sdk/rpc/server.hpp>
@@ -133,7 +134,7 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
 
     // if the type isn't reconfigurable by default, replace it
     try {
-        stop_resource_if_stoppable(res);
+        Stoppable::stop_if_stoppable(res);
     } catch (const std::exception& err) {
         BOOST_LOG_TRIVIAL(error) << "unable to stop resource: " << err.what();
     }
@@ -194,7 +195,7 @@ std::shared_ptr<Resource> ModuleService_::get_parent_resource(Name name) {
     }
 
     try {
-        stop_resource_if_stoppable(res);
+        Stoppable::stop_if_stoppable(res);
     } catch (const std::exception& err) {
         BOOST_LOG_TRIVIAL(error) << "unable to stop resource: " << err.what();
     }

--- a/src/viam/sdk/resource/resource.cpp
+++ b/src/viam/sdk/resource/resource.cpp
@@ -13,6 +13,7 @@ namespace viam {
 namespace sdk {
 
 Resource::~Resource() = default;
+Resource::Resource(std::string name) : name_(std::move(name)) {}
 
 std::string Resource::name() const {
     return name_;
@@ -32,13 +33,6 @@ ResourceName Resource::get_resource_name(std::string name) {
     *r.mutable_name() = std::move(name);
 
     return r;
-}
-
-void stop_resource_if_stoppable(std::shared_ptr<Resource> resource) {
-    auto stoppable_res = std::dynamic_pointer_cast<Stoppable>(resource);
-    if (stoppable_res != NULL) {
-        stoppable_res->stop();
-    }
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/resource/resource.cpp
+++ b/src/viam/sdk/resource/resource.cpp
@@ -34,5 +34,12 @@ ResourceName Resource::get_resource_name(std::string name) {
     return r;
 }
 
+void stop_resource_if_stoppable(std::shared_ptr<Resource> resource) {
+    auto stoppable_res = std::dynamic_pointer_cast<Stoppable>(resource);
+    if (stoppable_res != NULL) {
+        stoppable_res->stop();
+    }
+}
+
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/resource/resource.hpp
+++ b/src/viam/sdk/resource/resource.hpp
@@ -17,7 +17,7 @@ using Dependencies = std::unordered_map<Name, std::shared_ptr<Resource>>;
 class Resource {
    public:
     virtual ~Resource();
-    explicit Resource(std::string name) : name_(std::move(name)){};
+    explicit Resource(std::string name);
     static API static_api();
 
     /// @brief Returns the `API` associated with a particular resource.
@@ -37,22 +37,6 @@ class Resource {
    private:
     std::string name_;
 };
-
-class Stoppable {
-   public:
-    /// @brief Stops a resource from running.
-    /// @param extra Extra arguments to pass to the resource's `stop` method.
-    virtual void stop(const AttributeMap& extra) = 0;
-
-    /// @brief Stops a resource from running.
-    inline void stop() {
-        return stop({});
-    }
-};
-
-/// @brief Stops a Resource if it is Stoppable.
-/// @param resource The Resource to stop.
-void stop_resource_if_stoppable(std::shared_ptr<Resource> resource);
 
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/resource/resource.hpp
+++ b/src/viam/sdk/resource/resource.hpp
@@ -26,15 +26,6 @@ class Resource {
     /// @brief Returns a `ResourceName` for a particular resource name.
     virtual viam::common::v1::ResourceName get_resource_name(std::string name);
 
-    /// @brief Stops a resource from running.
-    /// @param extra Extra arguments to pass to the resource's `stop` method.
-    virtual void stop(const AttributeMap& extra) = 0;
-
-    /// @brief Stops a resource from running.
-    inline void stop() {
-        return stop({});
-    }
-
     /// @brief Reconfigures a resource.
     /// @param deps Dependencies of the resource.
     /// @param cfg The resource's config.
@@ -46,6 +37,22 @@ class Resource {
    private:
     std::string name_;
 };
+
+class Stoppable {
+   public:
+    /// @brief Stops a resource from running.
+    /// @param extra Extra arguments to pass to the resource's `stop` method.
+    virtual void stop(const AttributeMap& extra) = 0;
+
+    /// @brief Stops a resource from running.
+    inline void stop() {
+        return stop({});
+    }
+};
+
+/// @brief Stops a Resource if it is Stoppable.
+/// @param resource The Resource to stop.
+void stop_resource_if_stoppable(std::shared_ptr<Resource> resource);
 
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/resource/stoppable.cpp
+++ b/src/viam/sdk/resource/stoppable.cpp
@@ -1,0 +1,18 @@
+#include <viam/sdk/resource/stoppable.hpp>
+
+namespace viam {
+namespace sdk {
+
+Stoppable::~Stoppable() = default;
+Stoppable::Stoppable() = default;
+
+void Stoppable::stop_if_stoppable(const std::shared_ptr<Resource>& resource,
+                                  const AttributeMap& extra) {
+    auto stoppable_res = std::dynamic_pointer_cast<Stoppable>(resource);
+    if (stoppable_res) {
+        stoppable_res->stop(extra);
+    }
+}
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/resource/stoppable.hpp
+++ b/src/viam/sdk/resource/stoppable.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <viam/sdk/common/utils.hpp>
+
+namespace viam {
+namespace sdk {
+
+class Stoppable {
+   public:
+    virtual ~Stoppable();
+    /// @brief Stops a resource from running.
+    /// @param extra Extra arguments to pass to the resource's `stop` method.
+    virtual void stop(const AttributeMap& extra) = 0;
+
+    /// @brief Stops a resource from running.
+    inline void stop() {
+        return stop({});
+    }
+
+    /// @brief Stops a Resource if it is Stoppable.
+    /// @param resource The Resource to stop.
+    /// @param extra Extra arguments to pass to the resource's `stop` method.
+    static void stop_if_stoppable(const std::shared_ptr<Resource>& resource,
+                                  const AttributeMap& extra);
+
+    /// @brief Stops a Resource if it is Stoppable.
+    /// @param resource The Resource to stop.
+    inline static void stop_if_stoppable(const std::shared_ptr<Resource>& resource) {
+        return stop_if_stoppable(resource, {});
+    }
+
+   protected:
+    explicit Stoppable();
+};
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/robot/service.cpp
+++ b/src/viam/sdk/robot/service.cpp
@@ -164,11 +164,11 @@ void RobotService_::stream_status(
         const std::string rn_ = rn.SerializeAsString();
         if (extra.find(rn_) != extra.end()) {
             try {
-                resource->stop(extra.at(rn_));
+                stop_resource_if_stoppable(resource);
             } catch (const std::runtime_error& err) {
                 try {
                     status_message = err.what();
-                    resource->stop();
+                    stop_resource_if_stoppable(resource);
                 } catch (std::runtime_error& err) {
                     status_message = err.what();
                     status = grpc::UNKNOWN;
@@ -179,7 +179,7 @@ void RobotService_::stream_status(
             }
         } else {
             try {
-                resource->stop();
+                stop_resource_if_stoppable(resource);
             } catch (std::runtime_error& err) {
                 status_message = err.what();
                 status = grpc::UNKNOWN;

--- a/src/viam/sdk/robot/service.cpp
+++ b/src/viam/sdk/robot/service.cpp
@@ -19,6 +19,7 @@
 #include <viam/sdk/config/resource.hpp>
 #include <viam/sdk/registry/registry.hpp>
 #include <viam/sdk/resource/resource.hpp>
+#include <viam/sdk/resource/stoppable.hpp>
 #include <viam/sdk/robot/client.hpp>
 #include <viam/sdk/services/service.hpp>
 
@@ -164,11 +165,11 @@ void RobotService_::stream_status(
         const std::string rn_ = rn.SerializeAsString();
         if (extra.find(rn_) != extra.end()) {
             try {
-                stop_resource_if_stoppable(resource);
+                Stoppable::stop_if_stoppable(resource, extra.at(rn_));
             } catch (const std::runtime_error& err) {
                 try {
                     status_message = err.what();
-                    stop_resource_if_stoppable(resource);
+                    Stoppable::stop_if_stoppable(resource);
                 } catch (std::runtime_error& err) {
                     status_message = err.what();
                     status = grpc::UNKNOWN;
@@ -179,7 +180,7 @@ void RobotService_::stream_status(
             }
         } else {
             try {
-                stop_resource_if_stoppable(resource);
+                Stoppable::stop_if_stoppable(resource);
             } catch (std::runtime_error& err) {
                 status_message = err.what();
                 status = grpc::UNKNOWN;

--- a/src/viam/sdk/services/mlmodel/client.cpp
+++ b/src/viam/sdk/services/mlmodel/client.cpp
@@ -148,7 +148,5 @@ struct MLModelService::metadata MLModelServiceClient::metadata(const AttributeMa
     return result;
 }
 
-void MLModelServiceClient::stop(const AttributeMap& extra) {}
-
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/services/mlmodel/client.hpp
+++ b/src/viam/sdk/services/mlmodel/client.hpp
@@ -35,7 +35,6 @@ class MLModelServiceClient : public MLModelService {
     std::shared_ptr<named_tensor_views> infer(const named_tensor_views& inputs,
                                               const AttributeMap& extra) override;
     struct metadata metadata(const AttributeMap& extra) override;
-    void stop(const AttributeMap& extra) override;
 
     // the `extra` param is frequently unnecessary but needs to be supported. Ideally, we'd
     // like to live in a world where implementers of derived classes don't need to go out of

--- a/src/viam/sdk/services/mlmodel/mlmodel.hpp
+++ b/src/viam/sdk/services/mlmodel/mlmodel.hpp
@@ -24,7 +24,6 @@
 
 #include <viam/sdk/registry/registry.hpp>
 #include <viam/sdk/resource/resource_manager.hpp>
-#include <viam/sdk/resource/stoppable.hpp>
 #include <viam/sdk/services/service.hpp>
 
 namespace viam {
@@ -48,7 +47,7 @@ class MLModelServiceRegistration : public ResourceRegistration {
 /// This class acts as an abstract base class to be used by any driver
 /// implementing an MLModel. It is also used as the base class for the
 /// gRPC client for communicating with a remote MLModel instance.
-class MLModelService : public Service, public Stoppable {
+class MLModelService : public Service {
    private:
     template <typename T>
     struct make_tensor_view_ {
@@ -180,15 +179,6 @@ class MLModelService : public Service, public Stoppable {
     ///
     /// @param `extra`: Any additional arguments to the method.
     virtual struct metadata metadata(const AttributeMap& extra) = 0;
-
-    /// @brief Stops a resource from running.
-    inline void stop() {
-        return stop({});
-    }
-
-    /// @brief Stops a resource from running.
-    /// @param extra Extra arguments to pass to the resource's `stop` method.
-    void stop(const AttributeMap& extra) override = 0;
 
    protected:
     explicit MLModelService(std::string name);

--- a/src/viam/sdk/services/mlmodel/mlmodel.hpp
+++ b/src/viam/sdk/services/mlmodel/mlmodel.hpp
@@ -47,7 +47,7 @@ class MLModelServiceRegistration : public ResourceRegistration {
 /// This class acts as an abstract base class to be used by any driver
 /// implementing an MLModel. It is also used as the base class for the
 /// gRPC client for communicating with a remote MLModel instance.
-class MLModelService : public Service {
+class MLModelService : public Service, public Stoppable {
    private:
     template <typename T>
     struct make_tensor_view_ {
@@ -179,6 +179,15 @@ class MLModelService : public Service {
     ///
     /// @param `extra`: Any additional arguments to the method.
     virtual struct metadata metadata(const AttributeMap& extra) = 0;
+
+    /// @brief Stops a resource from running.
+    inline void stop() {
+        return stop({});
+    }
+
+    /// @brief Stops a resource from running.
+    /// @param extra Extra arguments to pass to the resource's `stop` method.
+    void stop(const AttributeMap& extra) override = 0;
 
    protected:
     explicit MLModelService(std::string name);

--- a/src/viam/sdk/services/mlmodel/mlmodel.hpp
+++ b/src/viam/sdk/services/mlmodel/mlmodel.hpp
@@ -24,6 +24,7 @@
 
 #include <viam/sdk/registry/registry.hpp>
 #include <viam/sdk/resource/resource_manager.hpp>
+#include <viam/sdk/resource/stoppable.hpp>
 #include <viam/sdk/services/service.hpp>
 
 namespace viam {

--- a/src/viam/sdk/services/motion/client.cpp
+++ b/src/viam/sdk/services/motion/client.cpp
@@ -151,7 +151,5 @@ AttributeMap MotionClient::do_command(const AttributeMap& command) {
     return struct_to_map(response.result());
 }
 
-void MotionClient::stop(const AttributeMap& extra) {}
-
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/services/motion/client.hpp
+++ b/src/viam/sdk/services/motion/client.hpp
@@ -16,7 +16,6 @@ namespace sdk {
 class MotionClient : public Motion {
    public:
     MotionClient(std::string name, std::shared_ptr<grpc::Channel> channel);
-    void stop(const AttributeMap& extra) override;
     bool move(const pose_in_frame& destination,
               const Name& component_name,
               std::shared_ptr<WorldState> world_state,

--- a/src/viam/sdk/tests/mocks/mlmodel_mocks.hpp
+++ b/src/viam/sdk/tests/mocks/mlmodel_mocks.hpp
@@ -32,7 +32,6 @@ class MockMLModelService : public sdk::MLModelService {
     MockMLModelService& set_infer_handler(infer_handler handler);
     std::shared_ptr<named_tensor_views> infer(const named_tensor_views& inputs,
                                               const sdk::AttributeMap& extra) override;
-    void stop(const sdk::AttributeMap& extra) override{};
 
     MockMLModelService& set_metadata(struct metadata metadata);
     struct metadata metadata(const sdk::AttributeMap& extra) override;

--- a/src/viam/sdk/tests/mocks/mlmodel_mocks.hpp
+++ b/src/viam/sdk/tests/mocks/mlmodel_mocks.hpp
@@ -32,6 +32,7 @@ class MockMLModelService : public sdk::MLModelService {
     MockMLModelService& set_infer_handler(infer_handler handler);
     std::shared_ptr<named_tensor_views> infer(const named_tensor_views& inputs,
                                               const sdk::AttributeMap& extra) override;
+    void stop(const sdk::AttributeMap& extra) override{};
 
     MockMLModelService& set_metadata(struct metadata metadata);
     struct metadata metadata(const sdk::AttributeMap& extra) override;


### PR DESCRIPTION
[RSDK-5881](https://viam.atlassian.net/browse/RSDK-5881)

Adds a `Stoppable` class with a purely virtual `stop` method from which stoppable resources should inherit.

[RSDK-5881]: https://viam.atlassian.net/browse/RSDK-5881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ