### PR TITLE
RSDK-2747: use attributemap in mocks

### DIFF
--- a/src/viam/sdk/tests/mocks/mock_motor.hpp
+++ b/src/viam/sdk/tests/mocks/mock_motor.hpp
@@ -34,15 +34,6 @@ class MockMotor : public Motor {
 
     MockMotor(std::string name) : Motor(std::move(name)){};
 
-    // the `extra` param is frequently unnecessary but needs to be supported. Ideally, we'd
-    // like to live in a world where implementers of derived classes don't need to go out of
-    // their way to support two versions of a method (an `extra` version and a non-`extra`
-    // version), and users don't need to pass an unnecessary parameters to all method calls.
-    //
-    // To do this, we define in the parent resource class a non-virtual version of the methods
-    // that calls the virtual method and passes a `nullptr` by default in place of the `extra`
-    // param. In order to access these versions of the methods within the client code, however,
-    // we need to include these `using` lines.
     using Motor::get_geometries;
     using Motor::get_position;
     using Motor::get_power_status;

--- a/src/viam/sdk/tests/mocks/mock_motor.hpp
+++ b/src/viam/sdk/tests/mocks/mock_motor.hpp
@@ -57,8 +57,7 @@ class MockMotor : public Motor {
     Motor::position position_;
     Motor::power_status power_status_;
     Motor::properties properties_;
-    // TODO(RSDK-2747) swap to AttributeMap
-    std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<viam::sdk::ProtoType>>> map_;
+    viam::sdk::AttributeMap map_;
 };
 
 Motor::position fake_position();


### PR DESCRIPTION
Found while working on #196 for [RSDK-1674](https://viam.atlassian.net/browse/RSDK-1674).

[RSDK-1674]: https://viam.atlassian.net/browse/RSDK-1674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

It seems like the only mock component who needs a change is `mock_motor`.