### PR TITLE
use EXCLUDE_FROM_ALL to shrink dependent builds

### DIFF
--- a/etc/docker/tests/run_test.sh
+++ b/etc/docker/tests/run_test.sh
@@ -13,6 +13,7 @@ ninja install
 pushd src/viam/sdk/tests
 UBSAN_OPTIONS="print_stacktrace=1" ctest --output-on-failure
 popd
+ninja src/viam/examples/modules/complex/all
 pushd src/viam/examples/modules/complex
 UBSAN_OPTIONS="print_stacktrace=1" ctest --output-on-failure
 popd

--- a/etc/docker/tests/run_test.sh
+++ b/etc/docker/tests/run_test.sh
@@ -8,6 +8,7 @@ cmake .. -G Ninja -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON \
 		-DVIAMCPPSDK_SANITIZED_BUILD=ON \
 		-DVIAMCPPSDK_CLANG_TIDY=ON
 ninja all
+ninja src/viam/sdk/tests/all
 ninja install
 pushd src/viam/sdk/tests
 UBSAN_OPTIONS="print_stacktrace=1" ctest --output-on-failure

--- a/src/viam/CMakeLists.txt
+++ b/src/viam/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 add_subdirectory(api)
 add_subdirectory(sdk)
-add_subdirectory(examples)
+add_subdirectory(examples EXCLUDE_FROM_ALL)
 
 # Generate CMake configs to enable importing this project
 # into others via `find_package`.

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -272,4 +272,4 @@ install(FILES
 )
 
 
-add_subdirectory(tests)
+add_subdirectory(tests EXCLUDE_FROM_ALL)


### PR DESCRIPTION
## What changed
- Add `EXCLUDE_FROM_ALL` directive to sdk tests + examples
## Why
- Faster builds for dependent projects if they build the SDK rather than using an installed copy
- May unblock cpack
## Perf
**TLDR** 130 seconds -> 70 seconds

(Note: these are N=1, so may not be stable, but the similar times for this repo + the example module suggests some repeatability. I ran on my 32g ram / many core laptop)

The test command is:
```sh
mkdir build && cd build && time /snap/bin/cmake -G Ninja .. && time ninja
```

branch | project | # targets | time
---|---|---|---
main | cpp sdk | 177 | 2m12.940s
exclude-all | cpp sdk | 105 | 1m21.290s
exclude-all | example module | 108 | 1m22.449s
main | example module | 180 | 2m12.321s