### PR TITLE
RSDK-3019 - add clang-tidy performance-move-const-arg

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,6 @@
 # readability-implicit-bool-conversion: We have decided that !ptr-type is cleaner than ptr-type==nullptr
 # readability-magic-numbers: This encourages useless variables and extra lint lines
 # performance-unnecessary-value-param: TODO(RSDK-3007) remove this and fix all lints.
-# performance-move-const-arg: TODO(RSDK-3019)
 # misc-unused-parameters: TODO(RSDK-3008) remove this and fix all lints.
 # misc-include-cleaner: TODO(RSDK-5479) this is overly finnicky, add IWYU support and fix.
 # readability-function-cognitive-complexity: No, complexity is subjective and sometimes necessary.
@@ -29,7 +28,6 @@ Checks: >
   -readability-implicit-bool-conversion,
   -readability-magic-numbers,
   -performance-unnecessary-value-param,
-  -performance-move-const-arg,
   -misc-unused-parameters,
   -misc-include-cleaner,
   -readability-function-cognitive-complexity,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,3 +39,5 @@ CheckOptions:
     value: true
   - key: readability-function-cognitive-complexity.Threshold
     value: 30
+  - key: performance-move-const-arg.CheckTriviallyCopyableMove
+    value: false

--- a/src/viam/sdk/registry/registry.cpp
+++ b/src/viam/sdk/registry/registry.cpp
@@ -57,13 +57,13 @@ const Model& ModelRegistration::model() const {
 };
 
 void Registry::register_model(std::shared_ptr<const ModelRegistration> resource) {
-    const std::string reg_key = resource->api().to_string() + "/" + resource->model().to_string();
+    std::string reg_key = resource->api().to_string() + "/" + resource->model().to_string();
     if (resources_.find(reg_key) != resources_.end()) {
         const std::string err = "Cannot add resource with name " + reg_key + "as it already exists";
         throw std::runtime_error(err);
     }
 
-    resources_.emplace(reg_key, std::move(resource));
+    resources_.emplace(std::move(reg_key), std::move(resource));
 }
 
 void Registry::register_resource_server_(

--- a/src/viam/sdk/registry/registry.cpp
+++ b/src/viam/sdk/registry/registry.cpp
@@ -95,14 +95,14 @@ std::shared_ptr<const ModelRegistration> Registry::lookup_model_inlock_(
 
 std::shared_ptr<const ModelRegistration> Registry::lookup_model(const std::string& name) {
     const std::lock_guard<std::mutex> lock(lock_);
-    return lookup_model_inlock_(name, std::move(lock));
+    return lookup_model_inlock_(name, lock);
 }
 
 std::shared_ptr<const ModelRegistration> Registry::lookup_model(const API& api,
                                                                 const Model& model) {
     const std::lock_guard<std::mutex> lock(lock_);
     const std::string name = api.to_string() + "/" + model.to_string();
-    return lookup_model_inlock_(name, std::move(lock));
+    return lookup_model_inlock_(name, lock);
 }
 
 std::shared_ptr<const ResourceServerRegistration> Registry::lookup_resource_server(const API& api) {

--- a/src/viam/sdk/registry/registry.cpp
+++ b/src/viam/sdk/registry/registry.cpp
@@ -63,7 +63,7 @@ void Registry::register_model(std::shared_ptr<const ModelRegistration> resource)
         throw std::runtime_error(err);
     }
 
-    resources_.emplace(std::move(reg_key), std::move(resource));
+    resources_.emplace(reg_key, std::move(resource));
 }
 
 void Registry::register_resource_server_(
@@ -102,7 +102,7 @@ std::shared_ptr<const ModelRegistration> Registry::lookup_model(const API& api,
                                                                 const Model& model) {
     const std::lock_guard<std::mutex> lock(lock_);
     const std::string name = api.to_string() + "/" + model.to_string();
-    return lookup_model_inlock_(std::move(name), std::move(lock));
+    return lookup_model_inlock_(name, std::move(lock));
 }
 
 std::shared_ptr<const ResourceServerRegistration> Registry::lookup_resource_server(const API& api) {

--- a/src/viam/sdk/resource/resource_api.cpp
+++ b/src/viam/sdk/resource/resource_api.cpp
@@ -200,12 +200,12 @@ bool operator==(const Model& lhs, const Model& rhs) {
 RPCSubtype::RPCSubtype(API api,
                        std::string proto_service_name,
                        const google::protobuf::ServiceDescriptor& descriptor)
-    : descriptor_(std::move(descriptor)),
+    : descriptor_(descriptor),
       proto_service_name_(std::move(proto_service_name)),
       api_(std::move(api)) {}
 
 RPCSubtype::RPCSubtype(API api, const google::protobuf::ServiceDescriptor& descriptor)
-    : descriptor_(std::move(descriptor)), api_(std::move(api)) {}
+    : descriptor_(descriptor), api_(std::move(api)) {}
 
 const std::string& RPCSubtype::proto_service_name() const {
     return proto_service_name_;

--- a/src/viam/sdk/resource/resource_manager.cpp
+++ b/src/viam/sdk/resource/resource_manager.cpp
@@ -47,9 +47,9 @@ void ResourceManager::replace_all(
     this->resources_ = new_resources;
     this->short_names_ = new_short_names;
 
-    for (auto resource : resources) {
+    for (const auto& resource : resources) {
         try {
-            do_add(resource.first, std::move(resource.second));
+            do_add(resource.first, resource.second);
         } catch (std::exception& exc) {
             BOOST_LOG_TRIVIAL(error) << "Error replacing all resources" << exc.what();
             return;
@@ -65,7 +65,7 @@ std::string get_shortcut_name(const std::string& name) {
     return name_split.at(name_split.size() - 1);
 }
 
-void ResourceManager::do_add(Name name, std::shared_ptr<Resource> resource) {
+void ResourceManager::do_add(const Name& name, std::shared_ptr<Resource> resource) {
     if (name.name().empty()) {
         throw "Empty name used for resource: " + name.to_string();
     }
@@ -90,10 +90,10 @@ void ResourceManager::do_add(std::string name, std::shared_ptr<Resource> resourc
     resources_.emplace(std::move(name), std::move(resource));
 }
 
-void ResourceManager::add(Name name, std::shared_ptr<Resource> resource) {
+void ResourceManager::add(const Name& name, std::shared_ptr<Resource> resource) {
     const std::lock_guard<std::mutex> lock(lock_);
     try {
-        do_add(std::move(name), std::move(resource));
+        do_add(name, std::move(resource));
     } catch (std::exception& exc) {
         BOOST_LOG_TRIVIAL(error) << "Error adding resource to subtype service: " << exc.what();
     }
@@ -134,11 +134,11 @@ void ResourceManager::remove(const Name& name) {
     };
 };
 
-void ResourceManager::replace_one(Name name, std::shared_ptr<Resource> resource) {
+void ResourceManager::replace_one(const Name& name, std::shared_ptr<Resource> resource) {
     const std::lock_guard<std::mutex> lock(lock_);
     try {
         do_remove(name);
-        do_add(std::move(name), std::move(resource));
+        do_add(name, std::move(resource));
     } catch (std::exception& exc) {
         BOOST_LOG_TRIVIAL(error) << "failed to replace resource " << name.to_string() << ": "
                                  << exc.what();

--- a/src/viam/sdk/resource/resource_manager.hpp
+++ b/src/viam/sdk/resource/resource_manager.hpp
@@ -44,7 +44,7 @@ class ResourceManager {
     /// @brief Adds a single resource to the manager.
     /// @param name The name of the resource.
     /// @param resource The resource being added.
-    void add(Name name, std::shared_ptr<Resource> resource);
+    void add(const Name& name, std::shared_ptr<Resource> resource);
 
     /// @brief Adds a single resource to the manager.
     /// @param name The name of the resource.
@@ -58,7 +58,7 @@ class ResourceManager {
     /// @brief Replaces an existing resource. No-op if the named resource does not exist.
     /// @param name The name of the resource to replace.
     /// @param resource The new resource that is replacing the existing one.
-    void replace_one(Name name, std::shared_ptr<Resource> resource);
+    void replace_one(const Name& name, std::shared_ptr<Resource> resource);
 
     /// @brief Returns a reference to the existing resources within the manager.
     const std::unordered_map<std::string, std::shared_ptr<Resource>>& resources() const;
@@ -70,7 +70,7 @@ class ResourceManager {
     std::unordered_map<std::string, std::shared_ptr<Resource>> resources_;
     /// @brief `short_names_` is a shortened version of `Name` N of form <remote>:<name>.
     std::unordered_map<std::string, std::string> short_names_;
-    void do_add(Name name, std::shared_ptr<Resource> resource);
+    void do_add(const Name& name, std::shared_ptr<Resource> resource);
     void do_add(std::string name, std::shared_ptr<Resource> resource);
     void do_remove(const Name& name);
 };

--- a/src/viam/sdk/resource/resource_manager.hpp
+++ b/src/viam/sdk/resource/resource_manager.hpp
@@ -44,12 +44,12 @@ class ResourceManager {
     /// @brief Adds a single resource to the manager.
     /// @param name The name of the resource.
     /// @param resource The resource being added.
-    void add(const Name& name, const std::shared_ptr<Resource>& resource);
+    void add(Name name, std::shared_ptr<Resource> resource);
 
     /// @brief Adds a single resource to the manager.
     /// @param name The name of the resource.
     /// @param resource The resource being added.
-    void add(const std::string& name, const std::shared_ptr<Resource>& resource);
+    void add(std::string name, std::shared_ptr<Resource> resource);
 
     /// @brief Remodes a single resource from the manager.
     /// @param name The name of the resource to remove.
@@ -58,7 +58,7 @@ class ResourceManager {
     /// @brief Replaces an existing resource. No-op if the named resource does not exist.
     /// @param name The name of the resource to replace.
     /// @param resource The new resource that is replacing the existing one.
-    void replace_one(const Name& name, const std::shared_ptr<Resource>& resource);
+    void replace_one(Name name, std::shared_ptr<Resource> resource);
 
     /// @brief Returns a reference to the existing resources within the manager.
     const std::unordered_map<std::string, std::shared_ptr<Resource>>& resources() const;
@@ -70,8 +70,8 @@ class ResourceManager {
     std::unordered_map<std::string, std::shared_ptr<Resource>> resources_;
     /// @brief `short_names_` is a shortened version of `Name` N of form <remote>:<name>.
     std::unordered_map<std::string, std::string> short_names_;
-    void do_add(const Name& name, const std::shared_ptr<Resource>& resource);
-    void do_add(const std::string& name, const std::shared_ptr<Resource>& resource);
+    void do_add(Name name, std::shared_ptr<Resource> resource);
+    void do_add(std::string name, std::shared_ptr<Resource> resource);
     void do_remove(const Name& name);
 };
 

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -60,7 +60,7 @@ void DialOptions::set_entity(boost::optional<std::string> entity) {
 }
 
 void DialOptions::set_timeout(std::chrono::duration<float> timeout) {
-    timeout_ = timeout;
+    timeout_ = std::move(timeout);
 }
 
 const boost::optional<std::string>& DialOptions::entity() const {

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -60,7 +60,7 @@ void DialOptions::set_entity(boost::optional<std::string> entity) {
 }
 
 void DialOptions::set_timeout(std::chrono::duration<float> timeout) {
-    timeout_ = std::move(timeout);
+    timeout_ = timeout;
 }
 
 const boost::optional<std::string>& DialOptions::entity() const {

--- a/src/viam/sdk/rpc/server.cpp
+++ b/src/viam/sdk/rpc/server.cpp
@@ -47,8 +47,8 @@ void Server::add_resource(std::shared_ptr<Resource> resource) {
                << " but no matching resource server as found";
         throw std::runtime_error(buffer.str());
     }
-    auto resource_server = managed_servers_.at(std::move(api));
-    resource_server->resource_manager()->add(resource->name(), std::move(resource));
+    auto resource_server = managed_servers_.at(api);
+    resource_server->resource_manager()->add(resource->name(), resource);
 }
 
 void Server::start() {

--- a/src/viam/sdk/rpc/server.cpp
+++ b/src/viam/sdk/rpc/server.cpp
@@ -48,7 +48,8 @@ void Server::add_resource(std::shared_ptr<Resource> resource) {
         throw std::runtime_error(buffer.str());
     }
     auto resource_server = managed_servers_.at(api);
-    resource_server->resource_manager()->add(resource->name(), resource);
+    auto name = resource->name();
+    resource_server->resource_manager()->add(std::move(name), std::move(resource));
 }
 
 void Server::start() {

--- a/src/viam/sdk/services/mlmodel/client.cpp
+++ b/src/viam/sdk/services/mlmodel/client.cpp
@@ -69,7 +69,7 @@ std::shared_ptr<MLModelService::named_tensor_views> MLModelServiceClient::infer(
         aav->views.emplace(kv.first, std::move(tensor));
     }
     auto* const tsav_views = &aav->views;
-    return {std::move(aav), tsav_views};
+    return {aav, tsav_views};
 }
 
 struct MLModelService::metadata MLModelServiceClient::metadata(const AttributeMap& extra) {

--- a/src/viam/sdk/services/mlmodel/client.cpp
+++ b/src/viam/sdk/services/mlmodel/client.cpp
@@ -69,7 +69,11 @@ std::shared_ptr<MLModelService::named_tensor_views> MLModelServiceClient::infer(
         aav->views.emplace(kv.first, std::move(tensor));
     }
     auto* const tsav_views = &aav->views;
-    return {aav, tsav_views};
+    // This move does nothing pre-C++20 because the `shared_ptr` aliasing constructor takes
+    // its first arg by `const&`. However, having it here is harmless, and in C++20 this
+    // move would be correct to minimize refcount modification.
+    // NOLINTNEXTLINE(performance-move-const-arg)
+    return {std::move(aav), tsav_views};
 }
 
 struct MLModelService::metadata MLModelServiceClient::metadata(const AttributeMap& extra) {

--- a/src/viam/sdk/services/mlmodel/server.cpp
+++ b/src/viam/sdk/services/mlmodel/server.cpp
@@ -91,8 +91,8 @@ MLModelServiceServer::MLModelServiceServer(std::shared_ptr<ResourceManager> mana
             target.Reserve(source.size());
             for (auto&& s : source) {
                 auto& new_entry = *target.Add();
-                *new_entry.mutable_name() = std::move(s.name);
-                *new_entry.mutable_description() = std::move(s.description);
+                *new_entry.mutable_name() = s.name;
+                *new_entry.mutable_description() = s.description;
 
                 const auto* string_for_data_type =
                     MLModelService::tensor_info::data_type_to_string(s.data_type);
@@ -118,8 +118,8 @@ MLModelServiceServer::MLModelServiceServer(std::shared_ptr<ResourceManager> mana
                 associated_files.Reserve(s.associated_files.size());
                 for (auto&& af : s.associated_files) {
                     auto& new_af = *associated_files.Add();
-                    *new_af.mutable_name() = std::move(af.name);
-                    *new_af.mutable_description() = std::move(af.description);
+                    *new_af.mutable_name() = af.name;
+                    *new_af.mutable_description() = af.description;
                     switch (af.label_type) {
                         case MLModelService::tensor_info::file::k_label_type_tensor_value:
                             new_af.set_label_type(

--- a/src/viam/sdk/services/mlmodel/server.cpp
+++ b/src/viam/sdk/services/mlmodel/server.cpp
@@ -85,14 +85,13 @@ MLModelServiceServer::MLModelServiceServer(std::shared_ptr<ResourceManager> mana
         *metadata_pb.mutable_type() = std::move(md.type);
         *metadata_pb.mutable_description() = std::move(md.description);
 
-        const auto pack_tensor_info = [&helper](
-                                          auto& target,
-                                          const std::vector<MLModelService::tensor_info>& source) {
+        const auto pack_tensor_info = [&helper](auto& target,
+                                                std::vector<MLModelService::tensor_info>& source) {
             target.Reserve(source.size());
             for (auto&& s : source) {
                 auto& new_entry = *target.Add();
-                *new_entry.mutable_name() = s.name;
-                *new_entry.mutable_description() = s.description;
+                *new_entry.mutable_name() = std::move(s.name);
+                *new_entry.mutable_description() = std::move(s.description);
 
                 const auto* string_for_data_type =
                     MLModelService::tensor_info::data_type_to_string(s.data_type);
@@ -118,8 +117,8 @@ MLModelServiceServer::MLModelServiceServer(std::shared_ptr<ResourceManager> mana
                 associated_files.Reserve(s.associated_files.size());
                 for (auto&& af : s.associated_files) {
                     auto& new_af = *associated_files.Add();
-                    *new_af.mutable_name() = af.name;
-                    *new_af.mutable_description() = af.description;
+                    *new_af.mutable_name() = std::move(af.name);
+                    *new_af.mutable_description() = std::move(af.description);
                     switch (af.label_type) {
                         case MLModelService::tensor_info::file::k_label_type_tensor_value:
                             new_af.set_label_type(

--- a/src/viam/sdk/services/motion/client.cpp
+++ b/src/viam/sdk/services/motion/client.cpp
@@ -92,7 +92,7 @@ pose_in_frame MotionClient::get_pose(
         .with(extra,
               [&](auto& request) {
                   *request.mutable_component_name() = component_name.to_proto();
-                  *request.mutable_destination_frame() = std::move(destination_frame);
+                  *request.mutable_destination_frame() = destination_frame;
                   for (const auto& transform : supplemental_transforms) {
                       *request.mutable_supplemental_transforms()->Add() = transform.to_proto();
                   }

--- a/src/viam/sdk/services/motion/server.cpp
+++ b/src/viam/sdk/services/motion/server.cpp
@@ -94,7 +94,6 @@ MotionServer::MotionServer(std::shared_ptr<ResourceManager> manager)
     });
 }
 
-// CR erodkin: we weren't using `make_service_helper` here. Make note of flyby.
 ::grpc::Status MotionServer::GetPose(
     ::grpc::ServerContext* context,
     const ::viam::service::motion::v1::GetPoseRequest* request,

--- a/src/viam/sdk/spatialmath/geometry.cpp
+++ b/src/viam/sdk/spatialmath/geometry.cpp
@@ -130,7 +130,7 @@ std::vector<GeometryConfig> GeometryConfig::from_proto(
     const viam::common::v1::GetGeometriesResponse& proto) {
     std::vector<GeometryConfig> response;
     for (const auto& geometry : proto.geometries()) {
-        response.push_back(from_proto(std::move(geometry)));
+        response.push_back(from_proto(geometry));
     }
     return response;
 }
@@ -170,22 +170,22 @@ viam::common::v1::Geometry GeometryConfig::to_proto() const {
     }
 }
 void GeometryConfig::set_coordinates(coordinates coordinates) {
-    pose_.coordinates = std::move(coordinates);
+    pose_.coordinates = coordinates;
 }
 void GeometryConfig::set_pose(pose pose) {
-    pose_ = std::move(pose);
+    pose_ = pose;
 }
 void GeometryConfig::set_geometry_specifics(geometry_specifics gs) {
     geometry_specifics_ = std::move(gs);
 }
 void GeometryConfig::set_pose_orientation(pose_orientation orientation) {
-    pose_.orientation = std::move(orientation);
+    pose_.orientation = orientation;
 }
 void GeometryConfig::set_theta(double theta) {
-    pose_.theta = std::move(theta);
+    pose_.theta = theta;
 }
 void GeometryConfig::set_geometry_type(GeometryType type) {
-    geometry_type_ = std::move(type);
+    geometry_type_ = type;
 }
 void GeometryConfig::set_orientation_config(OrientationConfig config) {
     orientation_config_ = std::move(config);

--- a/src/viam/sdk/spatialmath/geometry.cpp
+++ b/src/viam/sdk/spatialmath/geometry.cpp
@@ -170,22 +170,22 @@ viam::common::v1::Geometry GeometryConfig::to_proto() const {
     }
 }
 void GeometryConfig::set_coordinates(coordinates coordinates) {
-    pose_.coordinates = coordinates;
+    pose_.coordinates = std::move(coordinates);
 }
 void GeometryConfig::set_pose(pose pose) {
-    pose_ = pose;
+    pose_ = std::move(pose);
 }
 void GeometryConfig::set_geometry_specifics(geometry_specifics gs) {
     geometry_specifics_ = std::move(gs);
 }
 void GeometryConfig::set_pose_orientation(pose_orientation orientation) {
-    pose_.orientation = orientation;
+    pose_.orientation = std::move(orientation);
 }
 void GeometryConfig::set_theta(double theta) {
-    pose_.theta = theta;
+    pose_.theta = std::move(theta);
 }
 void GeometryConfig::set_geometry_type(GeometryType type) {
-    geometry_type_ = type;
+    geometry_type_ = std::move(type);
 }
 void GeometryConfig::set_orientation_config(OrientationConfig config) {
     orientation_config_ = std::move(config);


### PR DESCRIPTION
- No longer disable `performance-move-const-arg` in `clang-tidy`. 
- Necessary fixes for `clang-tidy` to pass.