### PR TITLE
RSDK-5682 Further clarify PKG_CONFIG_PATH in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -116,6 +116,9 @@ simple as:
 cmake .. -G Ninja
 ```
 
+If you encounter an error about an inability to link an OpenSSL target on MacOS,
+try setting your [PKG_CONFIG_PATH](#setting-`PKG_CONFIG_PATH`).
+
 If all went well, you should now have a file named `build.ninja` in
 the `build` directory created above. Note that `git status` will not
 show this, since the `build` directory is ignored.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -117,7 +117,8 @@ cmake .. -G Ninja
 ```
 
 If you encounter an error about an inability to link an OpenSSL target on MacOS,
-try setting your [PKG_CONFIG_PATH](#setting-pkg_config_path).
+try setting your [PKG_CONFIG_PATH](#setting-pkg_config_path) to point to your
+Homebrew installation.
 
 If all went well, you should now have a file named `build.ninja` in
 the `build` directory created above. Note that `git status` will not

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -117,7 +117,7 @@ cmake .. -G Ninja
 ```
 
 If you encounter an error about an inability to link an OpenSSL target on MacOS,
-try setting your [PKG_CONFIG_PATH](#setting-`PKG_CONFIG_PATH`).
+try setting your [PKG_CONFIG_PATH](#setting-pkg_config_path).
 
 If all went well, you should now have a file named `build.ninja` in
 the `build` directory created above. Note that `git status` will not


### PR DESCRIPTION
[RSDK-5682](https://viam.atlassian.net/browse/RSDK-5682)

References the "Setting `PKG_CONFIG_PATH`" section right after the initial `cmake` instructions in case a MacOS user immediately encounters a missing OpenSSL target.

cc @npentrel

[RSDK-5682]: https://viam.atlassian.net/browse/RSDK-5682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ