### PR TITLE
RSDK-5902 - add `set -e` to test bash script

### DIFF
--- a/etc/docker/tests/run_test.sh
+++ b/etc/docker/tests/run_test.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 mkdir build
 cd build
 cmake .. -G Ninja -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON \

--- a/src/viam/sdk/components/base/client.cpp
+++ b/src/viam/sdk/components/base/client.cpp
@@ -5,10 +5,6 @@
 #include <string>
 #include <utility>
 
-#include <google/protobuf/struct.pb.h>
-#include <grpcpp/client_context.h>
-#include <grpcpp/impl/status.h>
-
 #include <viam/api/common/v1/common.pb.h>
 #include <viam/api/component/base/v1/base.grpc.pb.h>
 #include <viam/api/component/base/v1/base.pb.h>


### PR DESCRIPTION
We forgot to add `set -e` to the top of the `run_test.sh` script! This caused the script to not exit early, and because the last command (`popd`) was always succeeding, the test was appearing to pass. This should now be fixed.

Note that the tests here will fail until `Stoppable` is added. Will hold off on merging until that PR is in.