### PR TITLE
RSDK-2990 - Template static api

### DIFF
--- a/src/viam/examples/camera/example_camera.cpp
+++ b/src/viam/examples/camera/example_camera.cpp
@@ -54,9 +54,9 @@ int main() {
         std::string camera_name("camera1");
 
         cout << "Getting camera: " << camera_name << endl;
-        std::shared_ptr<vs::CameraClient> camera;
+        std::shared_ptr<vs::Camera> camera;
         try {
-            camera = robot->resource_by_name<vs::CameraClient>(camera_name);
+            camera = robot->resource_by_name<vs::Camera>(camera_name);
         } catch (const std::exception& e) {
             cerr << "Failed to find " << camera_name << ". Exiting." << endl;
             throw;

--- a/src/viam/examples/dial/example_dial.cpp
+++ b/src/viam/examples/dial/example_dial.cpp
@@ -63,7 +63,7 @@ int main() {
     }
 
     // ensure we can create clients to the robot
-    auto gc = robot->resource_by_name<GenericClient>("generic1");
+    auto gc = robot->resource_by_name<Generic>("generic1");
     if (gc) {
         std::cout << "got generic client named " << gc->name() << std::endl;
     }

--- a/src/viam/examples/modules/complex/client.cpp
+++ b/src/viam/examples/modules/complex/client.cpp
@@ -39,8 +39,8 @@ int main() {
 
     // Register custom gizmo and summation API so robot client can access resources
     // of that type from the server.
-    Registry::register_resource(API::for_t<Gizmo>(), Gizmo::resource_registration());
-    Registry::register_resource(API::for_t<Summation>(), Summation::resource_registration());
+    Registry::register_resource(API::get<Gizmo>(), Gizmo::resource_registration());
+    Registry::register_resource(API::get<Summation>(), Summation::resource_registration());
 
     // Connect to robot.
     std::shared_ptr<RobotClient> robot = RobotClient::at_address(address, options);

--- a/src/viam/examples/modules/complex/client.cpp
+++ b/src/viam/examples/modules/complex/client.cpp
@@ -39,8 +39,8 @@ int main() {
 
     // Register custom gizmo and summation API so robot client can access resources
     // of that type from the server.
-    Registry::register_resource(Gizmo::static_api(), Gizmo::resource_registration());
-    Registry::register_resource(Summation::static_api(), Summation::resource_registration());
+    Registry::register_resource(API::for_t<Gizmo>(), Gizmo::resource_registration());
+    Registry::register_resource(API::for_t<Summation>(), Summation::resource_registration());
 
     // Connect to robot.
     std::shared_ptr<RobotClient> robot = RobotClient::at_address(address, options);
@@ -53,7 +53,7 @@ int main() {
     }
 
     // Exercise Gizmo methods.
-    auto gc = robot->resource_by_name<GizmoClient>("gizmo1");
+    auto gc = robot->resource_by_name<Gizmo>("gizmo1");
     if (!gc) {
         std::cerr << "could not get 'gizmo1' resource from robot" << std::endl;
         return EXIT_FAILURE;
@@ -76,7 +76,7 @@ int main() {
     }
 
     // Exercise Summation methods.
-    auto sc = robot->resource_by_name<SummationClient>("mysum1");
+    auto sc = robot->resource_by_name<Summation>("mysum1");
     if (!sc) {
         std::cerr << "could not get 'mysum1' resource from robot" << std::endl;
         return EXIT_FAILURE;
@@ -85,7 +85,7 @@ int main() {
     std::cout << "mysum1 sum of numbers [0, 10) is: " << sum << std::endl;
 
     // Exercise a Base method.
-    auto bc = robot->resource_by_name<BaseClient>("base1");
+    auto bc = robot->resource_by_name<Base>("base1");
     if (!bc) {
         std::cerr << "could not get 'base1' resource from robot" << std::endl;
         return EXIT_FAILURE;

--- a/src/viam/examples/modules/complex/gizmo/api.cpp
+++ b/src/viam/examples/modules/complex/gizmo/api.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<ResourceRegistration> Gizmo::resource_registration() {
 }
 
 API Gizmo::api() const {
-    return API::for_t<Gizmo>();
+    return API::get<Gizmo>();
 }
 
 Gizmo::Gizmo(std::string name) : Component(std::move(name)){};

--- a/src/viam/examples/modules/complex/gizmo/api.cpp
+++ b/src/viam/examples/modules/complex/gizmo/api.cpp
@@ -43,12 +43,8 @@ std::shared_ptr<ResourceRegistration> Gizmo::resource_registration() {
     return std::make_shared<GizmoRegistration>(sd);
 }
 
-API Gizmo::static_api() {
-    return {"viam", "component", "gizmo"};
-}
-
-API Gizmo::dynamic_api() const {
-    return static_api();
+API Gizmo::api() const {
+    return API::for_t<Gizmo>();
 }
 
 Gizmo::Gizmo(std::string name) : Component(std::move(name)){};

--- a/src/viam/examples/modules/complex/gizmo/api.cpp
+++ b/src/viam/examples/modules/complex/gizmo/api.cpp
@@ -47,6 +47,10 @@ API Gizmo::api() const {
     return API::get<Gizmo>();
 }
 
+API API::traits<Gizmo>::api() {
+    return {"viam", "component", "gizmo"};
+}
+
 Gizmo::Gizmo(std::string name) : Component(std::move(name)){};
 
 /* Gizmo server methods */

--- a/src/viam/examples/modules/complex/gizmo/api.hpp
+++ b/src/viam/examples/modules/complex/gizmo/api.hpp
@@ -31,8 +31,7 @@ class Gizmo : public Component {
    public:
     // methods shared across all components
     static std::shared_ptr<ResourceRegistration> resource_registration();
-    static API static_api();
-    API dynamic_api() const override;
+    API api() const override;
 
     virtual bool do_one(std::string arg1) = 0;
     virtual bool do_one_client_stream(std::vector<std::string> arg1) = 0;
@@ -42,6 +41,13 @@ class Gizmo : public Component {
 
    protected:
     explicit Gizmo(std::string name);
+};
+
+template <>
+struct API::api_map<Gizmo> {
+    static API api() {
+        return {"viam", "component", "gizmo"};
+    }
 };
 
 // `GizmoClient` is the gRPC client implementation of a `Gizmo` component.

--- a/src/viam/examples/modules/complex/gizmo/api.hpp
+++ b/src/viam/examples/modules/complex/gizmo/api.hpp
@@ -43,12 +43,12 @@ class Gizmo : public Component {
     explicit Gizmo(std::string name);
 };
 
+namespace viam::sdk {
 template <>
-struct API::api_map<Gizmo> {
-    static API api() {
-        return {"viam", "component", "gizmo"};
-    }
+struct API::traits<Gizmo> {
+    static ::viam::sdk::API api();
 };
+}  // namespace viam::sdk
 
 // `GizmoClient` is the gRPC client implementation of a `Gizmo` component.
 class GizmoClient : public Gizmo {

--- a/src/viam/examples/modules/complex/main.cpp
+++ b/src/viam/examples/modules/complex/main.cpp
@@ -28,7 +28,7 @@
 using namespace viam::sdk;
 
 int main(int argc, char** argv) {
-    API base_api = Base::static_api();
+    API base_api = API::for_t<Base>();
     Model mybase_model("viam", "base", "mybase");
 
     std::shared_ptr<ModelRegistration> mybase_mr = std::make_shared<ModelRegistration>(
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
         [](Dependencies deps, ResourceConfig cfg) { return std::make_unique<MyBase>(deps, cfg); },
         MyBase::validate);
 
-    API gizmo_api = Gizmo::static_api();
+    API gizmo_api = API::for_t<Gizmo>();
     Model mygizmo_model("viam", "gizmo", "mygizmo");
     // Make sure to explicity register resources with custom APIs. Note that
     // this must be done in `main` and not in resource implementation files due
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
         [](Dependencies deps, ResourceConfig cfg) { return std::make_unique<MyGizmo>(deps, cfg); },
         MyGizmo::validate);
 
-    API summation_api = Summation::static_api();
+    API summation_api = API::for_t<Summation>();
     Model mysummation_model("viam", "summation", "mysummation");
     // Make sure to explicity register resources with custom APIs. Note that
     // this must be done in `main` and not in resource implementation files due

--- a/src/viam/examples/modules/complex/main.cpp
+++ b/src/viam/examples/modules/complex/main.cpp
@@ -28,7 +28,7 @@
 using namespace viam::sdk;
 
 int main(int argc, char** argv) {
-    API base_api = API::for_t<Base>();
+    API base_api = API::get<Base>();
     Model mybase_model("viam", "base", "mybase");
 
     std::shared_ptr<ModelRegistration> mybase_mr = std::make_shared<ModelRegistration>(
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
         [](Dependencies deps, ResourceConfig cfg) { return std::make_unique<MyBase>(deps, cfg); },
         MyBase::validate);
 
-    API gizmo_api = API::for_t<Gizmo>();
+    API gizmo_api = API::get<Gizmo>();
     Model mygizmo_model("viam", "gizmo", "mygizmo");
     // Make sure to explicity register resources with custom APIs. Note that
     // this must be done in `main` and not in resource implementation files due
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
         [](Dependencies deps, ResourceConfig cfg) { return std::make_unique<MyGizmo>(deps, cfg); },
         MyGizmo::validate);
 
-    API summation_api = API::for_t<Summation>();
+    API summation_api = API::get<Summation>();
     Model mysummation_model("viam", "summation", "mysummation");
     // Make sure to explicity register resources with custom APIs. Note that
     // this must be done in `main` and not in resource implementation files due

--- a/src/viam/examples/modules/complex/summation/api.cpp
+++ b/src/viam/examples/modules/complex/summation/api.cpp
@@ -48,6 +48,10 @@ API Summation::api() const {
     return API::get<Summation>();
 }
 
+API API::traits<Summation>::api() {
+    return {"viam", "service", "summation"};
+}
+
 Summation::Summation(std::string name) : Service(std::move(name)){};
 
 /* Summation server methods */

--- a/src/viam/examples/modules/complex/summation/api.cpp
+++ b/src/viam/examples/modules/complex/summation/api.cpp
@@ -44,12 +44,8 @@ std::shared_ptr<ResourceRegistration> Summation::resource_registration() {
     return std::make_shared<SummationRegistration>(sd);
 }
 
-API Summation::static_api() {
-    return {"viam", "service", "summation"};
-}
-
-API Summation::dynamic_api() const {
-    return static_api();
+API Summation::api() const {
+    return API::for_t<Summation>();
 }
 
 Summation::Summation(std::string name) : Service(std::move(name)){};

--- a/src/viam/examples/modules/complex/summation/api.cpp
+++ b/src/viam/examples/modules/complex/summation/api.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<ResourceRegistration> Summation::resource_registration() {
 }
 
 API Summation::api() const {
-    return API::for_t<Summation>();
+    return API::get<Summation>();
 }
 
 Summation::Summation(std::string name) : Service(std::move(name)){};

--- a/src/viam/examples/modules/complex/summation/api.hpp
+++ b/src/viam/examples/modules/complex/summation/api.hpp
@@ -41,12 +41,12 @@ class Summation : public Service {
     explicit Summation(std::string name);
 };
 
+namespace viam::sdk {
 template <>
-struct API::api_map<Summation> {
-    static API api() {
-        return {"viam", "service", "summation"};
-    }
+struct API::traits<Summation> {
+    static API api();
 };
+}  // namespace viam::sdk
 
 // `SummationClient` is the gRPC client implementation of a `Summation`
 // service.

--- a/src/viam/examples/modules/complex/summation/api.hpp
+++ b/src/viam/examples/modules/complex/summation/api.hpp
@@ -33,13 +33,19 @@ class Summation : public Service {
    public:
     // methods shared across all services
     static std::shared_ptr<ResourceRegistration> resource_registration();
-    static API static_api();
-    API dynamic_api() const override;
+    API api() const override;
 
     virtual double sum(std::vector<double> numbers) = 0;
 
    protected:
     explicit Summation(std::string name);
+};
+
+template <>
+struct API::api_map<Summation> {
+    static API api() {
+        return {"viam", "service", "summation"};
+    }
 };
 
 // `SummationClient` is the gRPC client implementation of a `Summation`

--- a/src/viam/examples/modules/simple/main.cpp
+++ b/src/viam/examples/modules/simple/main.cpp
@@ -77,7 +77,7 @@ class Printer : public Generic {
 };
 
 int main(int argc, char** argv) {
-    API generic = API::for_t<Generic>();
+    API generic = API::get<Generic>();
     Model m("viam", "generic", "printer");
 
     std::shared_ptr<ModelRegistration> mr = std::make_shared<ModelRegistration>(

--- a/src/viam/examples/modules/simple/main.cpp
+++ b/src/viam/examples/modules/simple/main.cpp
@@ -77,7 +77,7 @@ class Printer : public Generic {
 };
 
 int main(int argc, char** argv) {
-    API generic = Generic::static_api();
+    API generic = API::for_t<Generic>();
     Model m("viam", "generic", "printer");
 
     std::shared_ptr<ModelRegistration> mr = std::make_shared<ModelRegistration>(

--- a/src/viam/examples/modules/tflite/main.cpp
+++ b/src/viam/examples/modules/tflite/main.cpp
@@ -726,7 +726,7 @@ int serve(const std::string& socket_path) try {
     // Create a new model registration for the service.
     auto module_registration = std::make_shared<vsdk::ModelRegistration>(
         // Identify that this resource offers the MLModelService API
-        vsdk::API::for_t<vsdk::MLModelService>(),
+        vsdk::API::get<vsdk::MLModelService>(),
 
         // Declare a model triple for this service.
         vsdk::Model{"viam", "mlmodelservice", "example_mlmodelservice_tflite"},

--- a/src/viam/examples/modules/tflite/main.cpp
+++ b/src/viam/examples/modules/tflite/main.cpp
@@ -726,7 +726,7 @@ int serve(const std::string& socket_path) try {
     // Create a new model registration for the service.
     auto module_registration = std::make_shared<vsdk::ModelRegistration>(
         // Identify that this resource offers the MLModelService API
-        vsdk::MLModelService::static_api(),
+        vsdk::API::for_t<vsdk::MLModelService>(),
 
         // Declare a model triple for this service.
         vsdk::Model{"viam", "mlmodelservice", "example_mlmodelservice_tflite"},

--- a/src/viam/examples/motor/example_motor.cpp
+++ b/src/viam/examples/motor/example_motor.cpp
@@ -10,7 +10,7 @@
 #include <viam/sdk/robot/service.hpp>
 #include <viam/sdk/rpc/dial.hpp>
 
-void print_motor_position(std::shared_ptr<viam::sdk::MotorClient> motor) {
+void print_motor_position(std::shared_ptr<viam::sdk::Motor> motor) {
     // Whether the motor supports returning its position
     if (motor->get_properties().position_reporting) {
         // Position is measured in rotations (position is a typedef double)
@@ -66,9 +66,11 @@ int main() {
         std::string motor_name("motor1");
 
         cout << "Getting motor: " << motor_name << endl;
-        std::shared_ptr<vs::MotorClient> motor;
+        // CR erodkin: this is a significant change! make sure there isn't a better option, and if
+        // not then be sure to flag this loudly in review
+        std::shared_ptr<vs::Motor> motor;
         try {
-            motor = robot->resource_by_name<vs::MotorClient>(motor_name);
+            motor = robot->resource_by_name<vs::Motor>(motor_name);
         } catch (const std::exception& e) {
             cerr << "Failed to find " << motor_name << ". Exiting." << endl;
             throw;

--- a/src/viam/examples/motor/example_motor.cpp
+++ b/src/viam/examples/motor/example_motor.cpp
@@ -66,8 +66,6 @@ int main() {
         std::string motor_name("motor1");
 
         cout << "Getting motor: " << motor_name << endl;
-        // CR erodkin: this is a significant change! make sure there isn't a better option, and if
-        // not then be sure to flag this loudly in review
         std::shared_ptr<vs::Motor> motor;
         try {
             motor = robot->resource_by_name<vs::Motor>(motor_name);

--- a/src/viam/sdk/common/utils.cpp
+++ b/src/viam/sdk/common/utils.cpp
@@ -30,7 +30,7 @@ std::vector<ResourceName> resource_names_for_resource(const std::shared_ptr<Reso
     std::vector<ResourceName> resource_names;
     for (auto& kv : Registry::registered_models()) {
         const std::shared_ptr<ModelRegistration> reg = kv.second;
-        if (reg->api().to_string() == resource->dynamic_api().to_string()) {
+        if (reg->api().to_string() == resource->api().to_string()) {
             resource_type = reg->api().resource_type();
             resource_subtype = reg->api().resource_subtype();
         } else {

--- a/src/viam/sdk/components/base/base.cpp
+++ b/src/viam/sdk/components/base/base.cpp
@@ -37,12 +37,8 @@ std::shared_ptr<ResourceRegistration> Base::resource_registration() {
     return std::make_shared<BaseRegistration>(sd);
 }
 
-API Base::static_api() {
-    return {kRDK, kComponent, "base"};
-}
-
-API Base::dynamic_api() const {
-    return static_api();
+API Base::api() const {
+    return API::for_t<Base>();
 }
 
 Base::properties Base::properties::from_proto(
@@ -68,7 +64,7 @@ Base::Base(std::string name) : Component(std::move(name)){};
 
 namespace {
 bool init() {
-    Registry::register_resource(Base::static_api(), Base::resource_registration());
+    Registry::register_resource(API::for_t<Base>(), Base::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/base/base.cpp
+++ b/src/viam/sdk/components/base/base.cpp
@@ -38,7 +38,11 @@ std::shared_ptr<ResourceRegistration> Base::resource_registration() {
 }
 
 API Base::api() const {
-    return API::for_t<Base>();
+    return API::get<Base>();
+}
+
+API API::api_map<Base>::api() {
+    return {kRDK, kComponent, "base"};
 }
 
 Base::properties Base::properties::from_proto(
@@ -64,7 +68,7 @@ Base::Base(std::string name) : Component(std::move(name)){};
 
 namespace {
 bool init() {
-    Registry::register_resource(API::for_t<Base>(), Base::resource_registration());
+    Registry::register_resource(API::get<Base>(), Base::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/base/base.cpp
+++ b/src/viam/sdk/components/base/base.cpp
@@ -41,7 +41,7 @@ API Base::api() const {
     return API::get<Base>();
 }
 
-API API::api_map<Base>::api() {
+API API::traits<Base>::api() {
     return {kRDK, kComponent, "base"};
 }
 

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -54,7 +54,6 @@ class Base : public Component, public Stoppable {
 
     // functions shared across all components
     static std::shared_ptr<ResourceRegistration> resource_registration();
-    static API static_api();
 
     /// @brief Move a robot's base in a straight line by a given distance. This method blocks
     /// until completed or cancelled
@@ -157,10 +156,17 @@ class Base : public Component, public Stoppable {
     /// @return The requested `GeometryConfig`s associated with the component.
     virtual std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) = 0;
 
-    API dynamic_api() const override;
+    API api() const override;
 
    protected:
     explicit Base(std::string name);
+};
+
+template <>
+struct API::api_map<Base> {
+    static API api() {
+        return {kRDK, kComponent, "base"};
+    }
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -163,7 +163,7 @@ class Base : public Component, public Stoppable {
 };
 
 template <>
-struct API::api_map<Base> {
+struct API::traits<Base> {
     static API api();
 };
 

--- a/src/viam/sdk/components/base/base.hpp
+++ b/src/viam/sdk/components/base/base.hpp
@@ -164,9 +164,7 @@ class Base : public Component, public Stoppable {
 
 template <>
 struct API::api_map<Base> {
-    static API api() {
-        return {kRDK, kComponent, "base"};
-    }
+    static API api();
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/board/board.cpp
+++ b/src/viam/sdk/components/board/board.cpp
@@ -37,12 +37,8 @@ std::shared_ptr<ResourceRegistration> Board::resource_registration() {
     return std::make_shared<BoardRegistration>(sd);
 }
 
-API Board::static_api() {
-    return {kRDK, kComponent, "board"};
-}
-
-API Board::dynamic_api() const {
-    return static_api();
+API Board::api() const {
+    return API::for_t<Board>();
 }
 
 Board::status Board::from_proto(viam::common::v1::BoardStatus proto) {
@@ -153,7 +149,7 @@ bool operator==(const Board::status& lhs, const Board::status& rhs) {
 
 namespace {
 bool init() {
-    Registry::register_resource(Board::static_api(), Board::resource_registration());
+    Registry::register_resource(API::for_t<Board>(), Board::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/board/board.cpp
+++ b/src/viam/sdk/components/board/board.cpp
@@ -38,7 +38,11 @@ std::shared_ptr<ResourceRegistration> Board::resource_registration() {
 }
 
 API Board::api() const {
-    return API::for_t<Board>();
+    return API::get<Board>();
+}
+
+API API::api_map<Board>::api() {
+    return {kRDK, kComponent, "board"};
 }
 
 Board::status Board::from_proto(viam::common::v1::BoardStatus proto) {
@@ -149,7 +153,7 @@ bool operator==(const Board::status& lhs, const Board::status& rhs) {
 
 namespace {
 bool init() {
-    Registry::register_resource(API::for_t<Board>(), Board::resource_registration());
+    Registry::register_resource(API::get<Board>(), Board::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/board/board.cpp
+++ b/src/viam/sdk/components/board/board.cpp
@@ -41,7 +41,7 @@ API Board::api() const {
     return API::get<Board>();
 }
 
-API API::api_map<Board>::api() {
+API API::traits<Board>::api() {
     return {kRDK, kComponent, "board"};
 }
 

--- a/src/viam/sdk/components/board/board.hpp
+++ b/src/viam/sdk/components/board/board.hpp
@@ -280,9 +280,7 @@ class Board : public Component {
 
 template <>
 struct API::api_map<Board> {
-    static API api() {
-        return {kRDK, kComponent, "board"};
-    }
+    static API api();
 };
 
 bool operator==(const Board::status& lhs, const Board::status& rhs);

--- a/src/viam/sdk/components/board/board.hpp
+++ b/src/viam/sdk/components/board/board.hpp
@@ -67,8 +67,7 @@ class Board : public Component {
 
     // functions shared across all components
     static std::shared_ptr<ResourceRegistration> resource_registration();
-    static API static_api();
-    API dynamic_api() const override;
+    API api() const override;
 
     /// @brief Creates a `status` struct from its proto representation.
     static status from_proto(viam::common::v1::BoardStatus proto);
@@ -277,6 +276,13 @@ class Board : public Component {
 
    protected:
     explicit Board(std::string name);
+};
+
+template <>
+struct API::api_map<Board> {
+    static API api() {
+        return {kRDK, kComponent, "board"};
+    }
 };
 
 bool operator==(const Board::status& lhs, const Board::status& rhs);

--- a/src/viam/sdk/components/board/board.hpp
+++ b/src/viam/sdk/components/board/board.hpp
@@ -279,7 +279,7 @@ class Board : public Component {
 };
 
 template <>
-struct API::api_map<Board> {
+struct API::traits<Board> {
     static API api();
 };
 

--- a/src/viam/sdk/components/camera/camera.cpp
+++ b/src/viam/sdk/components/camera/camera.cpp
@@ -43,12 +43,8 @@ std::shared_ptr<ResourceRegistration> Camera::resource_registration() {
 // NOLINTNEXTLINE
 const std::string Camera::lazy_suffix = "+lazy";
 
-API Camera::static_api() {
-    return {kRDK, kComponent, "camera"};
-}
-
-API Camera::dynamic_api() const {
-    return static_api();
+API Camera::api() const {
+    return API::for_t<Camera>();
 }
 
 std::string Camera::normalize_mime_type(const std::string& str) {
@@ -223,7 +219,7 @@ bool operator==(const Camera::properties& lhs, const Camera::properties& rhs) {
 
 namespace {
 bool init() {
-    Registry::register_resource(Camera::static_api(), Camera::resource_registration());
+    Registry::register_resource(API::for_t<Camera>(), Camera::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/camera/camera.cpp
+++ b/src/viam/sdk/components/camera/camera.cpp
@@ -47,7 +47,7 @@ API Camera::api() const {
     return API::get<Camera>();
 }
 
-API API::api_map<Camera>::api() {
+API API::traits<Camera>::api() {
     return {kRDK, kComponent, "camera"};
 }
 

--- a/src/viam/sdk/components/camera/camera.cpp
+++ b/src/viam/sdk/components/camera/camera.cpp
@@ -44,7 +44,11 @@ std::shared_ptr<ResourceRegistration> Camera::resource_registration() {
 const std::string Camera::lazy_suffix = "+lazy";
 
 API Camera::api() const {
-    return API::for_t<Camera>();
+    return API::get<Camera>();
+}
+
+API API::api_map<Camera>::api() {
+    return {kRDK, kComponent, "camera"};
 }
 
 std::string Camera::normalize_mime_type(const std::string& str) {
@@ -219,7 +223,7 @@ bool operator==(const Camera::properties& lhs, const Camera::properties& rhs) {
 
 namespace {
 bool init() {
-    Registry::register_resource(API::for_t<Camera>(), Camera::resource_registration());
+    Registry::register_resource(API::get<Camera>(), Camera::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/camera/camera.hpp
+++ b/src/viam/sdk/components/camera/camera.hpp
@@ -194,7 +194,7 @@ class Camera : public Component {
 };
 
 template <>
-struct API::api_map<Camera> {
+struct API::traits<Camera> {
     static API api();
 };
 

--- a/src/viam/sdk/components/camera/camera.hpp
+++ b/src/viam/sdk/components/camera/camera.hpp
@@ -195,9 +195,7 @@ class Camera : public Component {
 
 template <>
 struct API::api_map<Camera> {
-    static API api() {
-        return {kRDK, kComponent, "camera"};
-    }
+    static API api();
 };
 
 bool operator==(const Camera::raw_image& lhs, const Camera::raw_image& rhs);

--- a/src/viam/sdk/components/camera/camera.hpp
+++ b/src/viam/sdk/components/camera/camera.hpp
@@ -15,6 +15,7 @@
 #include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/config/resource.hpp>
 #include <viam/sdk/registry/registry.hpp>
+#include <viam/sdk/resource/resource_api.hpp>
 #include <viam/sdk/resource/resource_manager.hpp>
 
 namespace viam {
@@ -101,9 +102,6 @@ class Camera : public Component {
     /// @brief Creates a `ResourceRegistration` for the `Camera` component.
     static std::shared_ptr<ResourceRegistration> resource_registration();
 
-    /// @brief Creates a `Camera` `API`.
-    static API static_api();
-
     /// @brief remove any extra suffix's from the mime type string.
     static std::string normalize_mime_type(const std::string& str);
 
@@ -189,10 +187,17 @@ class Camera : public Component {
     /// @return The camera properties.
     virtual properties get_properties() = 0;
 
-    API dynamic_api() const override;
+    API api() const override;
 
    protected:
     explicit Camera(std::string name);
+};
+
+template <>
+struct API::api_map<Camera> {
+    static API api() {
+        return {kRDK, kComponent, "camera"};
+    }
 };
 
 bool operator==(const Camera::raw_image& lhs, const Camera::raw_image& rhs);

--- a/src/viam/sdk/components/encoder/encoder.cpp
+++ b/src/viam/sdk/components/encoder/encoder.cpp
@@ -39,7 +39,11 @@ std::shared_ptr<ResourceRegistration> Encoder::resource_registration() {
 }
 
 API Encoder::api() const {
-    return API::for_t<Encoder>();
+    return API::get<Encoder>();
+}
+
+API API::api_map<Encoder>::api() {
+    return {kRDK, kComponent, "encoder"};
 }
 
 Encoder::position_type Encoder::from_proto(viam::component::encoder::v1::PositionType proto) {
@@ -121,7 +125,7 @@ bool operator==(const Encoder::properties& lhs, const Encoder::properties& rhs) 
 
 namespace {
 bool init() {
-    Registry::register_resource(API::for_t<Encoder>(), Encoder::resource_registration());
+    Registry::register_resource(API::get<Encoder>(), Encoder::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/encoder/encoder.cpp
+++ b/src/viam/sdk/components/encoder/encoder.cpp
@@ -38,12 +38,8 @@ std::shared_ptr<ResourceRegistration> Encoder::resource_registration() {
     return std::make_shared<EncoderRegistration>(sd);
 }
 
-API Encoder::static_api() {
-    return {kRDK, kComponent, "encoder"};
-}
-
-API Encoder::dynamic_api() const {
-    return static_api();
+API Encoder::api() const {
+    return API::for_t<Encoder>();
 }
 
 Encoder::position_type Encoder::from_proto(viam::component::encoder::v1::PositionType proto) {
@@ -125,7 +121,7 @@ bool operator==(const Encoder::properties& lhs, const Encoder::properties& rhs) 
 
 namespace {
 bool init() {
-    Registry::register_resource(Encoder::static_api(), Encoder::resource_registration());
+    Registry::register_resource(API::for_t<Encoder>(), Encoder::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/encoder/encoder.cpp
+++ b/src/viam/sdk/components/encoder/encoder.cpp
@@ -42,7 +42,7 @@ API Encoder::api() const {
     return API::get<Encoder>();
 }
 
-API API::api_map<Encoder>::api() {
+API API::traits<Encoder>::api() {
     return {kRDK, kComponent, "encoder"};
 }
 

--- a/src/viam/sdk/components/encoder/encoder.hpp
+++ b/src/viam/sdk/components/encoder/encoder.hpp
@@ -143,9 +143,7 @@ class Encoder : public Component {
 
 template <>
 struct API::api_map<Encoder> {
-    static API api() {
-        return {kRDK, kComponent, "encoder"};
-    }
+    static API api();
 };
 
 bool operator==(const Encoder::position& lhs, const Encoder::position& rhs);

--- a/src/viam/sdk/components/encoder/encoder.hpp
+++ b/src/viam/sdk/components/encoder/encoder.hpp
@@ -142,7 +142,7 @@ class Encoder : public Component {
 };
 
 template <>
-struct API::api_map<Encoder> {
+struct API::traits<Encoder> {
     static API api();
 };
 

--- a/src/viam/sdk/components/encoder/encoder.hpp
+++ b/src/viam/sdk/components/encoder/encoder.hpp
@@ -64,7 +64,6 @@ class Encoder : public Component {
 
     // functions shared across all components
     static std::shared_ptr<ResourceRegistration> resource_registration();
-    static API static_api();
 
     /// @brief Creates a `position_type` struct from its proto representation.
     static position_type from_proto(viam::component::encoder::v1::PositionType proto);
@@ -136,10 +135,17 @@ class Encoder : public Component {
     /// @return The requested `GeometryConfig`s associated with the component.
     virtual std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) = 0;
 
-    API dynamic_api() const override;
+    API api() const override;
 
    protected:
     explicit Encoder(std::string name);
+};
+
+template <>
+struct API::api_map<Encoder> {
+    static API api() {
+        return {kRDK, kComponent, "encoder"};
+    }
 };
 
 bool operator==(const Encoder::position& lhs, const Encoder::position& rhs);

--- a/src/viam/sdk/components/generic/generic.cpp
+++ b/src/viam/sdk/components/generic/generic.cpp
@@ -40,14 +40,18 @@ std::shared_ptr<ResourceRegistration> Generic::resource_registration() {
 }
 
 API Generic::api() const {
-    return API::for_t<Generic>();
+    return API::get<Generic>();
+}
+
+API API::api_map<Generic>::api() {
+    return {kRDK, kComponent, "generic"};
 }
 
 Generic::Generic(std::string name) : Component(std::move(name)){};
 
 namespace {
 bool init() {
-    Registry::register_resource(API::for_t<Generic>(), Generic::resource_registration());
+    Registry::register_resource(API::get<Generic>(), Generic::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/generic/generic.cpp
+++ b/src/viam/sdk/components/generic/generic.cpp
@@ -43,7 +43,7 @@ API Generic::api() const {
     return API::get<Generic>();
 }
 
-API API::api_map<Generic>::api() {
+API API::traits<Generic>::api() {
     return {kRDK, kComponent, "generic"};
 }
 

--- a/src/viam/sdk/components/generic/generic.cpp
+++ b/src/viam/sdk/components/generic/generic.cpp
@@ -39,19 +39,15 @@ std::shared_ptr<ResourceRegistration> Generic::resource_registration() {
     return std::make_shared<GenericRegistration>(sd);
 }
 
-API Generic::static_api() {
-    return {kRDK, kComponent, "generic"};
-}
-
-API Generic::dynamic_api() const {
-    return static_api();
+API Generic::api() const {
+    return API::for_t<Generic>();
 }
 
 Generic::Generic(std::string name) : Component(std::move(name)){};
 
 namespace {
 bool init() {
-    Registry::register_resource(Generic::static_api(), Generic::resource_registration());
+    Registry::register_resource(API::for_t<Generic>(), Generic::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/generic/generic.hpp
+++ b/src/viam/sdk/components/generic/generic.hpp
@@ -41,7 +41,6 @@ class Generic : public Component {
     static std::shared_ptr<ResourceRegistration> resource_registration();
 
     /// @brief Creates a `Generic` `API`.
-    static API static_api();
 
     /// @brief Send/receive arbitrary commands to the resource.
     /// @param command the command to execute.
@@ -56,10 +55,17 @@ class Generic : public Component {
 
     virtual std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) = 0;
 
-    API dynamic_api() const override;
+    API api() const override;
 
    protected:
     explicit Generic(std::string name);
+};
+
+template <>
+struct API::api_map<Generic> {
+    static API api() {
+        return {kRDK, kComponent, "generic"};
+    }
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/generic/generic.hpp
+++ b/src/viam/sdk/components/generic/generic.hpp
@@ -63,9 +63,7 @@ class Generic : public Component {
 
 template <>
 struct API::api_map<Generic> {
-    static API api() {
-        return {kRDK, kComponent, "generic"};
-    }
+    static API api();
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/generic/generic.hpp
+++ b/src/viam/sdk/components/generic/generic.hpp
@@ -62,7 +62,7 @@ class Generic : public Component {
 };
 
 template <>
-struct API::api_map<Generic> {
+struct API::traits<Generic> {
     static API api();
 };
 

--- a/src/viam/sdk/components/motor/motor.cpp
+++ b/src/viam/sdk/components/motor/motor.cpp
@@ -43,7 +43,7 @@ API Motor::api() const {
     return API::get<Motor>();
 }
 
-API API::api_map<Motor>::api() {
+API API::traits<Motor>::api() {
     return {kRDK, kComponent, "motor"};
 }
 

--- a/src/viam/sdk/components/motor/motor.cpp
+++ b/src/viam/sdk/components/motor/motor.cpp
@@ -36,15 +36,11 @@ std::shared_ptr<ResourceRegistration> Motor::resource_registration() {
     return std::make_shared<MotorRegistration>(sd);
 }
 
-API Motor::static_api() {
-    return {kRDK, kComponent, "motor"};
-}
-
 Motor::position Motor::from_proto(viam::component::motor::v1::GetPositionResponse proto) {
     return proto.position();
 }
-API Motor::dynamic_api() const {
-    return static_api();
+API Motor::api() const {
+    return API::for_t<Motor>();
 }
 
 Motor::power_status Motor::from_proto(viam::component::motor::v1::IsPoweredResponse proto) {
@@ -93,7 +89,7 @@ bool operator==(const Motor::properties& lhs, const Motor::properties& rhs) {
 
 namespace {
 bool init() {
-    Registry::register_resource(Motor::static_api(), Motor::resource_registration());
+    Registry::register_resource(API::for_t<Motor>(), Motor::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/motor/motor.cpp
+++ b/src/viam/sdk/components/motor/motor.cpp
@@ -40,7 +40,11 @@ Motor::position Motor::from_proto(viam::component::motor::v1::GetPositionRespons
     return proto.position();
 }
 API Motor::api() const {
-    return API::for_t<Motor>();
+    return API::get<Motor>();
+}
+
+API API::api_map<Motor>::api() {
+    return {kRDK, kComponent, "motor"};
 }
 
 Motor::power_status Motor::from_proto(viam::component::motor::v1::IsPoweredResponse proto) {
@@ -89,7 +93,7 @@ bool operator==(const Motor::properties& lhs, const Motor::properties& rhs) {
 
 namespace {
 bool init() {
-    Registry::register_resource(API::for_t<Motor>(), Motor::resource_registration());
+    Registry::register_resource(API::get<Motor>(), Motor::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/motor/motor.hpp
+++ b/src/viam/sdk/components/motor/motor.hpp
@@ -215,9 +215,7 @@ class Motor : public Component, public Stoppable {
 
 template <>
 struct API::api_map<Motor> {
-    static API api() {
-        return {kRDK, kComponent, "motor"};
-    }
+    static API api();
 };
 
 bool operator==(const Motor::power_status& lhs, const Motor::power_status& rhs);

--- a/src/viam/sdk/components/motor/motor.hpp
+++ b/src/viam/sdk/components/motor/motor.hpp
@@ -63,7 +63,6 @@ class Motor : public Component, public Stoppable {
 
     // functions shared across all components
     static std::shared_ptr<ResourceRegistration> resource_registration();
-    static API static_api();
 
     /// @brief Creates a `position` struct from its proto representation.
     static position from_proto(viam::component::motor::v1::GetPositionResponse proto);
@@ -208,10 +207,17 @@ class Motor : public Component, public Stoppable {
     /// @return The requested `GeometryConfig`s associated with the component.
     virtual std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) = 0;
 
-    API dynamic_api() const override;
+    API api() const override;
 
    protected:
     explicit Motor(std::string name);
+};
+
+template <>
+struct API::api_map<Motor> {
+    static API api() {
+        return {kRDK, kComponent, "motor"};
+    }
 };
 
 bool operator==(const Motor::power_status& lhs, const Motor::power_status& rhs);

--- a/src/viam/sdk/components/motor/motor.hpp
+++ b/src/viam/sdk/components/motor/motor.hpp
@@ -214,7 +214,7 @@ class Motor : public Component, public Stoppable {
 };
 
 template <>
-struct API::api_map<Motor> {
+struct API::traits<Motor> {
     static API api();
 };
 

--- a/src/viam/sdk/components/movement_sensor/movement_sensor.cpp
+++ b/src/viam/sdk/components/movement_sensor/movement_sensor.cpp
@@ -14,12 +14,8 @@
 namespace viam {
 namespace sdk {
 
-API MovementSensor::static_api() {
-    return {kRDK, kComponent, "movement_sensor"};
-}
-
-API MovementSensor::dynamic_api() const {
-    return static_api();
+API MovementSensor::api() const {
+    return API::for_t<MovementSensor>();
 }
 
 MovementSensor::compassheading MovementSensor::from_proto(
@@ -115,7 +111,7 @@ class MovementSensorRegistration final
 };
 
 bool init() {
-    Registry::register_resource(MovementSensor::static_api(),
+    Registry::register_resource(API::for_t<MovementSensor>(),
                                 MovementSensorRegistration::resource_registration());
     return true;
 };

--- a/src/viam/sdk/components/movement_sensor/movement_sensor.cpp
+++ b/src/viam/sdk/components/movement_sensor/movement_sensor.cpp
@@ -15,7 +15,11 @@ namespace viam {
 namespace sdk {
 
 API MovementSensor::api() const {
-    return API::for_t<MovementSensor>();
+    return API::get<MovementSensor>();
+}
+
+API API::api_map<MovementSensor>::api() {
+    return {kRDK, kComponent, "movement_sensor"};
 }
 
 MovementSensor::compassheading MovementSensor::from_proto(
@@ -111,7 +115,7 @@ class MovementSensorRegistration final
 };
 
 bool init() {
-    Registry::register_resource(API::for_t<MovementSensor>(),
+    Registry::register_resource(API::get<MovementSensor>(),
                                 MovementSensorRegistration::resource_registration());
     return true;
 };

--- a/src/viam/sdk/components/movement_sensor/movement_sensor.cpp
+++ b/src/viam/sdk/components/movement_sensor/movement_sensor.cpp
@@ -18,7 +18,7 @@ API MovementSensor::api() const {
     return API::get<MovementSensor>();
 }
 
-API API::api_map<MovementSensor>::api() {
+API API::traits<MovementSensor>::api() {
     return {kRDK, kComponent, "movement_sensor"};
 }
 

--- a/src/viam/sdk/components/movement_sensor/movement_sensor.hpp
+++ b/src/viam/sdk/components/movement_sensor/movement_sensor.hpp
@@ -154,7 +154,7 @@ class MovementSensor : public Component {
 };
 
 template <>
-struct API::api_map<MovementSensor> {
+struct API::traits<MovementSensor> {
     static API api();
 };
 

--- a/src/viam/sdk/components/movement_sensor/movement_sensor.hpp
+++ b/src/viam/sdk/components/movement_sensor/movement_sensor.hpp
@@ -155,9 +155,7 @@ class MovementSensor : public Component {
 
 template <>
 struct API::api_map<MovementSensor> {
-    static API api() {
-        return {kRDK, kComponent, "movement_sensor"};
-    }
+    static API api();
 };
 
 bool operator==(const MovementSensor::compassheading& lhs,

--- a/src/viam/sdk/components/movement_sensor/movement_sensor.hpp
+++ b/src/viam/sdk/components/movement_sensor/movement_sensor.hpp
@@ -56,8 +56,7 @@ class MovementSensor : public Component {
         bool linear_acceleration_supported;
     };
 
-    static API static_api();
-    API dynamic_api() const override;
+    API api() const override;
 
     /// @brief Creates a `compassheading` struct from its proto representation.
     static compassheading from_proto(
@@ -152,6 +151,13 @@ class MovementSensor : public Component {
 
    protected:
     explicit MovementSensor(std::string name) : Component(std::move(name)){};
+};
+
+template <>
+struct API::api_map<MovementSensor> {
+    static API api() {
+        return {kRDK, kComponent, "movement_sensor"};
+    }
 };
 
 bool operator==(const MovementSensor::compassheading& lhs,

--- a/src/viam/sdk/components/power_sensor/power_sensor.cpp
+++ b/src/viam/sdk/components/power_sensor/power_sensor.cpp
@@ -15,7 +15,11 @@ namespace viam {
 namespace sdk {
 
 API PowerSensor::api() const {
-    return API::for_t<PowerSensor>();
+    return API::get<PowerSensor>();
+}
+
+API API::api_map<PowerSensor>::api() {
+    return {kRDK, kComponent, "power_sensor"};
 }
 
 PowerSensor::voltage PowerSensor::from_proto(GetVoltageResponse proto) {
@@ -65,7 +69,7 @@ class PowerSensorRegistration final
 };
 
 bool init() {
-    Registry::register_resource(API::for_t<PowerSensor>(),
+    Registry::register_resource(API::get<PowerSensor>(),
                                 PowerSensorRegistration::resource_registration());
     return true;
 };

--- a/src/viam/sdk/components/power_sensor/power_sensor.cpp
+++ b/src/viam/sdk/components/power_sensor/power_sensor.cpp
@@ -18,7 +18,7 @@ API PowerSensor::api() const {
     return API::get<PowerSensor>();
 }
 
-API API::api_map<PowerSensor>::api() {
+API API::traits<PowerSensor>::api() {
     return {kRDK, kComponent, "power_sensor"};
 }
 

--- a/src/viam/sdk/components/power_sensor/power_sensor.cpp
+++ b/src/viam/sdk/components/power_sensor/power_sensor.cpp
@@ -14,12 +14,8 @@ using namespace viam::component::powersensor::v1;
 namespace viam {
 namespace sdk {
 
-API PowerSensor::static_api() {
-    return {kRDK, kComponent, "power_sensor"};
-}
-
-API PowerSensor::dynamic_api() const {
-    return static_api();
+API PowerSensor::api() const {
+    return API::for_t<PowerSensor>();
 }
 
 PowerSensor::voltage PowerSensor::from_proto(GetVoltageResponse proto) {
@@ -69,7 +65,7 @@ class PowerSensorRegistration final
 };
 
 bool init() {
-    Registry::register_resource(PowerSensor::static_api(),
+    Registry::register_resource(API::for_t<PowerSensor>(),
                                 PowerSensorRegistration::resource_registration());
     return true;
 };

--- a/src/viam/sdk/components/power_sensor/power_sensor.hpp
+++ b/src/viam/sdk/components/power_sensor/power_sensor.hpp
@@ -44,8 +44,7 @@ class PowerSensor : public Component {
         bool is_ac;
     };
 
-    static API static_api();
-    API dynamic_api() const override;
+    API api() const override;
 
     /// @brief Creates a `voltage` struct from its proto representation.
     static voltage from_proto(GetVoltageResponse proto);
@@ -110,6 +109,13 @@ class PowerSensor : public Component {
 
    protected:
     explicit PowerSensor(std::string name) : Component(std::move(name)){};
+};
+
+template <>
+struct API::api_map<PowerSensor> {
+    static API api() {
+        return {kRDK, kComponent, "power_sensor"};
+    }
 };
 
 bool operator==(const PowerSensor::voltage& lhs, const PowerSensor::voltage& rhs);

--- a/src/viam/sdk/components/power_sensor/power_sensor.hpp
+++ b/src/viam/sdk/components/power_sensor/power_sensor.hpp
@@ -113,9 +113,7 @@ class PowerSensor : public Component {
 
 template <>
 struct API::api_map<PowerSensor> {
-    static API api() {
-        return {kRDK, kComponent, "power_sensor"};
-    }
+    static API api();
 };
 
 bool operator==(const PowerSensor::voltage& lhs, const PowerSensor::voltage& rhs);

--- a/src/viam/sdk/components/power_sensor/power_sensor.hpp
+++ b/src/viam/sdk/components/power_sensor/power_sensor.hpp
@@ -112,7 +112,7 @@ class PowerSensor : public Component {
 };
 
 template <>
-struct API::api_map<PowerSensor> {
+struct API::traits<PowerSensor> {
     static API api();
 };
 

--- a/src/viam/sdk/components/sensor/sensor.cpp
+++ b/src/viam/sdk/components/sensor/sensor.cpp
@@ -11,12 +11,8 @@
 namespace viam {
 namespace sdk {
 
-API Sensor::static_api() {
-    return {kRDK, kComponent, "sensor"};
-}
-
-API Sensor::dynamic_api() const {
-    return static_api();
+API Sensor::api() const {
+    return API::for_t<Sensor>();
 }
 
 namespace {
@@ -30,7 +26,7 @@ class SensorRegistration final
 };
 
 bool init() {
-    Registry::register_resource(Sensor::static_api(), SensorRegistration::resource_registration());
+    Registry::register_resource(API::for_t<Sensor>(), SensorRegistration::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/sensor/sensor.cpp
+++ b/src/viam/sdk/components/sensor/sensor.cpp
@@ -15,7 +15,7 @@ API Sensor::api() const {
     return API::get<Sensor>();
 }
 
-API API::api_map<Sensor>::api() {
+API API::traits<Sensor>::api() {
     return {kRDK, kComponent, "sensor"};
 }
 

--- a/src/viam/sdk/components/sensor/sensor.cpp
+++ b/src/viam/sdk/components/sensor/sensor.cpp
@@ -12,7 +12,11 @@ namespace viam {
 namespace sdk {
 
 API Sensor::api() const {
-    return API::for_t<Sensor>();
+    return API::get<Sensor>();
+}
+
+API API::api_map<Sensor>::api() {
+    return {kRDK, kComponent, "sensor"};
 }
 
 namespace {
@@ -26,7 +30,7 @@ class SensorRegistration final
 };
 
 bool init() {
-    Registry::register_resource(API::for_t<Sensor>(), SensorRegistration::resource_registration());
+    Registry::register_resource(API::get<Sensor>(), SensorRegistration::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/sensor/sensor.hpp
+++ b/src/viam/sdk/components/sensor/sensor.hpp
@@ -60,7 +60,7 @@ class Sensor : public Component {
 };
 
 template <>
-struct API::api_map<Sensor> {
+struct API::traits<Sensor> {
     static API api();
 };
 

--- a/src/viam/sdk/components/sensor/sensor.hpp
+++ b/src/viam/sdk/components/sensor/sensor.hpp
@@ -61,9 +61,7 @@ class Sensor : public Component {
 
 template <>
 struct API::api_map<Sensor> {
-    static API api() {
-        return {kRDK, kComponent, "sensor"};
-    }
+    static API api();
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/sensor/sensor.hpp
+++ b/src/viam/sdk/components/sensor/sensor.hpp
@@ -26,8 +26,7 @@ namespace sdk {
 /// specific sensor implementations. This class cannot be used on its own.
 class Sensor : public Component {
    public:
-    static API static_api();
-    API dynamic_api() const override;
+    API api() const override;
 
     /// @brief Send/receive arbitrary commands to the resource.
     /// @param Command the command to execute.
@@ -58,6 +57,13 @@ class Sensor : public Component {
 
    protected:
     explicit Sensor(std::string name) : Component(std::move(name)){};
+};
+
+template <>
+struct API::api_map<Sensor> {
+    static API api() {
+        return {kRDK, kComponent, "sensor"};
+    }
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/servo/servo.cpp
+++ b/src/viam/sdk/components/servo/servo.cpp
@@ -35,7 +35,11 @@ std::shared_ptr<ResourceRegistration> Servo::resource_registration() {
 }
 
 API Servo::api() const {
-    return API::for_t<Servo>();
+    return API::get<Servo>();
+}
+
+API API::api_map<Servo>::api() {
+    return {kRDK, kComponent, "servo"};
 }
 
 Servo::position Servo::from_proto(viam::component::servo::v1::GetPositionResponse proto) {
@@ -44,7 +48,7 @@ Servo::position Servo::from_proto(viam::component::servo::v1::GetPositionRespons
 
 namespace {
 bool init() {
-    Registry::register_resource(API::for_t<Servo>(), Servo::resource_registration());
+    Registry::register_resource(API::get<Servo>(), Servo::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/servo/servo.cpp
+++ b/src/viam/sdk/components/servo/servo.cpp
@@ -38,7 +38,7 @@ API Servo::api() const {
     return API::get<Servo>();
 }
 
-API API::api_map<Servo>::api() {
+API API::traits<Servo>::api() {
     return {kRDK, kComponent, "servo"};
 }
 

--- a/src/viam/sdk/components/servo/servo.cpp
+++ b/src/viam/sdk/components/servo/servo.cpp
@@ -34,12 +34,8 @@ std::shared_ptr<ResourceRegistration> Servo::resource_registration() {
     return std::make_shared<ServoRegistration>(sd);
 }
 
-API Servo::static_api() {
-    return {kRDK, kComponent, "servo"};
-}
-
-API Servo::dynamic_api() const {
-    return static_api();
+API Servo::api() const {
+    return API::for_t<Servo>();
 }
 
 Servo::position Servo::from_proto(viam::component::servo::v1::GetPositionResponse proto) {
@@ -48,7 +44,7 @@ Servo::position Servo::from_proto(viam::component::servo::v1::GetPositionRespons
 
 namespace {
 bool init() {
-    Registry::register_resource(Servo::static_api(), Servo::resource_registration());
+    Registry::register_resource(API::for_t<Servo>(), Servo::resource_registration());
     return true;
 };
 

--- a/src/viam/sdk/components/servo/servo.hpp
+++ b/src/viam/sdk/components/servo/servo.hpp
@@ -101,7 +101,7 @@ class Servo : public Component, public Stoppable {
 };
 
 template <>
-struct API::api_map<Servo> {
+struct API::traits<Servo> {
     static API api();
 };
 

--- a/src/viam/sdk/components/servo/servo.hpp
+++ b/src/viam/sdk/components/servo/servo.hpp
@@ -102,9 +102,7 @@ class Servo : public Component, public Stoppable {
 
 template <>
 struct API::api_map<Servo> {
-    static API api() {
-        return {kRDK, kComponent, "servo"};
-    }
+    static API api();
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/components/servo/servo.hpp
+++ b/src/viam/sdk/components/servo/servo.hpp
@@ -40,9 +40,8 @@ class Servo : public Component, public Stoppable {
     /// @brief Current position of the servo relative to its home
     typedef uint32_t position;
 
-    static API static_api();
     static std::shared_ptr<ResourceRegistration> resource_registration();
-    API dynamic_api() const override;
+    API api() const override;
 
     /// @brief Creates a `position` struct from its proto representation.
     static position from_proto(viam::component::servo::v1::GetPositionResponse proto);
@@ -100,5 +99,13 @@ class Servo : public Component, public Stoppable {
    protected:
     explicit Servo(std::string name) : Component(std::move(name)){};
 };
+
+template <>
+struct API::api_map<Servo> {
+    static API api() {
+        return {kRDK, kComponent, "servo"};
+    }
+};
+
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/resource/resource.cpp
+++ b/src/viam/sdk/resource/resource.cpp
@@ -19,17 +19,13 @@ std::string Resource::name() const {
     return name_;
 }
 
-API Resource::static_api() {
-    return {kRDK, kResource, "Resource"};
-}
-
 void Resource::reconfigure(Dependencies deps, ResourceConfig cfg){};
 
 ResourceName Resource::get_resource_name(std::string name) {
     ResourceName r;
     *r.mutable_namespace_() = kRDK;
     *r.mutable_type() = kResource;
-    *r.mutable_subtype() = this->dynamic_api().resource_subtype();
+    *r.mutable_subtype() = this->api().resource_subtype();
     *r.mutable_name() = std::move(name);
 
     return r;

--- a/src/viam/sdk/resource/resource.hpp
+++ b/src/viam/sdk/resource/resource.hpp
@@ -18,10 +18,9 @@ class Resource {
    public:
     virtual ~Resource();
     explicit Resource(std::string name);
-    static API static_api();
 
     /// @brief Returns the `API` associated with a particular resource.
-    virtual API dynamic_api() const = 0;
+    virtual API api() const = 0;
 
     /// @brief Returns a `ResourceName` for a particular resource name.
     virtual viam::common::v1::ResourceName get_resource_name(std::string name);
@@ -36,6 +35,13 @@ class Resource {
 
    private:
     std::string name_;
+};
+
+template <>
+struct API::api_map<Resource> {
+    static API api() {
+        return {"rdk", "resource", "Resource"};
+    }
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/resource/resource.hpp
+++ b/src/viam/sdk/resource/resource.hpp
@@ -38,7 +38,7 @@ class Resource {
 };
 
 template <>
-struct API::api_map<Resource> {
+struct API::traits<Resource> {
     static API api() {
         return {"rdk", "resource", "Resource"};
     }

--- a/src/viam/sdk/resource/resource_api.cpp
+++ b/src/viam/sdk/resource/resource_api.cpp
@@ -162,6 +162,11 @@ bool operator<(const API& lhs, const API& rhs) {
     return lhs.to_string() < rhs.to_string();
 }
 
+std::ostream& operator<<(std::ostream& os, const API& v) {
+    os << v.to_string();
+    return os;
+}
+
 bool operator==(const Name& lhs, const Name& rhs) {
     return lhs.to_string() == rhs.to_string();
 }

--- a/src/viam/sdk/resource/resource_api.hpp
+++ b/src/viam/sdk/resource/resource_api.hpp
@@ -47,11 +47,11 @@ class API : public APIType {
     friend std::ostream& operator<<(std::ostream& os, const API& v);
 
     template <typename T>
-    struct api_map;
+    struct traits;
 
     template <typename T>
     static API get() {
-        return api_map<T>::api();
+        return traits<T>::api();
     }
 
    private:

--- a/src/viam/sdk/resource/resource_api.hpp
+++ b/src/viam/sdk/resource/resource_api.hpp
@@ -50,7 +50,7 @@ class API : public APIType {
     struct api_map;
 
     template <typename T>
-    static API for_t() {
+    static API get() {
         return api_map<T>::api();
     }
 

--- a/src/viam/sdk/resource/resource_api.hpp
+++ b/src/viam/sdk/resource/resource_api.hpp
@@ -44,6 +44,15 @@ class API : public APIType {
     bool is_service_type();
     friend bool operator==(API const& lhs, API const& rhs);
     friend bool operator<(const API& lhs, const API& rhs);
+    friend std::ostream& operator<<(std::ostream& os, const API& v);
+
+    template <typename T>
+    struct api_map;
+
+    template <typename T>
+    static API for_t() {
+        return api_map<T>::api();
+    }
 
    private:
     std::string resource_subtype_;

--- a/src/viam/sdk/robot/client.hpp
+++ b/src/viam/sdk/robot/client.hpp
@@ -90,7 +90,7 @@ class RobotClient {
     /// @return a `shared_ptr` to the requested resource.
     std::shared_ptr<T> resource_by_name(std::string name) {
         ResourceName r;
-        API api = API::for_t<T>();
+        API api = API::get<T>();
         *r.mutable_namespace_() = api.type_namespace();
         *r.mutable_type() = api.resource_type();
         *r.mutable_subtype() = api.resource_subtype();

--- a/src/viam/sdk/robot/client.hpp
+++ b/src/viam/sdk/robot/client.hpp
@@ -90,7 +90,7 @@ class RobotClient {
     /// @return a `shared_ptr` to the requested resource.
     std::shared_ptr<T> resource_by_name(std::string name) {
         ResourceName r;
-        API api = T::static_api();
+        API api = API::for_t<T>();
         *r.mutable_namespace_() = api.type_namespace();
         *r.mutable_type() = api.resource_type();
         *r.mutable_subtype() = api.resource_subtype();

--- a/src/viam/sdk/robot/service.cpp
+++ b/src/viam/sdk/robot/service.cpp
@@ -46,8 +46,7 @@ std::vector<Status> RobotService_::generate_status(RepeatedPtrField<ResourceName
         const std::shared_ptr<Resource> resource = cmp.second;
         for (const auto& kv : Registry::registered_models()) {
             const std::shared_ptr<ModelRegistration> registration = kv.second;
-            if (registration->api().resource_subtype() ==
-                resource->api().resource_subtype()) {
+            if (registration->api().resource_subtype() == resource->api().resource_subtype()) {
                 bool resource_present = false;
                 const ResourceName name = resource->get_resource_name(resource->name());
                 for (auto& resource_name : resource_names) {

--- a/src/viam/sdk/robot/service.cpp
+++ b/src/viam/sdk/robot/service.cpp
@@ -47,7 +47,7 @@ std::vector<Status> RobotService_::generate_status(RepeatedPtrField<ResourceName
         for (const auto& kv : Registry::registered_models()) {
             const std::shared_ptr<ModelRegistration> registration = kv.second;
             if (registration->api().resource_subtype() ==
-                resource->dynamic_api().resource_subtype()) {
+                resource->api().resource_subtype()) {
                 bool resource_present = false;
                 const ResourceName name = resource->get_resource_name(resource->name());
                 for (auto& resource_name : resource_names) {

--- a/src/viam/sdk/services/mlmodel/mlmodel.cpp
+++ b/src/viam/sdk/services/mlmodel/mlmodel.cpp
@@ -47,7 +47,11 @@ std::shared_ptr<ResourceRegistration> MLModelService::resource_registration() {
 }
 
 API MLModelService::api() const {
-    return API::for_t<MLModelService>();
+    return API::get<MLModelService>();
+}
+
+API API::api_map<MLModelService>::api() {
+    return API(kRDK, kService, "mlmodel");
 }
 
 boost::optional<MLModelService::tensor_info::data_types>
@@ -174,7 +178,7 @@ MLModelService::MLModelService(std::string name) : Service(std::move(name)) {}
 
 namespace {
 bool init() {
-    Registry::register_resource(API::for_t<MLModelService>(),
+    Registry::register_resource(API::get<MLModelService>(),
                                 MLModelService::resource_registration());
     return true;
 };

--- a/src/viam/sdk/services/mlmodel/mlmodel.cpp
+++ b/src/viam/sdk/services/mlmodel/mlmodel.cpp
@@ -35,10 +35,6 @@ std::shared_ptr<Resource> MLModelServiceRegistration::create_rpc_client(
     return std::make_shared<MLModelServiceClient>(std::move(name), std::move(channel));
 };
 
-API MLModelService::static_api() {
-    return API(kRDK, kService, "mlmodel");
-}
-
 std::shared_ptr<ResourceRegistration> MLModelService::resource_registration() {
     const google::protobuf::DescriptorPool* p = google::protobuf::DescriptorPool::generated_pool();
     const google::protobuf::ServiceDescriptor* sd =
@@ -50,8 +46,8 @@ std::shared_ptr<ResourceRegistration> MLModelService::resource_registration() {
     return std::make_shared<MLModelServiceRegistration>(sd);
 }
 
-API MLModelService::dynamic_api() const {
-    return static_api();
+API MLModelService::api() const {
+    return API::for_t<MLModelService>();
 }
 
 boost::optional<MLModelService::tensor_info::data_types>
@@ -178,7 +174,7 @@ MLModelService::MLModelService(std::string name) : Service(std::move(name)) {}
 
 namespace {
 bool init() {
-    Registry::register_resource(MLModelService::static_api(),
+    Registry::register_resource(API::for_t<MLModelService>(),
                                 MLModelService::resource_registration());
     return true;
 };

--- a/src/viam/sdk/services/mlmodel/mlmodel.cpp
+++ b/src/viam/sdk/services/mlmodel/mlmodel.cpp
@@ -50,7 +50,7 @@ API MLModelService::api() const {
     return API::get<MLModelService>();
 }
 
-API API::api_map<MLModelService>::api() {
+API API::traits<MLModelService>::api() {
     return API(kRDK, kService, "mlmodel");
 }
 

--- a/src/viam/sdk/services/mlmodel/mlmodel.hpp
+++ b/src/viam/sdk/services/mlmodel/mlmodel.hpp
@@ -22,6 +22,7 @@
 
 #include <viam/api/service/mlmodel/v1/mlmodel.grpc.pb.h>
 
+#include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/registry/registry.hpp>
 #include <viam/sdk/resource/resource_manager.hpp>
 #include <viam/sdk/services/service.hpp>
@@ -62,9 +63,8 @@ class MLModelService : public Service {
     };
 
    public:
-    static API static_api();
     static std::shared_ptr<ResourceRegistration> resource_registration();
-    API dynamic_api() const override;
+    API api() const override;
 
     template <typename T>
     using tensor_view = typename make_tensor_view_<T>::type;
@@ -182,6 +182,13 @@ class MLModelService : public Service {
 
    protected:
     explicit MLModelService(std::string name);
+};
+
+template <>
+struct API::api_map<MLModelService> {
+    static API api() {
+        return API(kRDK, kService, "mlmodel");
+    }
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/services/mlmodel/mlmodel.hpp
+++ b/src/viam/sdk/services/mlmodel/mlmodel.hpp
@@ -185,7 +185,7 @@ class MLModelService : public Service {
 };
 
 template <>
-struct API::api_map<MLModelService> {
+struct API::traits<MLModelService> {
     static API api();
 };
 

--- a/src/viam/sdk/services/mlmodel/mlmodel.hpp
+++ b/src/viam/sdk/services/mlmodel/mlmodel.hpp
@@ -186,9 +186,7 @@ class MLModelService : public Service {
 
 template <>
 struct API::api_map<MLModelService> {
-    static API api() {
-        return API(kRDK, kService, "mlmodel");
-    }
+    static API api();
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/services/motion/motion.cpp
+++ b/src/viam/sdk/services/motion/motion.cpp
@@ -100,7 +100,7 @@ API Motion::api() const {
     return API::get<Motion>();
 }
 
-API API::api_map<Motion>::api() {
+API API::traits<Motion>::api() {
     return {kRDK, kService, "motion"};
 }
 

--- a/src/viam/sdk/services/motion/motion.cpp
+++ b/src/viam/sdk/services/motion/motion.cpp
@@ -96,12 +96,8 @@ Motion::constraints Motion::constraints::from_proto(const service::motion::v1::C
     return constraints;
 }
 
-API Motion::static_api() {
-    return {kRDK, kService, "motion"};
-}
-
-API Motion::dynamic_api() const {
-    return static_api();
+API Motion::api() const {
+    return API::for_t<Motion>();
 }
 
 std::shared_ptr<ResourceRegistration> Motion::resource_registration() {
@@ -435,7 +431,7 @@ service::motion::v1::PlanStatusWithID Motion::plan_status_with_id::to_proto() co
 
 namespace {
 bool init() {
-    Registry::register_resource(Motion::static_api(), Motion::resource_registration());
+    Registry::register_resource(API::for_t<Motion>(), Motion::resource_registration());
     return true;
 }
 

--- a/src/viam/sdk/services/motion/motion.cpp
+++ b/src/viam/sdk/services/motion/motion.cpp
@@ -97,7 +97,11 @@ Motion::constraints Motion::constraints::from_proto(const service::motion::v1::C
 }
 
 API Motion::api() const {
-    return API::for_t<Motion>();
+    return API::get<Motion>();
+}
+
+API API::api_map<Motion>::api() {
+    return {kRDK, kService, "motion"};
 }
 
 std::shared_ptr<ResourceRegistration> Motion::resource_registration() {
@@ -431,7 +435,7 @@ service::motion::v1::PlanStatusWithID Motion::plan_status_with_id::to_proto() co
 
 namespace {
 bool init() {
-    Registry::register_resource(API::for_t<Motion>(), Motion::resource_registration());
+    Registry::register_resource(API::get<Motion>(), Motion::resource_registration());
     return true;
 }
 

--- a/src/viam/sdk/services/motion/motion.hpp
+++ b/src/viam/sdk/services/motion/motion.hpp
@@ -499,9 +499,7 @@ class Motion : public Service {
 
 template <>
 struct API::api_map<Motion> {
-    static API api() {
-        return {kRDK, kService, "motion"};
-    }
+    static API api();
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/services/motion/motion.hpp
+++ b/src/viam/sdk/services/motion/motion.hpp
@@ -498,7 +498,7 @@ class Motion : public Service {
 };
 
 template <>
-struct API::api_map<Motion> {
+struct API::traits<Motion> {
     static API api();
 };
 

--- a/src/viam/sdk/services/motion/motion.hpp
+++ b/src/viam/sdk/services/motion/motion.hpp
@@ -240,8 +240,7 @@ class Motion : public Service {
         service::motion::v1::Constraints to_proto() const;
     };
 
-    static API static_api();
-    API dynamic_api() const override;
+    API api() const override;
 
     /// @brief Creates a `ResourceRegistration` for the `Motion` service.
     static std::shared_ptr<ResourceRegistration> resource_registration();
@@ -496,6 +495,13 @@ class Motion : public Service {
 
    protected:
     explicit Motion(std::string name);
+};
+
+template <>
+struct API::api_map<Motion> {
+    static API api() {
+        return {kRDK, kService, "motion"};
+    }
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/tests/test_base.cpp
+++ b/src/viam/sdk/tests/test_base.cpp
@@ -34,8 +34,8 @@ using boost::qvm::mag;
 BOOST_AUTO_TEST_SUITE(test_base)
 
 BOOST_AUTO_TEST_CASE(mock_get_api) {
-    const auto base = MockBase::get_mock_base();
-    auto api = base->api();
+    const MockBase base("mock_base");
+    auto api = base.api();
     auto static_api = API::for_t<Base>();
 
     BOOST_CHECK_EQUAL(api, static_api);

--- a/src/viam/sdk/tests/test_base.cpp
+++ b/src/viam/sdk/tests/test_base.cpp
@@ -33,6 +33,15 @@ using boost::qvm::mag;
 
 BOOST_AUTO_TEST_SUITE(test_base)
 
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    const auto base = MockBase::get_mock_base();
+    auto api = base->api();
+    auto static_api = API::for_t<Base>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "base");
+}
+
 // This sets up the following architecture
 // -- MockComponent
 //        /\

--- a/src/viam/sdk/tests/test_base.cpp
+++ b/src/viam/sdk/tests/test_base.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_SUITE(test_base)
 BOOST_AUTO_TEST_CASE(mock_get_api) {
     const MockBase base("mock_base");
     auto api = base.api();
-    auto static_api = API::for_t<Base>();
+    auto static_api = API::get<Base>();
 
     BOOST_CHECK_EQUAL(api, static_api);
     BOOST_CHECK_EQUAL(static_api.resource_subtype(), "base");

--- a/src/viam/sdk/tests/test_board.cpp
+++ b/src/viam/sdk/tests/test_board.cpp
@@ -29,6 +29,16 @@ using namespace board;
 using namespace viam::sdk;
 
 BOOST_AUTO_TEST_SUITE(test_board)
+
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    const MockBoard board("mock_board");
+    auto api = board.api();
+    auto static_api = API::for_t<Board>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "board");
+}
+
 // This sets up the following architecture
 // -- MockComponent
 //        /\

--- a/src/viam/sdk/tests/test_board.cpp
+++ b/src/viam/sdk/tests/test_board.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_SUITE(test_board)
 BOOST_AUTO_TEST_CASE(mock_get_api) {
     const MockBoard board("mock_board");
     auto api = board.api();
-    auto static_api = API::for_t<Board>();
+    auto static_api = API::get<Board>();
 
     BOOST_CHECK_EQUAL(api, static_api);
     BOOST_CHECK_EQUAL(static_api.resource_subtype(), "board");

--- a/src/viam/sdk/tests/test_camera.cpp
+++ b/src/viam/sdk/tests/test_camera.cpp
@@ -30,6 +30,14 @@ BOOST_AUTO_TEST_SUITE(test_camera)
 
 std::shared_ptr<MockCamera> camera = MockCamera::get_mock_camera();
 
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    auto api = camera->api();
+    auto static_api = API::for_t<Camera>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "camera");
+}
+
 BOOST_AUTO_TEST_CASE(test_get_image) {
     Camera::raw_image expected_image = fake_raw_image();
     Camera::raw_image image = camera->get_image("JPEG", {});

--- a/src/viam/sdk/tests/test_camera.cpp
+++ b/src/viam/sdk/tests/test_camera.cpp
@@ -32,7 +32,7 @@ std::shared_ptr<MockCamera> camera = MockCamera::get_mock_camera();
 
 BOOST_AUTO_TEST_CASE(mock_get_api) {
     auto api = camera->api();
-    auto static_api = API::for_t<Camera>();
+    auto static_api = API::get<Camera>();
 
     BOOST_CHECK_EQUAL(api, static_api);
     BOOST_CHECK_EQUAL(static_api.resource_subtype(), "camera");

--- a/src/viam/sdk/tests/test_encoder.cpp
+++ b/src/viam/sdk/tests/test_encoder.cpp
@@ -29,6 +29,16 @@ using namespace encoder;
 using namespace viam::sdk;
 
 BOOST_AUTO_TEST_SUITE(test_encoder)
+
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    const MockEncoder encoder("mock_encoder");
+    auto api = encoder.api();
+    auto static_api = API::for_t<Encoder>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "encoder");
+}
+
 // This sets up the following architecture
 // -- MockComponent
 //        /\

--- a/src/viam/sdk/tests/test_encoder.cpp
+++ b/src/viam/sdk/tests/test_encoder.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_SUITE(test_encoder)
 BOOST_AUTO_TEST_CASE(mock_get_api) {
     const MockEncoder encoder("mock_encoder");
     auto api = encoder.api();
-    auto static_api = API::for_t<Encoder>();
+    auto static_api = API::get<Encoder>();
 
     BOOST_CHECK_EQUAL(api, static_api);
     BOOST_CHECK_EQUAL(static_api.resource_subtype(), "encoder");

--- a/src/viam/sdk/tests/test_generic_component.cpp
+++ b/src/viam/sdk/tests/test_generic_component.cpp
@@ -30,7 +30,7 @@ std::shared_ptr<MockGeneric> generic = MockGeneric::get_mock_generic();
 BOOST_AUTO_TEST_CASE(mock_get_api) {
     const auto generic = MockGeneric::get_mock_generic();
     auto api = generic->api();
-    auto static_api = API::for_t<Generic>();
+    auto static_api = API::get<Generic>();
 
     BOOST_CHECK_EQUAL(api, static_api);
     BOOST_CHECK_EQUAL(static_api.resource_subtype(), "generic");

--- a/src/viam/sdk/tests/test_generic_component.cpp
+++ b/src/viam/sdk/tests/test_generic_component.cpp
@@ -27,6 +27,15 @@ BOOST_AUTO_TEST_SUITE(generic_suite)
 
 std::shared_ptr<MockGeneric> generic = MockGeneric::get_mock_generic();
 
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    const auto generic = MockGeneric::get_mock_generic();
+    auto api = generic->api();
+    auto static_api = API::for_t<Generic>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "generic");
+}
+
 BOOST_AUTO_TEST_CASE(test_do) {
     AttributeMap expected = fake_map();
 

--- a/src/viam/sdk/tests/test_mlmodel.cpp
+++ b/src/viam/sdk/tests/test_mlmodel.cpp
@@ -176,6 +176,15 @@ const struct MLModelService::metadata test_metadata {
 
 BOOST_AUTO_TEST_SUITE(test_mock_mlmodel)
 
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    const MockMLModelService mlms("mock_mlms");
+    auto api = mlms.api();
+    auto static_api = API::for_t<MLModelService>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "mlmodel");
+}
+
 BOOST_AUTO_TEST_CASE(mock_construction) {
     const std::string mock_name = "mocky mock";
     MockMLModelService mock_mlms(mock_name);

--- a/src/viam/sdk/tests/test_mlmodel.cpp
+++ b/src/viam/sdk/tests/test_mlmodel.cpp
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_SUITE(test_mock_mlmodel)
 BOOST_AUTO_TEST_CASE(mock_get_api) {
     const MockMLModelService mlms("mock_mlms");
     auto api = mlms.api();
-    auto static_api = API::for_t<MLModelService>();
+    auto static_api = API::get<MLModelService>();
 
     BOOST_CHECK_EQUAL(api, static_api);
     BOOST_CHECK_EQUAL(static_api.resource_subtype(), "mlmodel");

--- a/src/viam/sdk/tests/test_motion.cpp
+++ b/src/viam/sdk/tests/test_motion.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_SUITE(test_mock)
 BOOST_AUTO_TEST_CASE(mock_get_api) {
     const MockMotion motion("mock_motion");
     auto api = motion.api();
-    auto static_api = API::for_t<Motion>();
+    auto static_api = API::get<Motion>();
 
     BOOST_CHECK_EQUAL(api, static_api);
     BOOST_CHECK_EQUAL(static_api.resource_subtype(), "motion");

--- a/src/viam/sdk/tests/test_motion.cpp
+++ b/src/viam/sdk/tests/test_motion.cpp
@@ -36,6 +36,15 @@ WorldState mock_world_state() {
 
 BOOST_AUTO_TEST_SUITE(test_mock)
 
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    const MockMotion motion("mock_motion");
+    auto api = motion.api();
+    auto static_api = API::for_t<Motion>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "motion");
+}
+
 BOOST_AUTO_TEST_CASE(mock_move_and_get_pose) {
     std::shared_ptr<MockMotion> motion = MockMotion::get_mock_motion();
 

--- a/src/viam/sdk/tests/test_motor.cpp
+++ b/src/viam/sdk/tests/test_motor.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_SUITE(test_mock)
 BOOST_AUTO_TEST_CASE(mock_get_api) {
     const MockMotor motor("mock_motor");
     auto api = motor.api();
-    auto static_api = API::for_t<Motor>();
+    auto static_api = API::get<Motor>();
 
     BOOST_CHECK_EQUAL(api, static_api);
     BOOST_CHECK_EQUAL(static_api.resource_subtype(), "motor");

--- a/src/viam/sdk/tests/test_motor.cpp
+++ b/src/viam/sdk/tests/test_motor.cpp
@@ -28,6 +28,15 @@ using namespace viam::sdk;
 
 BOOST_AUTO_TEST_SUITE(test_mock)
 
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    const MockMotor motor("mock_motor");
+    auto api = motor.api();
+    auto static_api = API::for_t<Motor>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "motor");
+}
+
 BOOST_AUTO_TEST_CASE(mock_set_power) {
     std::shared_ptr<MockMotor> motor = MockMotor::get_mock_motor();
     motor->set_power(1.0);

--- a/src/viam/sdk/tests/test_movement_sensor.cpp
+++ b/src/viam/sdk/tests/test_movement_sensor.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_SUITE(test_movementsensor)
 BOOST_AUTO_TEST_CASE(mock_get_api) {
     const MockMovementSensor movement_sensor("mock_movement_sensor");
     auto api = movement_sensor.api();
-    auto static_api = API::for_t<MovementSensor>();
+    auto static_api = API::get<MovementSensor>();
 
     BOOST_CHECK_EQUAL(api, static_api);
     BOOST_CHECK_EQUAL(static_api.resource_subtype(), "movement_sensor");

--- a/src/viam/sdk/tests/test_movement_sensor.cpp
+++ b/src/viam/sdk/tests/test_movement_sensor.cpp
@@ -30,6 +30,15 @@ using namespace viam::sdk;
 
 BOOST_AUTO_TEST_SUITE(test_movementsensor)
 
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    const MockMovementSensor movement_sensor("mock_movement_sensor");
+    auto api = movement_sensor.api();
+    auto static_api = API::for_t<MovementSensor>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "movement_sensor");
+}
+
 // This sets up the following architecture
 // -- MockComponent
 //        /\

--- a/src/viam/sdk/tests/test_power_sensor.cpp
+++ b/src/viam/sdk/tests/test_power_sensor.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_SUITE(test_powersensor)
 BOOST_AUTO_TEST_CASE(mock_get_api) {
     const MockPowerSensor power_sensor("mock_power_sensor");
     auto api = power_sensor.api();
-    auto static_api = API::for_t<PowerSensor>();
+    auto static_api = API::get<PowerSensor>();
 
     BOOST_CHECK_EQUAL(api, static_api);
     BOOST_CHECK_EQUAL(static_api.resource_subtype(), "power_sensor");

--- a/src/viam/sdk/tests/test_power_sensor.cpp
+++ b/src/viam/sdk/tests/test_power_sensor.cpp
@@ -29,6 +29,15 @@ using namespace viam::sdk;
 
 BOOST_AUTO_TEST_SUITE(test_powersensor)
 
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    const MockPowerSensor power_sensor("mock_power_sensor");
+    auto api = power_sensor.api();
+    auto static_api = API::for_t<PowerSensor>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "power_sensor");
+}
+
 // This sets up the following architecture
 // -- MockComponent
 //        /\

--- a/src/viam/sdk/tests/test_robot.cpp
+++ b/src/viam/sdk/tests/test_robot.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(test_registering_resources) {
     // constructors. This tests that we register correctly.
     Model camera_model("fake", "fake", "mock_camera");
     std::shared_ptr<ModelRegistration> cr = std::make_shared<ModelRegistration>(
-        API::for_t<Camera>(),
+        API::get<Camera>(),
         camera_model,
         [](Dependencies, ResourceConfig cfg) { return camera::MockCamera::get_mock_camera(); },
         [](ResourceConfig cfg) -> std::vector<std::string> { return {}; });
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(test_registering_resources) {
 
     Model generic_model("fake", "fake", "mock_generic");
     std::shared_ptr<ModelRegistration> gr = std::make_shared<ModelRegistration>(
-        API::for_t<Generic>(),
+        API::get<Generic>(),
         generic_model,
         [](Dependencies, ResourceConfig cfg) { return generic::MockGeneric::get_mock_generic(); },
         [](ResourceConfig cfg) -> std::vector<std::string> { return {}; });
@@ -78,15 +78,15 @@ BOOST_AUTO_TEST_CASE(test_registering_resources) {
 
     Model motor_model("fake", "fake", "mock_motor");
     std::shared_ptr<ModelRegistration> mr = std::make_shared<ModelRegistration>(
-        API::for_t<Motor>(),
+        API::get<Motor>(),
         motor_model,
         [](Dependencies, ResourceConfig cfg) { return motor::MockMotor::get_mock_motor(); },
         [](ResourceConfig cfg) -> std::vector<std::string> { return {}; });
     Registry::register_model(mr);
 
-    BOOST_CHECK(Registry::lookup_model(API::for_t<Camera>(), camera_model));
-    BOOST_CHECK(Registry::lookup_model(API::for_t<Generic>(), generic_model));
-    BOOST_CHECK(Registry::lookup_model(API::for_t<Motor>(), motor_model));
+    BOOST_CHECK(Registry::lookup_model(API::get<Camera>(), camera_model));
+    BOOST_CHECK(Registry::lookup_model(API::get<Generic>(), generic_model));
+    BOOST_CHECK(Registry::lookup_model(API::get<Motor>(), motor_model));
 }
 
 template <typename T>
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(test_get_resource) {
     server_to_client_pipeline(
         [](std::shared_ptr<RobotClient> client, MockRobotService& service) -> void {
             auto mock_motor = client->resource_by_name<Motor>("mock_motor");
-            BOOST_CHECK(mock_motor != nullptr);
+            BOOST_CHECK(mock_motor);
         });
 }
 

--- a/src/viam/sdk/tests/test_robot.cpp
+++ b/src/viam/sdk/tests/test_robot.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(test_registering_resources) {
     // constructors. This tests that we register correctly.
     Model camera_model("fake", "fake", "mock_camera");
     std::shared_ptr<ModelRegistration> cr = std::make_shared<ModelRegistration>(
-        Camera::static_api(),
+        API::for_t<Camera>(),
         camera_model,
         [](Dependencies, ResourceConfig cfg) { return camera::MockCamera::get_mock_camera(); },
         [](ResourceConfig cfg) -> std::vector<std::string> { return {}; });
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(test_registering_resources) {
 
     Model generic_model("fake", "fake", "mock_generic");
     std::shared_ptr<ModelRegistration> gr = std::make_shared<ModelRegistration>(
-        Generic::static_api(),
+        API::for_t<Generic>(),
         generic_model,
         [](Dependencies, ResourceConfig cfg) { return generic::MockGeneric::get_mock_generic(); },
         [](ResourceConfig cfg) -> std::vector<std::string> { return {}; });
@@ -78,15 +78,15 @@ BOOST_AUTO_TEST_CASE(test_registering_resources) {
 
     Model motor_model("fake", "fake", "mock_motor");
     std::shared_ptr<ModelRegistration> mr = std::make_shared<ModelRegistration>(
-        Motor::static_api(),
+        API::for_t<Motor>(),
         motor_model,
         [](Dependencies, ResourceConfig cfg) { return motor::MockMotor::get_mock_motor(); },
         [](ResourceConfig cfg) -> std::vector<std::string> { return {}; });
     Registry::register_model(mr);
 
-    BOOST_CHECK(Registry::lookup_model(Camera::static_api(), camera_model));
-    BOOST_CHECK(Registry::lookup_model(Generic::static_api(), generic_model));
-    BOOST_CHECK(Registry::lookup_model(Motor::static_api(), motor_model));
+    BOOST_CHECK(Registry::lookup_model(API::for_t<Camera>(), camera_model));
+    BOOST_CHECK(Registry::lookup_model(API::for_t<Generic>(), generic_model));
+    BOOST_CHECK(Registry::lookup_model(API::for_t<Motor>(), motor_model));
 }
 
 template <typename T>
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(test_stop_all) {
 BOOST_AUTO_TEST_CASE(test_get_resource) {
     server_to_client_pipeline(
         [](std::shared_ptr<RobotClient> client, MockRobotService& service) -> void {
-            auto mock_motor = client->resource_by_name<MotorClient>("mock_motor");
+            auto mock_motor = client->resource_by_name<Motor>("mock_motor");
             BOOST_CHECK(mock_motor);
         });
 }

--- a/src/viam/sdk/tests/test_robot.cpp
+++ b/src/viam/sdk/tests/test_robot.cpp
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(test_get_resource) {
     server_to_client_pipeline(
         [](std::shared_ptr<RobotClient> client, MockRobotService& service) -> void {
             auto mock_motor = client->resource_by_name<Motor>("mock_motor");
-            BOOST_CHECK(mock_motor);
+            BOOST_CHECK(mock_motor != nullptr);
         });
 }
 

--- a/src/viam/sdk/tests/test_sensor.cpp
+++ b/src/viam/sdk/tests/test_sensor.cpp
@@ -30,6 +30,15 @@ using namespace viam::sdk;
 
 BOOST_AUTO_TEST_SUITE(test_sensor)
 
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    const MockSensor sensor("mock_sensor");
+    auto api = sensor.api();
+    auto static_api = API::for_t<Sensor>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "sensor");
+}
+
 // This sets up the following architecture
 // -- MockComponent
 //        /\

--- a/src/viam/sdk/tests/test_sensor.cpp
+++ b/src/viam/sdk/tests/test_sensor.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_SUITE(test_sensor)
 BOOST_AUTO_TEST_CASE(mock_get_api) {
     const MockSensor sensor("mock_sensor");
     auto api = sensor.api();
-    auto static_api = API::for_t<Sensor>();
+    auto static_api = API::get<Sensor>();
 
     BOOST_CHECK_EQUAL(api, static_api);
     BOOST_CHECK_EQUAL(static_api.resource_subtype(), "sensor");

--- a/src/viam/sdk/tests/test_servo.cpp
+++ b/src/viam/sdk/tests/test_servo.cpp
@@ -28,6 +28,15 @@ using namespace viam::sdk;
 
 BOOST_AUTO_TEST_SUITE(test_mock)
 
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    const MockServo servo("mock_servo");
+    auto api = servo.api();
+    auto static_api = API::for_t<Servo>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "servo");
+}
+
 BOOST_AUTO_TEST_CASE(mock_move_and_get_position) {
     std::shared_ptr<MockServo> servo = MockServo::get_mock_servo();
 

--- a/src/viam/sdk/tests/test_servo.cpp
+++ b/src/viam/sdk/tests/test_servo.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_SUITE(test_mock)
 BOOST_AUTO_TEST_CASE(mock_get_api) {
     const MockServo servo("mock_servo");
     auto api = servo.api();
-    auto static_api = API::for_t<Servo>();
+    auto static_api = API::get<Servo>();
 
     BOOST_CHECK_EQUAL(api, static_api);
     BOOST_CHECK_EQUAL(static_api.resource_subtype(), "servo");


### PR DESCRIPTION
#### Major Changes
Moves `static_api()` method to be a templated method on the `API` class, renames `dynamic_api()` methods to just `api()`.

#### Note to reviewers
There's the potential for a pretty significant change that comes with this. In short: getting the `API` on a `{ResourceType}Client` worked before because the `{ResourceType}` base class had a static `static_api` method that the `Client` type inherited. Now that the static method is on `API`, the `Client` types aren't inheriting it and so additional work is necessary. I can see two potential solutions here: 
1) start treating `{ResourceType}Client`s as `{ResourceType}`s in code. This works as expected, but is a bit of a gotcha. Additionally, if new methods existed solely on the `Client` class then we'd have to do some typecasting shenanigans to access then. I'm not sure how much of a concern this is in practice (I believe at this point all our `client`s just implement the base class methods without adding anything new) but in principle it could be concerning.
2) Additionally add the templated `struct` required by the `Api::for_t` method to all `Client` wrappers. This is verbose and adds more boilerplate, which makes the gains from this PR feel a bit smaller. It still creats a more intuitive user experience however, and is the more defensive approach imo.
3) We could create a dummy `T` in the `resource_by_name<T>(...)` method and then grab the `API` dynamically from the `T::api()` method. This seems bad because 1) it is hacky, and 2) it solves the problem in its current expression (`resource_by_name<T>` isn't working when the `T` is a `client` wrapper) only and fails to solve it if `Api::for_t<Client>` is called directly.

I ended up going with option (1) in this PR not because I'm convinced it's the better choice, but simply to provide more direct visibility into what this change necessitates. Personally I'm a bit inclined to go with option (2) but I certainly welcome feedback from reviewers on their preferences, or suggestions for a better approach.