### PR TITLE
RSDK-3007 - add clang-tidy performance-unnecessary-value-param

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,7 +6,6 @@
 # readability-named-parameter: Useful to fix lints about unused parameters
 # readability-implicit-bool-conversion: We have decided that !ptr-type is cleaner than ptr-type==nullptr
 # readability-magic-numbers: This encourages useless variables and extra lint lines
-# performance-unnecessary-value-param: TODO(RSDK-3007) remove this and fix all lints.
 # performance-move-const-arg: TODO(RSDK-3019)
 # misc-unused-parameters: TODO(RSDK-3008) remove this and fix all lints.
 # misc-include-cleaner: TODO(RSDK-5479) this is overly finnicky, add IWYU support and fix.
@@ -28,7 +27,6 @@ Checks: >
   -readability-named-parameter,
   -readability-implicit-bool-conversion,
   -readability-magic-numbers,
-  -performance-unnecessary-value-param,
   -performance-move-const-arg,
   -misc-unused-parameters,
   -misc-include-cleaner,

--- a/src/viam/examples/modules/complex/base/impl.cpp
+++ b/src/viam/examples/modules/complex/base/impl.cpp
@@ -34,7 +34,7 @@ std::string find_motor(ResourceConfig cfg, std::string motor_name) {
     return *motor_string;
 }
 
-void MyBase::reconfigure(Dependencies deps, ResourceConfig cfg) {
+void MyBase::reconfigure(const Dependencies& deps, const ResourceConfig& cfg) {
     // Downcast `left` and `right` dependencies to motors.
     auto left = find_motor(cfg, "left");
     auto right = find_motor(cfg, "right");

--- a/src/viam/examples/modules/complex/base/impl.hpp
+++ b/src/viam/examples/modules/complex/base/impl.hpp
@@ -13,10 +13,10 @@ using namespace viam::sdk;
 // specifies a static `validate` method that checks config validity.
 class MyBase : public Base {
    public:
-    MyBase(Dependencies deps, ResourceConfig cfg) : Base(cfg.name()) {
+    MyBase(const Dependencies& deps, const ResourceConfig& cfg) : Base(cfg.name()) {
         this->reconfigure(deps, cfg);
     };
-    void reconfigure(Dependencies deps, ResourceConfig cfg) override;
+    void reconfigure(const Dependencies& deps, const ResourceConfig& cfg) override;
     static std::vector<std::string> validate(ResourceConfig cfg);
 
     bool is_moving() override;

--- a/src/viam/examples/modules/complex/gizmo/impl.cpp
+++ b/src/viam/examples/modules/complex/gizmo/impl.cpp
@@ -31,7 +31,7 @@ std::string find_arg1(ResourceConfig cfg) {
     return *arg1_string;
 }
 
-void MyGizmo::reconfigure(Dependencies deps, ResourceConfig cfg) {
+void MyGizmo::reconfigure(const Dependencies& deps, const ResourceConfig& cfg) {
     arg1_ = find_arg1(cfg);
 }
 

--- a/src/viam/examples/modules/complex/gizmo/impl.hpp
+++ b/src/viam/examples/modules/complex/gizmo/impl.hpp
@@ -14,10 +14,10 @@ using namespace viam::sdk;
 class MyGizmo : public Gizmo {
    public:
     MyGizmo(std::string name, std::string arg1) : Gizmo(std::move(name)), arg1_(std::move(arg1)){};
-    MyGizmo(Dependencies deps, ResourceConfig cfg) : Gizmo(cfg.name()) {
+    MyGizmo(const Dependencies& deps, const ResourceConfig& cfg) : Gizmo(cfg.name()) {
         this->reconfigure(deps, cfg);
     };
-    void reconfigure(Dependencies deps, ResourceConfig cfg) override;
+    void reconfigure(const Dependencies& deps, const ResourceConfig& cfg) override;
     static std::vector<std::string> validate(ResourceConfig cfg);
 
     bool do_one(std::string arg1) override;

--- a/src/viam/examples/modules/complex/summation/impl.cpp
+++ b/src/viam/examples/modules/complex/summation/impl.cpp
@@ -24,7 +24,7 @@ bool find_subtract(ResourceConfig cfg) {
     return *subtract_bool;
 }
 
-void MySummation::reconfigure(Dependencies deps, ResourceConfig cfg) {
+void MySummation::reconfigure(const Dependencies& deps, const ResourceConfig& cfg) {
     subtract_ = find_subtract(cfg);
 }
 

--- a/src/viam/examples/modules/complex/summation/impl.hpp
+++ b/src/viam/examples/modules/complex/summation/impl.hpp
@@ -12,10 +12,10 @@ class MySummation : public Summation {
    public:
     MySummation(std::string name, bool subtract)
         : Summation(std::move(name)), subtract_(subtract){};
-    MySummation(Dependencies deps, ResourceConfig cfg) : Summation(cfg.name()) {
+    MySummation(const Dependencies& deps, const ResourceConfig& cfg) : Summation(cfg.name()) {
         this->reconfigure(deps, cfg);
     };
-    void reconfigure(Dependencies deps, ResourceConfig cfg) override;
+    void reconfigure(const Dependencies& deps, const ResourceConfig& cfg) override;
     static std::vector<std::string> validate(ResourceConfig cfg);
 
     double sum(std::vector<double> numbers) override;

--- a/src/viam/sdk/common/linear_algebra.cpp
+++ b/src/viam/sdk/common/linear_algebra.cpp
@@ -53,7 +53,7 @@ viam::common::v1::Vector3 Vector3::to_proto(const Vector3& vec) {
     return result;
 };
 
-Vector3 Vector3::from_proto(viam::common::v1::Vector3 vec) {
+Vector3 Vector3::from_proto(const viam::common::v1::Vector3& vec) {
     return {vec.x(), vec.y(), vec.z()};
 }
 

--- a/src/viam/sdk/common/linear_algebra.cpp
+++ b/src/viam/sdk/common/linear_algebra.cpp
@@ -45,11 +45,11 @@ std::array<double, 3>& Vector3::data() {
     return this->data_;
 }
 
-viam::common::v1::Vector3 Vector3::to_proto(const Vector3& vec) {
+viam::common::v1::Vector3 Vector3::to_proto() const {
     viam::common::v1::Vector3 result;
-    result.set_x(vec.x());
-    result.set_y(vec.y());
-    result.set_z(vec.z());
+    result.set_x(x());
+    result.set_y(y());
+    result.set_z(z());
     return result;
 };
 

--- a/src/viam/sdk/common/linear_algebra.hpp
+++ b/src/viam/sdk/common/linear_algebra.hpp
@@ -30,7 +30,8 @@ class Vector3 {
 
     const std::array<scalar_type, 3>& data() const;
     std::array<scalar_type, 3>& data();
-    static viam::common::v1::Vector3 to_proto(const Vector3& vec);
+    // CR erodkin: this was static but there doesn't seem to be a good reason for that
+    viam::common::v1::Vector3 to_proto() const;
     static Vector3 from_proto(const viam::common::v1::Vector3& vec);
 
    private:

--- a/src/viam/sdk/common/linear_algebra.hpp
+++ b/src/viam/sdk/common/linear_algebra.hpp
@@ -31,7 +31,7 @@ class Vector3 {
     const std::array<scalar_type, 3>& data() const;
     std::array<scalar_type, 3>& data();
     static viam::common::v1::Vector3 to_proto(const Vector3& vec);
-    static Vector3 from_proto(viam::common::v1::Vector3 vec);
+    static Vector3 from_proto(const viam::common::v1::Vector3& vec);
 
    private:
     std::array<scalar_type, 3> data_;

--- a/src/viam/sdk/common/linear_algebra.hpp
+++ b/src/viam/sdk/common/linear_algebra.hpp
@@ -30,7 +30,6 @@ class Vector3 {
 
     const std::array<scalar_type, 3>& data() const;
     std::array<scalar_type, 3>& data();
-    // CR erodkin: this was static but there doesn't seem to be a good reason for that
     viam::common::v1::Vector3 to_proto() const;
     static Vector3 from_proto(const viam::common::v1::Vector3& vec);
 

--- a/src/viam/sdk/common/proto_type.cpp
+++ b/src/viam/sdk/common/proto_type.cpp
@@ -19,7 +19,7 @@ using google::protobuf::Struct;
 using google::protobuf::Value;
 
 // NOLINTNEXTLINE(misc-no-recursion)
-Struct map_to_struct(AttributeMap dict) {
+Struct map_to_struct(const AttributeMap& dict) {
     Struct s;
     if (!dict) {
         return s;
@@ -36,7 +36,7 @@ Struct map_to_struct(AttributeMap dict) {
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-AttributeMap struct_to_map(Struct struct_) {
+AttributeMap struct_to_map(const Struct& struct_) {
     std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> map =
         std::make_shared<std::unordered_map<std::string, std::shared_ptr<ProtoType>>>();
 

--- a/src/viam/sdk/common/proto_type.hpp
+++ b/src/viam/sdk/common/proto_type.hpp
@@ -82,8 +82,8 @@ class ProtoType {
         proto_type_;
 };
 
-AttributeMap struct_to_map(google::protobuf::Struct struct_);
-google::protobuf::Struct map_to_struct(AttributeMap dict);
+AttributeMap struct_to_map(const google::protobuf::Struct& struct_);
+google::protobuf::Struct map_to_struct(const AttributeMap& dict);
 
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/common/world_state.hpp
+++ b/src/viam/sdk/common/world_state.hpp
@@ -33,7 +33,7 @@ class WorldState {
 
     WorldState() {}
     WorldState(std::vector<geometries_in_frame> obstacles, std::vector<transform> transforms)
-        : obstacles_(obstacles), transforms_(transforms) {}
+        : obstacles_(std::move(obstacles)), transforms_(std::move(transforms)) {}
 
     friend bool operator==(const WorldState& lhs, const WorldState& rhs);
     friend bool operator==(const geometries_in_frame& lhs, const geometries_in_frame& rhs);

--- a/src/viam/sdk/components/base/client.cpp
+++ b/src/viam/sdk/components/base/client.cpp
@@ -52,8 +52,8 @@ void BaseClient::set_power(const Vector3& linear,
     return make_client_helper(this, *stub_, &StubType::SetPower)
         .with(extra,
               [&](auto& request) {
-                  *request.mutable_linear() = Vector3::to_proto(linear);
-                  *request.mutable_angular() = Vector3::to_proto(angular);
+                  *request.mutable_linear() = linear.to_proto();
+                  *request.mutable_angular() = angular.to_proto();
               })
         .invoke();
 }
@@ -64,8 +64,8 @@ void BaseClient::set_velocity(const Vector3& linear,
     return make_client_helper(this, *stub_, &StubType::SetVelocity)
         .with(extra,
               [&](auto& request) {
-                  *request.mutable_linear() = Vector3::to_proto(linear);
-                  *request.mutable_angular() = Vector3::to_proto(angular);
+                  *request.mutable_linear() = linear.to_proto();
+                  *request.mutable_angular() = angular.to_proto();
               })
         .invoke();
 }

--- a/src/viam/sdk/components/board/board.cpp
+++ b/src/viam/sdk/components/board/board.cpp
@@ -19,7 +19,7 @@ API API::traits<Board>::api() {
     return {kRDK, kComponent, "board"};
 }
 
-Board::status Board::from_proto(viam::common::v1::BoardStatus proto) {
+Board::status Board::from_proto(const viam::common::v1::BoardStatus& proto) {
     Board::status status;
     for (const auto& analog : proto.analogs()) {
         status.analog_reader_values.emplace(analog.first, analog.second.value());
@@ -30,11 +30,11 @@ Board::status Board::from_proto(viam::common::v1::BoardStatus proto) {
     return status;
 }
 
-Board::analog_value Board::from_proto(viam::common::v1::AnalogStatus proto) {
+Board::analog_value Board::from_proto(const viam::common::v1::AnalogStatus& proto) {
     return proto.value();
 }
 
-Board::digital_value Board::from_proto(viam::common::v1::DigitalInterruptStatus proto) {
+Board::digital_value Board::from_proto(const viam::common::v1::DigitalInterruptStatus& proto) {
     return proto.value();
 }
 
@@ -53,7 +53,7 @@ Board::power_mode Board::from_proto(viam::component::board::v1::PowerMode proto)
     }
 }
 
-viam::common::v1::BoardStatus Board::to_proto(status status) {
+viam::common::v1::BoardStatus Board::to_proto(const status& status) {
     viam::common::v1::BoardStatus proto;
     for (const auto& analog : status.analog_reader_values) {
         proto.mutable_analogs()->insert({analog.first, to_proto(analog.second)});

--- a/src/viam/sdk/components/board/board.hpp
+++ b/src/viam/sdk/components/board/board.hpp
@@ -52,19 +52,19 @@ class Board : public Component {
     API api() const override;
 
     /// @brief Creates a `status` struct from its proto representation.
-    static status from_proto(viam::common::v1::BoardStatus proto);
+    static status from_proto(const viam::common::v1::BoardStatus& proto);
 
     /// @brief Creates a `analog_value` struct from its proto representation.
-    static analog_value from_proto(viam::common::v1::AnalogStatus proto);
+    static analog_value from_proto(const viam::common::v1::AnalogStatus& proto);
 
     /// @brief Creates a `digital_value` struct from its proto representation.
-    static digital_value from_proto(viam::common::v1::DigitalInterruptStatus proto);
+    static digital_value from_proto(const viam::common::v1::DigitalInterruptStatus& proto);
 
     /// @brief Creates a `power_mode` enum from its proto representation.
     static power_mode from_proto(viam::component::board::v1::PowerMode proto);
 
     /// @brief Converts a `status` struct to its proto representation.
-    static viam::common::v1::BoardStatus to_proto(status status);
+    static viam::common::v1::BoardStatus to_proto(const status& status);
 
     /// @brief Converts a `analog_value` struct to its proto representation.
     static viam::common::v1::AnalogStatus to_proto(analog_value analog_value);

--- a/src/viam/sdk/components/camera/camera.cpp
+++ b/src/viam/sdk/components/camera/camera.cpp
@@ -50,7 +50,8 @@ std::string Camera::format_to_MIME_string(viam::component::camera::v1::Format fo
     }
 }
 
-::viam::component::camera::v1::Format Camera::MIME_string_to_format(std::string mime_string) {
+::viam::component::camera::v1::Format Camera::MIME_string_to_format(
+    const std::string& mime_string) {
     if (mime_string == "image/vnd.viam.rgba") {
         return viam::component::camera::v1::FORMAT_RAW_RGBA;
     }
@@ -66,7 +67,7 @@ std::string Camera::format_to_MIME_string(viam::component::camera::v1::Format fo
     return viam::component::camera::v1::FORMAT_UNSPECIFIED;
 }
 
-Camera::raw_image Camera::from_proto(viam::component::camera::v1::GetImageResponse proto) {
+Camera::raw_image Camera::from_proto(const viam::component::camera::v1::GetImageResponse& proto) {
     Camera::raw_image raw_image;
     std::string img_string = proto.image();
     const std::vector<unsigned char> bytes(img_string.begin(), img_string.end());
@@ -76,7 +77,8 @@ Camera::raw_image Camera::from_proto(viam::component::camera::v1::GetImageRespon
     return raw_image;
 }
 
-Camera::image_collection Camera::from_proto(viam::component::camera::v1::GetImagesResponse proto) {
+Camera::image_collection Camera::from_proto(
+    const viam::component::camera::v1::GetImagesResponse& proto) {
     Camera::image_collection image_collection;
     std::vector<Camera::raw_image> images;
     for (const auto& img : proto.images()) {
@@ -93,7 +95,8 @@ Camera::image_collection Camera::from_proto(viam::component::camera::v1::GetImag
     return image_collection;
 }
 
-Camera::point_cloud Camera::from_proto(viam::component::camera::v1::GetPointCloudResponse proto) {
+Camera::point_cloud Camera::from_proto(
+    const viam::component::camera::v1::GetPointCloudResponse& proto) {
     Camera::point_cloud point_cloud;
     std::string pc_string = proto.point_cloud();
     const std::vector<unsigned char> bytes(pc_string.begin(), pc_string.end());
@@ -103,7 +106,7 @@ Camera::point_cloud Camera::from_proto(viam::component::camera::v1::GetPointClou
 }
 
 Camera::intrinsic_parameters Camera::from_proto(
-    viam::component::camera::v1::IntrinsicParameters proto) {
+    const viam::component::camera::v1::IntrinsicParameters& proto) {
     Camera::intrinsic_parameters params;
     // NOLINTNEXTLINE(bugprone-narrowing-conversions)
     params.width_px = proto.width_px();
@@ -117,14 +120,15 @@ Camera::intrinsic_parameters Camera::from_proto(
 }
 
 Camera::distortion_parameters Camera::from_proto(
-    viam::component::camera::v1::DistortionParameters proto) {
+    const viam::component::camera::v1::DistortionParameters& proto) {
     Camera::distortion_parameters params;
     params.model = proto.model();
     params.parameters = {proto.parameters().begin(), proto.parameters().end()};
     return params;
 }
 
-Camera::properties Camera::from_proto(viam::component::camera::v1::GetPropertiesResponse proto) {
+Camera::properties Camera::from_proto(
+    const viam::component::camera::v1::GetPropertiesResponse& proto) {
     Camera::distortion_parameters distortion_parameters;
     Camera::intrinsic_parameters intrinsic_parameters;
     Camera::properties properties;

--- a/src/viam/sdk/components/camera/camera.cpp
+++ b/src/viam/sdk/components/camera/camera.cpp
@@ -149,7 +149,7 @@ Camera::properties Camera::from_proto(
 }
 
 viam::component::camera::v1::IntrinsicParameters Camera::to_proto(
-    Camera::intrinsic_parameters params) {
+    const Camera::intrinsic_parameters& params) {
     viam::component::camera::v1::IntrinsicParameters proto;
     proto.set_width_px(params.width_px);
     proto.set_height_px(params.height_px);
@@ -160,7 +160,7 @@ viam::component::camera::v1::IntrinsicParameters Camera::to_proto(
     return proto;
 }
 viam::component::camera::v1::DistortionParameters Camera::to_proto(
-    Camera::distortion_parameters params) {
+    const Camera::distortion_parameters& params) {
     viam::component::camera::v1::DistortionParameters proto;
     *proto.mutable_model() = params.model;
     *proto.mutable_parameters() = {params.parameters.begin(), params.parameters.end()};

--- a/src/viam/sdk/components/camera/camera.hpp
+++ b/src/viam/sdk/components/camera/camera.hpp
@@ -114,10 +114,10 @@ class Camera : public Component {
     static properties from_proto(const viam::component::camera::v1::GetPropertiesResponse& proto);
 
     /// @brief converts a `distortion_parameters` struct to its proto representation.
-    static viam::component::camera::v1::DistortionParameters to_proto(distortion_parameters);
+    static viam::component::camera::v1::DistortionParameters to_proto(const distortion_parameters&);
 
     /// @brief converts an `intrinsic_parameters` struct to its proto representation.
-    static viam::component::camera::v1::IntrinsicParameters to_proto(intrinsic_parameters);
+    static viam::component::camera::v1::IntrinsicParameters to_proto(const intrinsic_parameters&);
 
     /// @brief Send/receive arbitrary commands to the resource.
     /// @param Command the command to execute.

--- a/src/viam/sdk/components/camera/camera.hpp
+++ b/src/viam/sdk/components/camera/camera.hpp
@@ -90,26 +90,28 @@ class Camera : public Component {
     static std::string format_to_MIME_string(viam::component::camera::v1::Format format);
 
     /// @brief convert a MIME type string with a protobuf format enum.
-    static viam::component::camera::v1::Format MIME_string_to_format(std::string mime_string);
+    static viam::component::camera::v1::Format MIME_string_to_format(
+        const std::string& mime_string);
 
     /// @brief Creates a `raw_image` struct from its proto representation.
-    static raw_image from_proto(viam::component::camera::v1::GetImageResponse proto);
+    static raw_image from_proto(const viam::component::camera::v1::GetImageResponse& proto);
 
     /// @brief Creates a `image_collection` struct from its proto representation.
-    static image_collection from_proto(viam::component::camera::v1::GetImagesResponse proto);
+    static image_collection from_proto(const viam::component::camera::v1::GetImagesResponse& proto);
 
     /// @brief Creates a `point_cloud` struct from its proto representation.
-    static point_cloud from_proto(viam::component::camera::v1::GetPointCloudResponse proto);
+    static point_cloud from_proto(const viam::component::camera::v1::GetPointCloudResponse& proto);
 
     /// @brief creates an `intrinsic_parameters` struct from its proto representation.
-    static intrinsic_parameters from_proto(viam::component::camera::v1::IntrinsicParameters proto);
+    static intrinsic_parameters from_proto(
+        const viam::component::camera::v1::IntrinsicParameters& proto);
 
     /// @brief creats a `distortion_parameters` struct from its proto representation.
     static distortion_parameters from_proto(
-        viam::component::camera::v1::DistortionParameters proto);
+        const viam::component::camera::v1::DistortionParameters& proto);
 
     /// @brief creates a `properties` struct from its proto representation.
-    static properties from_proto(viam::component::camera::v1::GetPropertiesResponse proto);
+    static properties from_proto(const viam::component::camera::v1::GetPropertiesResponse& proto);
 
     /// @brief converts a `distortion_parameters` struct to its proto representation.
     static viam::component::camera::v1::DistortionParameters to_proto(distortion_parameters);

--- a/src/viam/sdk/components/encoder/encoder.cpp
+++ b/src/viam/sdk/components/encoder/encoder.cpp
@@ -71,7 +71,7 @@ viam::component::encoder::v1::PositionType Encoder::to_proto(position_type posit
     }
 }
 
-viam::component::encoder::v1::GetPositionResponse Encoder::to_proto(position position) {
+viam::component::encoder::v1::GetPositionResponse Encoder::to_proto(const position& position) {
     viam::component::encoder::v1::GetPositionResponse proto;
     proto.set_value(position.value);
 
@@ -79,7 +79,8 @@ viam::component::encoder::v1::GetPositionResponse Encoder::to_proto(position pos
     return proto;
 }
 
-viam::component::encoder::v1::GetPropertiesResponse Encoder::to_proto(properties properties) {
+viam::component::encoder::v1::GetPropertiesResponse Encoder::to_proto(
+    const properties& properties) {
     viam::component::encoder::v1::GetPropertiesResponse proto;
     proto.set_ticks_count_supported(properties.ticks_count_supported);
 

--- a/src/viam/sdk/components/encoder/encoder.cpp
+++ b/src/viam/sdk/components/encoder/encoder.cpp
@@ -36,7 +36,8 @@ Encoder::position_type Encoder::from_proto(viam::component::encoder::v1::Positio
     }
 }
 
-Encoder::position Encoder::from_proto(viam::component::encoder::v1::GetPositionResponse proto) {
+Encoder::position Encoder::from_proto(
+    const viam::component::encoder::v1::GetPositionResponse& proto) {
     Encoder::position position;
     position.value = proto.value();
 
@@ -44,7 +45,8 @@ Encoder::position Encoder::from_proto(viam::component::encoder::v1::GetPositionR
     return position;
 }
 
-Encoder::properties Encoder::from_proto(viam::component::encoder::v1::GetPropertiesResponse proto) {
+Encoder::properties Encoder::from_proto(
+    const viam::component::encoder::v1::GetPropertiesResponse& proto) {
     Encoder::properties properties;
     properties.ticks_count_supported = proto.ticks_count_supported();
 

--- a/src/viam/sdk/components/encoder/encoder.hpp
+++ b/src/viam/sdk/components/encoder/encoder.hpp
@@ -59,10 +59,11 @@ class Encoder : public Component {
     static viam::component::encoder::v1::PositionType to_proto(position_type position_type);
 
     /// @brief Converts a `position` struct to its proto representation.
-    static viam::component::encoder::v1::GetPositionResponse to_proto(position position);
+    static viam::component::encoder::v1::GetPositionResponse to_proto(const position& position);
 
     /// @brief Converts a `properties` struct to its proto representation.
-    static viam::component::encoder::v1::GetPropertiesResponse to_proto(properties properties);
+    static viam::component::encoder::v1::GetPropertiesResponse to_proto(
+        const properties& properties);
 
     /// @brief Returns position of the encoder which can either be ticks since last zeroing for an
     /// incremental encoder or degrees for an absolute encoder.

--- a/src/viam/sdk/components/encoder/encoder.hpp
+++ b/src/viam/sdk/components/encoder/encoder.hpp
@@ -50,10 +50,10 @@ class Encoder : public Component {
     static position_type from_proto(viam::component::encoder::v1::PositionType proto);
 
     /// @brief Creates a `position` struct from its proto representation.
-    static position from_proto(viam::component::encoder::v1::GetPositionResponse proto);
+    static position from_proto(const viam::component::encoder::v1::GetPositionResponse& proto);
 
     /// @brief Creates a `properties` struct from its proto representation.
-    static properties from_proto(viam::component::encoder::v1::GetPropertiesResponse proto);
+    static properties from_proto(const viam::component::encoder::v1::GetPropertiesResponse& proto);
 
     /// @brief Converts a `position_type` struct to its proto representation.
     static viam::component::encoder::v1::PositionType to_proto(position_type position_type);

--- a/src/viam/sdk/components/motor/motor.cpp
+++ b/src/viam/sdk/components/motor/motor.cpp
@@ -11,7 +11,7 @@
 namespace viam {
 namespace sdk {
 
-Motor::position Motor::from_proto(viam::component::motor::v1::GetPositionResponse proto) {
+Motor::position Motor::from_proto(const viam::component::motor::v1::GetPositionResponse& proto) {
     return proto.position();
 }
 API Motor::api() const {
@@ -22,7 +22,7 @@ API API::traits<Motor>::api() {
     return {kRDK, kComponent, "motor"};
 }
 
-Motor::power_status Motor::from_proto(viam::component::motor::v1::IsPoweredResponse proto) {
+Motor::power_status Motor::from_proto(const viam::component::motor::v1::IsPoweredResponse& proto) {
     Motor::power_status power_status;
     power_status.is_on = proto.is_on();
 
@@ -30,7 +30,8 @@ Motor::power_status Motor::from_proto(viam::component::motor::v1::IsPoweredRespo
     return power_status;
 }
 
-Motor::properties Motor::from_proto(viam::component::motor::v1::GetPropertiesResponse proto) {
+Motor::properties Motor::from_proto(
+    const viam::component::motor::v1::GetPropertiesResponse& proto) {
     Motor::properties properties;
     properties.position_reporting = proto.position_reporting();
     return properties;

--- a/src/viam/sdk/components/motor/motor.cpp
+++ b/src/viam/sdk/components/motor/motor.cpp
@@ -37,13 +37,13 @@ Motor::properties Motor::from_proto(
     return properties;
 }
 
-viam::component::motor::v1::GetPositionResponse Motor::to_proto(position position) {
+viam::component::motor::v1::GetPositionResponse Motor::to_proto(const position& position) {
     viam::component::motor::v1::GetPositionResponse proto;
     proto.set_position(position);
     return proto;
 }
 
-viam::component::motor::v1::IsPoweredResponse Motor::to_proto(power_status power_status) {
+viam::component::motor::v1::IsPoweredResponse Motor::to_proto(const power_status& power_status) {
     viam::component::motor::v1::IsPoweredResponse proto;
     proto.set_is_on(power_status.is_on);
 
@@ -51,7 +51,7 @@ viam::component::motor::v1::IsPoweredResponse Motor::to_proto(power_status power
     return proto;
 }
 
-viam::component::motor::v1::GetPropertiesResponse Motor::to_proto(properties properties) {
+viam::component::motor::v1::GetPropertiesResponse Motor::to_proto(const properties& properties) {
     viam::component::motor::v1::GetPropertiesResponse proto;
     proto.set_position_reporting(properties.position_reporting);
     return proto;

--- a/src/viam/sdk/components/motor/motor.hpp
+++ b/src/viam/sdk/components/motor/motor.hpp
@@ -46,14 +46,15 @@ class Motor : public Component, public Stoppable {
     };
 
     /// @brief Creates a `position` struct from its proto representation.
-    static position from_proto(viam::component::motor::v1::GetPositionResponse proto);
+    static position from_proto(const viam::component::motor::v1::GetPositionResponse& proto);
 
     /// @brief Creates a `power_status` struct from its proto representation.
-    static power_status from_proto(viam::component::motor::v1::IsPoweredResponse proto);
+    static power_status from_proto(const viam::component::motor::v1::IsPoweredResponse& proto);
 
     /// @brief Creates a `properties` struct from its proto representation.
-    static properties from_proto(viam::component::motor::v1::GetPropertiesResponse proto);
+    static properties from_proto(const viam::component::motor::v1::GetPropertiesResponse& proto);
 
+    /// // CR erodkin: why aren't the `to_proto` methods complaining about lack of `const&`?
     /// @brief Converts a `position` struct to its proto representation.
     static viam::component::motor::v1::GetPositionResponse to_proto(position position);
 

--- a/src/viam/sdk/components/motor/motor.hpp
+++ b/src/viam/sdk/components/motor/motor.hpp
@@ -54,15 +54,14 @@ class Motor : public Component, public Stoppable {
     /// @brief Creates a `properties` struct from its proto representation.
     static properties from_proto(const viam::component::motor::v1::GetPropertiesResponse& proto);
 
-    /// // CR erodkin: why aren't the `to_proto` methods complaining about lack of `const&`?
     /// @brief Converts a `position` struct to its proto representation.
-    static viam::component::motor::v1::GetPositionResponse to_proto(position position);
+    static viam::component::motor::v1::GetPositionResponse to_proto(const position& position);
 
     /// @brief Converts a `power_status` struct to its proto representation.
-    static viam::component::motor::v1::IsPoweredResponse to_proto(power_status power_status);
+    static viam::component::motor::v1::IsPoweredResponse to_proto(const power_status& power_status);
 
     /// @brief Converts a `properties` struct to its proto representation.
-    static viam::component::motor::v1::GetPropertiesResponse to_proto(properties properties);
+    static viam::component::motor::v1::GetPropertiesResponse to_proto(const properties& properties);
 
     /// @brief Sets the percentage of the motor's total power that should be employed.
     /// @param power_pct Percentage of motor's power, between -1 and 1, where negative values

--- a/src/viam/sdk/components/movement_sensor/movement_sensor.cpp
+++ b/src/viam/sdk/components/movement_sensor/movement_sensor.cpp
@@ -56,13 +56,13 @@ MovementSensor::properties MovementSensor::from_proto(
 }
 
 viam::component::movementsensor::v1::GetCompassHeadingResponse MovementSensor::to_proto(
-    compassheading compassheading) {
+    const compassheading& compassheading) {
     viam::component::movementsensor::v1::GetCompassHeadingResponse proto;
     proto.set_value(compassheading.value);
     return proto;
 }
 
-viam::common::v1::Orientation MovementSensor::to_proto(orientation orientation) {
+viam::common::v1::Orientation MovementSensor::to_proto(const orientation& orientation) {
     viam::common::v1::Orientation proto;
     proto.set_o_x(orientation.o_x);
     proto.set_o_y(orientation.o_y);
@@ -71,8 +71,17 @@ viam::common::v1::Orientation MovementSensor::to_proto(orientation orientation) 
     return proto;
 }
 
+// CR erodkin: somehow this wasn't defined! gotta add it
+viam::component::movementsensor::v1::GetPositionResponse MovementSensor::to_proto(
+    const position& position) {
+    component::movementsensor::v1::GetPositionResponse proto;
+    proto.set_altitude_m(position.altitude_m);
+    *proto.mutable_coordinate() = position.coordinate.to_proto();
+    return proto;
+}
+
 viam::component::movementsensor::v1::GetPropertiesResponse MovementSensor::to_proto(
-    properties properties) {
+    const properties& properties) {
     viam::component::movementsensor::v1::GetPropertiesResponse proto;
     proto.set_linear_velocity_supported(properties.linear_velocity_supported);
     proto.set_angular_velocity_supported(properties.angular_velocity_supported);

--- a/src/viam/sdk/components/movement_sensor/movement_sensor.cpp
+++ b/src/viam/sdk/components/movement_sensor/movement_sensor.cpp
@@ -71,7 +71,6 @@ viam::common::v1::Orientation MovementSensor::to_proto(const orientation& orient
     return proto;
 }
 
-// CR erodkin: somehow this wasn't defined! gotta add it
 viam::component::movementsensor::v1::GetPositionResponse MovementSensor::to_proto(
     const position& position) {
     component::movementsensor::v1::GetPositionResponse proto;

--- a/src/viam/sdk/components/movement_sensor/movement_sensor.cpp
+++ b/src/viam/sdk/components/movement_sensor/movement_sensor.cpp
@@ -20,21 +20,21 @@ API API::traits<MovementSensor>::api() {
 }
 
 MovementSensor::compassheading MovementSensor::from_proto(
-    viam::component::movementsensor::v1::GetCompassHeadingResponse proto) {
+    const viam::component::movementsensor::v1::GetCompassHeadingResponse& proto) {
     MovementSensor::compassheading compassheading;
     compassheading.value = proto.value();
     return compassheading;
 }
 
 MovementSensor::position MovementSensor::from_proto(
-    viam::component::movementsensor::v1::GetPositionResponse proto) {
+    const viam::component::movementsensor::v1::GetPositionResponse& proto) {
     MovementSensor::position position;
     position.coordinate = viam::sdk::geo_point::from_proto(proto.coordinate());
     position.altitude_m = proto.altitude_m();
     return position;
 }
 
-MovementSensor::orientation MovementSensor::from_proto(viam::common::v1::Orientation proto) {
+MovementSensor::orientation MovementSensor::from_proto(const viam::common::v1::Orientation& proto) {
     MovementSensor::orientation orientation;
     orientation.o_x = proto.o_x();
     orientation.o_y = proto.o_y();
@@ -44,7 +44,7 @@ MovementSensor::orientation MovementSensor::from_proto(viam::common::v1::Orienta
 }
 
 MovementSensor::properties MovementSensor::from_proto(
-    viam::component::movementsensor::v1::GetPropertiesResponse proto) {
+    const viam::component::movementsensor::v1::GetPropertiesResponse& proto) {
     MovementSensor::properties properties;
     properties.linear_velocity_supported = proto.linear_velocity_supported();
     properties.angular_velocity_supported = proto.angular_velocity_supported();

--- a/src/viam/sdk/components/movement_sensor/movement_sensor.hpp
+++ b/src/viam/sdk/components/movement_sensor/movement_sensor.hpp
@@ -72,17 +72,18 @@ class MovementSensor : public Component {
 
     /// @brief Converts a `compassheading` struct to its proto representation.
     static viam::component::movementsensor::v1::GetCompassHeadingResponse to_proto(
-        compassheading compassheading);
+        const compassheading& compassheading);
 
     /// @brief Converts a `position` struct to its proto representation.
-    static viam::component::movementsensor::v1::GetPositionResponse to_proto(position position);
+    static viam::component::movementsensor::v1::GetPositionResponse to_proto(
+        const position& position);
 
     /// @brief Converts an `orientation` struct to its proto representation.
-    static viam::common::v1::Orientation to_proto(orientation orientation);
+    static viam::common::v1::Orientation to_proto(const orientation& orientation);
 
     /// @brief Converts a `properties` struct to its proto representation.
     static viam::component::movementsensor::v1::GetPropertiesResponse to_proto(
-        properties properties);
+        const properties& properties);
 
     inline Vector3 get_linear_velocity() {
         return get_linear_velocity({});

--- a/src/viam/sdk/components/movement_sensor/movement_sensor.hpp
+++ b/src/viam/sdk/components/movement_sensor/movement_sensor.hpp
@@ -57,16 +57,18 @@ class MovementSensor : public Component {
 
     /// @brief Creates a `compassheading` struct from its proto representation.
     static compassheading from_proto(
-        viam::component::movementsensor::v1::GetCompassHeadingResponse proto);
+        const viam::component::movementsensor::v1::GetCompassHeadingResponse& proto);
 
     /// @brief Creates a `position` struct from its proto representation.
-    static position from_proto(viam::component::movementsensor::v1::GetPositionResponse proto);
+    static position from_proto(
+        const viam::component::movementsensor::v1::GetPositionResponse& proto);
 
     /// @brief Creates an `orientation` struct from its proto representation.
-    static orientation from_proto(viam::common::v1::Orientation proto);
+    static orientation from_proto(const viam::common::v1::Orientation& proto);
 
     /// @brief Creates a `properties` struct from its proto representation.
-    static properties from_proto(viam::component::movementsensor::v1::GetPropertiesResponse proto);
+    static properties from_proto(
+        const viam::component::movementsensor::v1::GetPropertiesResponse& proto);
 
     /// @brief Converts a `compassheading` struct to its proto representation.
     static viam::component::movementsensor::v1::GetCompassHeadingResponse to_proto(

--- a/src/viam/sdk/components/movement_sensor/server.cpp
+++ b/src/viam/sdk/components/movement_sensor/server.cpp
@@ -23,7 +23,7 @@ MovementSensorServer::MovementSensorServer(std::shared_ptr<ResourceManager> mana
                                                this,
                                                request)([&](auto& helper, auto& movementsensor) {
         const Vector3 result = movementsensor->get_linear_velocity(helper.getExtra());
-        *response->mutable_linear_velocity() = Vector3::to_proto(result);
+        *response->mutable_linear_velocity() = result.to_proto();
     });
 }
 
@@ -35,7 +35,7 @@ MovementSensorServer::MovementSensorServer(std::shared_ptr<ResourceManager> mana
                                                this,
                                                request)([&](auto& helper, auto& movementsensor) {
         const Vector3 result = movementsensor->get_angular_velocity(helper.getExtra());
-        *response->mutable_angular_velocity() = Vector3::to_proto(result);
+        *response->mutable_angular_velocity() = result.to_proto();
     });
 }
 
@@ -111,7 +111,7 @@ MovementSensorServer::MovementSensorServer(std::shared_ptr<ResourceManager> mana
                                                this,
                                                request)([&](auto& helper, auto& movementsensor) {
         const Vector3 result = movementsensor->get_linear_acceleration(helper.getExtra());
-        *response->mutable_linear_acceleration() = Vector3::to_proto(result);
+        *response->mutable_linear_acceleration() = result.to_proto();
     });
 }
 

--- a/src/viam/sdk/components/power_sensor/power_sensor.cpp
+++ b/src/viam/sdk/components/power_sensor/power_sensor.cpp
@@ -19,14 +19,14 @@ API API::traits<PowerSensor>::api() {
     return {kRDK, kComponent, "power_sensor"};
 }
 
-PowerSensor::voltage PowerSensor::from_proto(GetVoltageResponse proto) {
+PowerSensor::voltage PowerSensor::from_proto(const GetVoltageResponse& proto) {
     PowerSensor::voltage v;
     v.volts = proto.volts();
     v.is_ac = proto.is_ac();
     return v;
 }
 
-PowerSensor::current PowerSensor::from_proto(GetCurrentResponse proto) {
+PowerSensor::current PowerSensor::from_proto(const GetCurrentResponse& proto) {
     PowerSensor::current c;
     c.amperes = proto.amperes();
     c.is_ac = proto.is_ac();

--- a/src/viam/sdk/components/power_sensor/power_sensor.cpp
+++ b/src/viam/sdk/components/power_sensor/power_sensor.cpp
@@ -33,14 +33,14 @@ PowerSensor::current PowerSensor::from_proto(const GetCurrentResponse& proto) {
     return c;
 }
 
-GetVoltageResponse PowerSensor::to_proto(voltage v) {
+GetVoltageResponse PowerSensor::to_proto(const voltage& v) {
     GetVoltageResponse proto;
     proto.set_volts(v.volts);
     proto.set_is_ac(v.is_ac);
     return proto;
 }
 
-GetCurrentResponse PowerSensor::to_proto(current c) {
+GetCurrentResponse PowerSensor::to_proto(const current& c) {
     GetCurrentResponse proto;
     proto.set_amperes(c.amperes);
     proto.set_is_ac(c.is_ac);

--- a/src/viam/sdk/components/power_sensor/power_sensor.hpp
+++ b/src/viam/sdk/components/power_sensor/power_sensor.hpp
@@ -44,10 +44,10 @@ class PowerSensor : public Component {
     API api() const override;
 
     /// @brief Creates a `voltage` struct from its proto representation.
-    static voltage from_proto(GetVoltageResponse proto);
+    static voltage from_proto(const GetVoltageResponse& proto);
 
     /// @brief Creates a `current` struct from its proto representation.
-    static current from_proto(GetCurrentResponse proto);
+    static current from_proto(const GetCurrentResponse& proto);
 
     /// @brief Converts a `voltage` struct to its proto representation.
     static GetVoltageResponse to_proto(voltage v);

--- a/src/viam/sdk/components/power_sensor/power_sensor.hpp
+++ b/src/viam/sdk/components/power_sensor/power_sensor.hpp
@@ -50,10 +50,10 @@ class PowerSensor : public Component {
     static current from_proto(const GetCurrentResponse& proto);
 
     /// @brief Converts a `voltage` struct to its proto representation.
-    static GetVoltageResponse to_proto(voltage v);
+    static GetVoltageResponse to_proto(const voltage& v);
 
     /// @brief Converts a `current` struct to its proto representation.
-    static GetCurrentResponse to_proto(current c);
+    static GetCurrentResponse to_proto(const current& c);
 
     /// @brief Returns the voltage reading of this sensor.
     /// @return The voltage reading of this sensor.

--- a/src/viam/sdk/components/servo/servo.cpp
+++ b/src/viam/sdk/components/servo/servo.cpp
@@ -17,7 +17,7 @@ API API::traits<Servo>::api() {
     return {kRDK, kComponent, "servo"};
 }
 
-Servo::position Servo::from_proto(viam::component::servo::v1::GetPositionResponse proto) {
+Servo::position Servo::from_proto(const viam::component::servo::v1::GetPositionResponse& proto) {
     return proto.position_deg();
 }
 

--- a/src/viam/sdk/components/servo/servo.hpp
+++ b/src/viam/sdk/components/servo/servo.hpp
@@ -29,7 +29,7 @@ class Servo : public Component, public Stoppable {
     API api() const override;
 
     /// @brief Creates a `position` struct from its proto representation.
-    static position from_proto(viam::component::servo::v1::GetPositionResponse proto);
+    static position from_proto(const viam::component::servo::v1::GetPositionResponse& proto);
 
     /// @brief Move the servo to the provided angle
     /// @param angle_deg The desired angle of the servo in degrees.

--- a/src/viam/sdk/config/resource.cpp
+++ b/src/viam/sdk/config/resource.cpp
@@ -138,7 +138,7 @@ viam::app::v1::ComponentConfig ResourceConfig::to_proto() const {
     return proto_cfg;
 }
 
-ResourceConfig::ResourceConfig(const std::string& type) : api_({kRDK, type, ""}), type_(type){};
+ResourceConfig::ResourceConfig(std::string type) : api_({kRDK, type, ""}), type_(std::move(type)){};
 
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/config/resource.cpp
+++ b/src/viam/sdk/config/resource.cpp
@@ -89,7 +89,7 @@ void ResourceConfig::fix_api() {
     }
 }
 
-ResourceConfig ResourceConfig::from_proto(viam::app::v1::ComponentConfig proto_cfg) {
+ResourceConfig ResourceConfig::from_proto(const viam::app::v1::ComponentConfig& proto_cfg) {
     ResourceConfig resource(proto_cfg.type());
     resource.name_ = proto_cfg.name();
     resource.namespace__ = proto_cfg.namespace_();
@@ -138,7 +138,7 @@ viam::app::v1::ComponentConfig ResourceConfig::to_proto() const {
     return proto_cfg;
 }
 
-ResourceConfig::ResourceConfig(std::string type) : api_({kRDK, type, ""}), type_(type){};
+ResourceConfig::ResourceConfig(const std::string& type) : api_({kRDK, type, ""}), type_(type){};
 
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/config/resource.hpp
+++ b/src/viam/sdk/config/resource.hpp
@@ -22,9 +22,9 @@ class ResourceLevelServiceConfig {
 
 class ResourceConfig {
    public:
-    static ResourceConfig from_proto(viam::app::v1::ComponentConfig proto_cfg);
+    static ResourceConfig from_proto(const viam::app::v1::ComponentConfig& proto_cfg);
     viam::app::v1::ComponentConfig to_proto() const;
-    ResourceConfig(std::string type);
+    ResourceConfig(const std::string& type);
     Name resource_name();
     const API& api() const;
     const LinkConfig& frame() const;

--- a/src/viam/sdk/config/resource.hpp
+++ b/src/viam/sdk/config/resource.hpp
@@ -24,7 +24,7 @@ class ResourceConfig {
    public:
     static ResourceConfig from_proto(const viam::app::v1::ComponentConfig& proto_cfg);
     viam::app::v1::ComponentConfig to_proto() const;
-    ResourceConfig(const std::string& type);
+    ResourceConfig(std::string type);
     Name resource_name();
     const API& api() const;
     const LinkConfig& frame() const;

--- a/src/viam/sdk/module/handler_map.cpp
+++ b/src/viam/sdk/module/handler_map.cpp
@@ -37,7 +37,7 @@ viam::module::v1::HandlerMap HandlerMap_::to_proto() const {
 HandlerMap_::HandlerMap_(){};
 
 // NOLINTNEXTLINE(readability-const-return-type)
-const HandlerMap_ HandlerMap_::from_proto(viam::module::v1::HandlerMap proto) {
+const HandlerMap_ HandlerMap_::from_proto(const viam::module::v1::HandlerMap& proto) {
     HandlerMap_ hm;
 
     const google::protobuf::RepeatedPtrField<viam::module::v1::HandlerDefinition>& handlers =
@@ -65,7 +65,7 @@ const HandlerMap_ HandlerMap_::from_proto(viam::module::v1::HandlerMap proto) {
     return hm;
 }
 
-void HandlerMap_::add_model(Model model, RPCSubtype subtype) {
+void HandlerMap_::add_model(const Model& model, const RPCSubtype& subtype) {
     handles_[subtype].push_back(model);
 }
 

--- a/src/viam/sdk/module/handler_map.cpp
+++ b/src/viam/sdk/module/handler_map.cpp
@@ -65,8 +65,8 @@ const HandlerMap_ HandlerMap_::from_proto(const viam::module::v1::HandlerMap& pr
     return hm;
 }
 
-void HandlerMap_::add_model(const Model& model, const RPCSubtype& subtype) {
-    handles_[subtype].push_back(model);
+void HandlerMap_::add_model(Model model, const RPCSubtype& subtype) {
+    handles_[subtype].push_back(std::move(model));
 }
 
 std::ostream& operator<<(std::ostream& os, const HandlerMap_& hm) {

--- a/src/viam/sdk/module/handler_map.hpp
+++ b/src/viam/sdk/module/handler_map.hpp
@@ -10,7 +10,7 @@ namespace sdk {
 class HandlerMap_ {
    public:
     HandlerMap_();
-    void add_model(const Model& model, const RPCSubtype& subtype);
+    void add_model(Model model, const RPCSubtype& subtype);
 
     viam::module::v1::HandlerMap to_proto() const;
     static const HandlerMap_ from_proto(const viam::module::v1::HandlerMap& proto);

--- a/src/viam/sdk/module/handler_map.hpp
+++ b/src/viam/sdk/module/handler_map.hpp
@@ -10,10 +10,10 @@ namespace sdk {
 class HandlerMap_ {
    public:
     HandlerMap_();
-    void add_model(Model model, RPCSubtype subtype);
+    void add_model(const Model& model, const RPCSubtype& subtype);
 
     viam::module::v1::HandlerMap to_proto() const;
-    static const HandlerMap_ from_proto(viam::module::v1::HandlerMap proto);
+    static const HandlerMap_ from_proto(const viam::module::v1::HandlerMap& proto);
     friend std::ostream& operator<<(std::ostream& os, const HandlerMap_& hm);
 
    private:

--- a/src/viam/sdk/module/module.cpp
+++ b/src/viam/sdk/module/module.cpp
@@ -10,7 +10,7 @@
 namespace viam {
 namespace sdk {
 
-Module::Module(std::string addr) : addr_(addr){};
+Module::Module(std::string addr) : addr_(std::move(addr)){};
 
 void Module::set_ready() {
     ready_ = true;

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -61,7 +61,7 @@ Dependencies ModuleService::get_dependencies_(
     return deps;
 }
 
-std::shared_ptr<Resource> ModuleService::get_parent_resource_(Name name) {
+std::shared_ptr<Resource> ModuleService::get_parent_resource_(const Name& name) {
     if (!parent_) {
         parent_ = RobotClient::at_local_socket(parent_addr_, {0, boost::none});
     }
@@ -215,7 +215,7 @@ ModuleService::ModuleService(std::string addr)
 
 ModuleService::ModuleService(int argc,
                              char** argv,
-                             std::vector<std::shared_ptr<ModelRegistration>> registrations) {
+                             const std::vector<std::shared_ptr<ModelRegistration>>& registrations) {
     if (argc < 2) {
         throw std::runtime_error("Need socket path as command line argument");
     }
@@ -264,8 +264,8 @@ ModuleService::~ModuleService() {
     }
 }
 
-void ModuleService::add_model_from_registry_inlock_(API api,
-                                                    Model model,
+void ModuleService::add_model_from_registry_inlock_(const API& api,
+                                                    const Model& model,
                                                     const std::lock_guard<std::mutex>& lock) {
     const std::shared_ptr<const ResourceServerRegistration> creator =
         Registry::lookup_resource_server(api);
@@ -279,7 +279,7 @@ void ModuleService::add_model_from_registry_inlock_(API api,
     module_->mutable_handles().add_model(model, rpc_subtype);
 };
 
-void ModuleService::add_model_from_registry(API api, Model model) {
+void ModuleService::add_model_from_registry(const API& api, const Model& model) {
     const std::lock_guard<std::mutex> lock(lock_);
     return add_model_from_registry_inlock_(api, model, lock);
 }

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -265,8 +265,8 @@ ModuleService::~ModuleService() {
     }
 }
 
-void ModuleService::add_model_from_registry_inlock_(const API& api,
-                                                    const Model& model,
+void ModuleService::add_model_from_registry_inlock_(API api,
+                                                    Model model,
                                                     const std::lock_guard<std::mutex>& lock) {
     const std::shared_ptr<const ResourceServerRegistration> creator =
         Registry::lookup_resource_server(api);
@@ -276,13 +276,13 @@ void ModuleService::add_model_from_registry_inlock_(const API& api,
         name = creator->service_descriptor()->full_name();
         sd = creator->service_descriptor();
     }
-    const RPCSubtype rpc_subtype(api, name, *sd);
-    module_->mutable_handles().add_model(model, rpc_subtype);
+    const RPCSubtype rpc_subtype(std::move(api), name, *sd);
+    module_->mutable_handles().add_model(std::move(model), rpc_subtype);
 };
 
-void ModuleService::add_model_from_registry(const API& api, const Model& model) {
+void ModuleService::add_model_from_registry(API api, Model model) {
     const std::lock_guard<std::mutex> lock(lock_);
-    return add_model_from_registry_inlock_(api, model, lock);
+    return add_model_from_registry_inlock_(std::move(api), std::move(model), lock);
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/module/service.hpp
+++ b/src/viam/sdk/module/service.hpp
@@ -47,7 +47,7 @@ class ModuleService : viam::module::v1::ModuleService::Service {
     /// of ModelRegistration, the passed in models will already be registered and added.
     /// @param api The API to add.
     /// @param model The model to add.
-    void add_model_from_registry(const API& api, const Model& model);
+    void add_model_from_registry(API api, Model model);
 
    private:
     ::grpc::Status AddResource(::grpc::ServerContext* context,
@@ -71,9 +71,7 @@ class ModuleService : viam::module::v1::ModuleService::Service {
                                   const ::viam::module::v1::ValidateConfigRequest* request,
                                   ::viam::module::v1::ValidateConfigResponse* response) override;
 
-    void add_model_from_registry_inlock_(const API& api,
-                                         const Model& model,
-                                         const std::lock_guard<std::mutex>&);
+    void add_model_from_registry_inlock_(API api, Model model, const std::lock_guard<std::mutex>&);
     Dependencies get_dependencies_(google::protobuf::RepeatedPtrField<std::string> const& proto,
                                    std::string const& resource_name);
     std::shared_ptr<Resource> get_parent_resource_(const Name& name);

--- a/src/viam/sdk/module/service.hpp
+++ b/src/viam/sdk/module/service.hpp
@@ -35,7 +35,7 @@ class ModuleService : viam::module::v1::ModuleService::Service {
     /// @param registrations Models to register and add to the module.
     explicit ModuleService(int argc,
                            char** argv,
-                           std::vector<std::shared_ptr<ModelRegistration>> registrations);
+                           const std::vector<std::shared_ptr<ModelRegistration>>& registrations);
     ~ModuleService();
 
     /// @brief Starts module. serve will return when SIGINT or SIGTERM is received
@@ -47,7 +47,7 @@ class ModuleService : viam::module::v1::ModuleService::Service {
     /// of ModelRegistration, the passed in models will already be registered and added.
     /// @param api The API to add.
     /// @param model The model to add.
-    void add_model_from_registry(API api, Model model);
+    void add_model_from_registry(const API& api, const Model& model);
 
    private:
     ::grpc::Status AddResource(::grpc::ServerContext* context,
@@ -71,10 +71,12 @@ class ModuleService : viam::module::v1::ModuleService::Service {
                                   const ::viam::module::v1::ValidateConfigRequest* request,
                                   ::viam::module::v1::ValidateConfigResponse* response) override;
 
-    void add_model_from_registry_inlock_(API api, Model model, const std::lock_guard<std::mutex>&);
+    void add_model_from_registry_inlock_(const API& api,
+                                         const Model& model,
+                                         const std::lock_guard<std::mutex>&);
     Dependencies get_dependencies_(google::protobuf::RepeatedPtrField<std::string> const& proto,
                                    std::string const& resource_name);
-    std::shared_ptr<Resource> get_parent_resource_(Name name);
+    std::shared_ptr<Resource> get_parent_resource_(const Name& name);
 
     std::mutex lock_;
     std::unique_ptr<Module> module_;

--- a/src/viam/sdk/referenceframe/frame.cpp
+++ b/src/viam/sdk/referenceframe/frame.cpp
@@ -22,7 +22,7 @@ viam::app::v1::Frame LinkConfig::to_proto() const {
     return frame;
 };
 
-LinkConfig LinkConfig::from_proto(viam::app::v1::Frame proto) {
+LinkConfig LinkConfig::from_proto(const viam::app::v1::Frame& proto) {
     LinkConfig lc;
 
     lc.parent_ = proto.parent();

--- a/src/viam/sdk/referenceframe/frame.hpp
+++ b/src/viam/sdk/referenceframe/frame.hpp
@@ -13,7 +13,7 @@ namespace sdk {
 class LinkConfig {
    public:
     viam::app::v1::Frame to_proto() const;
-    static LinkConfig from_proto(viam::app::v1::Frame proto);
+    static LinkConfig from_proto(const viam::app::v1::Frame& proto);
     translation get_translation() const;
     OrientationConfig get_orientation_config() const;
     GeometryConfig get_geometry_config() const;

--- a/src/viam/sdk/resource/resource.cpp
+++ b/src/viam/sdk/resource/resource.cpp
@@ -19,7 +19,7 @@ std::string Resource::name() const {
     return name_;
 }
 
-void Resource::reconfigure(Dependencies deps, ResourceConfig cfg){};
+void Resource::reconfigure(const Dependencies& deps, const ResourceConfig& cfg){};
 
 ResourceName Resource::get_resource_name(std::string name) const {
     ResourceName r;

--- a/src/viam/sdk/resource/resource.hpp
+++ b/src/viam/sdk/resource/resource.hpp
@@ -28,7 +28,7 @@ class Resource {
     /// @brief Reconfigures a resource.
     /// @param deps Dependencies of the resource.
     /// @param cfg The resource's config.
-    virtual void reconfigure(Dependencies deps, ResourceConfig cfg);
+    virtual void reconfigure(const Dependencies& deps, const ResourceConfig& cfg);
 
     /// @brief Return the resource's name.
     virtual std::string name() const;

--- a/src/viam/sdk/resource/resource_api.cpp
+++ b/src/viam/sdk/resource/resource_api.cpp
@@ -31,7 +31,7 @@ std::string APIType::to_string() const {
 }
 
 APIType::APIType(std::string namespace_, std::string resource_type)
-    : namespace_(namespace_), resource_type_(resource_type){};
+    : namespace_(std::move(namespace_)), resource_type_(std::move(resource_type)){};
 
 std::string API::to_string() const {
     return APIType::to_string() + ":" + resource_subtype_;
@@ -71,10 +71,11 @@ API API::from_string(std::string api) {
 }
 
 API::API(APIType type, std::string resource_subtype)
-    : APIType(type), resource_subtype_(resource_subtype) {}
+    : APIType(std::move(type)), resource_subtype_(std::move(resource_subtype)) {}
 
 API::API(std::string namespace_, std::string resource_type, std::string resource_subtype)
-    : APIType(namespace_, resource_type), resource_subtype_(resource_subtype) {}
+    : APIType(std::move(namespace_), std::move(resource_type)),
+      resource_subtype_(std::move(resource_subtype)) {}
 
 bool API::is_service_type() {
     return (this->resource_type() == "service");
@@ -163,7 +164,7 @@ Name Name::from_string(std::string name) {
 }
 
 Name::Name(API api, std::string remote, std::string name)
-    : api_(api), remote_name_(std::move(remote)), name_(std::move(name)) {}
+    : api_(std::move(api)), remote_name_(std::move(remote)), name_(std::move(name)) {}
 
 bool operator==(const API& lhs, const API& rhs) {
     return lhs.to_string() == rhs.to_string();
@@ -216,7 +217,7 @@ const API& RPCSubtype::api() const {
 };
 
 ModelFamily::ModelFamily(std::string namespace_, std::string family)
-    : namespace_(namespace_), family_(family) {}
+    : namespace_(std::move(namespace_)), family_(std::move(family)) {}
 
 Model::Model(ModelFamily model_family, std::string model_name)
     : model_family_(std::move(model_family)), model_name_(std::move(model_name)) {}

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -1,17 +1,11 @@
 #include <viam/sdk/robot/client.hpp>
 
-#include <algorithm>
 #include <chrono>
 #include <cstddef>
-#include <iostream>
 #include <memory>
 #include <mutex>
-#include <ostream>
-#include <set>
 #include <string>
 #include <thread>
-#include <tuple>
-#include <type_traits>
 #include <unistd.h>
 #include <vector>
 
@@ -78,7 +72,7 @@ void RobotClient::close() {
     viam_channel_->close();
 }
 
-bool is_error_response(grpc::Status response) {
+bool is_error_response(const grpc::Status& response) {
     return !response.ok() && (response.error_message() != kStreamRemoved);
 }
 std::vector<Status> RobotClient::get_status() {
@@ -222,7 +216,7 @@ void RobotClient::refresh_every() {
     }
 };
 
-RobotClient::RobotClient(std::shared_ptr<ViamChannel> channel)
+RobotClient::RobotClient(const std::shared_ptr<ViamChannel>& channel)
     : viam_channel_(channel),
       channel_(channel->channel()),
       should_close_channel_(false),
@@ -234,8 +228,8 @@ std::vector<ResourceName>* RobotClient::resource_names() {
     return resources;
 }
 
-std::shared_ptr<RobotClient> RobotClient::with_channel(std::shared_ptr<ViamChannel> channel,
-                                                       Options options) {
+std::shared_ptr<RobotClient> RobotClient::with_channel(const std::shared_ptr<ViamChannel>& channel,
+                                                       const Options& options) {
     std::shared_ptr<RobotClient> robot = std::make_shared<RobotClient>(channel);
     robot->refresh_interval_ = options.refresh_interval();
     robot->should_refresh_ = (robot->refresh_interval_ > 0);

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -247,7 +247,8 @@ std::shared_ptr<RobotClient> RobotClient::with_channel(const std::shared_ptr<Via
     return robot;
 };
 
-std::shared_ptr<RobotClient> RobotClient::at_address(std::string address, Options options) {
+std::shared_ptr<RobotClient> RobotClient::at_address(const std::string& address,
+                                                     const Options& options) {
     const char* uri = address.c_str();
     auto channel = ViamChannel::dial(uri, options.dial_options());
     std::shared_ptr<RobotClient> robot = RobotClient::with_channel(channel, options);
@@ -256,7 +257,8 @@ std::shared_ptr<RobotClient> RobotClient::at_address(std::string address, Option
     return robot;
 };
 
-std::shared_ptr<RobotClient> RobotClient::at_local_socket(std::string address, Options options) {
+std::shared_ptr<RobotClient> RobotClient::at_local_socket(const std::string& address,
+                                                          const Options& options) {
     const std::string addr = "unix://" + address;
     const char* uri = addr.c_str();
     const std::shared_ptr<grpc::Channel> channel =
@@ -271,7 +273,7 @@ std::shared_ptr<RobotClient> RobotClient::at_local_socket(std::string address, O
 };
 
 std::vector<FrameSystemConfig> RobotClient::get_frame_system_config(
-    std::vector<Transform> additional_transforms) {
+    const std::vector<Transform>& additional_transforms) {
     viam::robot::v1::FrameSystemConfigRequest req;
     viam::robot::v1::FrameSystemConfigResponse resp;
     ClientContext ctx;
@@ -300,13 +302,13 @@ std::vector<FrameSystemConfig> RobotClient::get_frame_system_config(
 
 PoseInFrame RobotClient::transform_pose(PoseInFrame query,
                                         std::string destination,
-                                        std::vector<Transform> additional_transforms) {
+                                        const std::vector<Transform>& additional_transforms) {
     viam::robot::v1::TransformPoseRequest req;
     viam::robot::v1::TransformPoseResponse resp;
     ClientContext ctx;
 
-    *req.mutable_source() = query;
-    *req.mutable_destination() = destination;
+    *req.mutable_source() = std::move(query);
+    *req.mutable_destination() = std::move(destination);
     RepeatedPtrField<Transform>* req_transforms = req.mutable_supplemental_transforms();
 
     for (const Transform& transform : additional_transforms) {
@@ -321,7 +323,8 @@ PoseInFrame RobotClient::transform_pose(PoseInFrame query,
     return resp.pose();
 }
 
-std::vector<Discovery> RobotClient::discover_components(std::vector<DiscoveryQuery> queries) {
+std::vector<Discovery> RobotClient::discover_components(
+    const std::vector<DiscoveryQuery>& queries) {
     viam::robot::v1::DiscoverComponentsRequest req;
     viam::robot::v1::DiscoverComponentsResponse resp;
     ClientContext ctx;
@@ -364,16 +367,16 @@ void RobotClient::stop_all() {
 }
 
 void RobotClient::stop_all(
-    std::unordered_map<ResourceName,
-                       std::unordered_map<std::string, std::shared_ptr<ProtoType>>,
-                       ResourceNameHasher,
-                       ResourceNameEqual> extra) {
+    const std::unordered_map<ResourceName,
+                             std::unordered_map<std::string, std::shared_ptr<ProtoType>>,
+                             ResourceNameHasher,
+                             ResourceNameEqual>& extra) {
     viam::robot::v1::StopAllRequest req;
     viam::robot::v1::StopAllResponse resp;
     ClientContext ctx;
 
     RepeatedPtrField<viam::robot::v1::StopExtraParameters>* ep = req.mutable_extra();
-    for (auto& xtra : extra) {
+    for (const auto& xtra : extra) {
         const ResourceName name = xtra.first;
         const std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<ProtoType>>> params =
             std::make_shared<std::unordered_map<std::string, std::shared_ptr<ProtoType>>>(

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -318,9 +318,9 @@ std::vector<Name> RobotClient::resource_names() const {
     return resource_names_;
 }
 
-std::shared_ptr<RobotClient> RobotClient::with_channel(const std::shared_ptr<ViamChannel>& channel,
+std::shared_ptr<RobotClient> RobotClient::with_channel(std::shared_ptr<ViamChannel> channel,
                                                        const Options& options) {
-    std::shared_ptr<RobotClient> robot = std::make_shared<RobotClient>(channel);
+    std::shared_ptr<RobotClient> robot = std::make_shared<RobotClient>(std::move(channel));
     robot->refresh_interval_ = options.refresh_interval();
     robot->should_refresh_ = (robot->refresh_interval_ > 0);
     if (robot->should_refresh_) {
@@ -460,8 +460,8 @@ void RobotClient::stop_all(const std::unordered_map<Name, AttributeMap>& extra) 
 
     RepeatedPtrField<viam::robot::v1::StopExtraParameters>* ep = req.mutable_extra();
     for (const auto& xtra : extra) {
-        const Name name = xtra.first;
-        const AttributeMap params = xtra.second;
+        const Name& name = xtra.first;
+        const AttributeMap& params = xtra.second;
         const google::protobuf::Struct s = map_to_struct(params);
         viam::robot::v1::StopExtraParameters stop;
         *stop.mutable_name() = name.to_proto();

--- a/src/viam/sdk/robot/client.hpp
+++ b/src/viam/sdk/robot/client.hpp
@@ -65,9 +65,9 @@ class RobotClient {
     /// @param options Options for connecting and refreshing.
     /// Connects directly to a pre-existing channel. A robot created this way must be
     /// `close()`d manually.
-    static std::shared_ptr<RobotClient> with_channel(std::shared_ptr<ViamChannel> channel,
-                                                     Options options);
-    RobotClient(std::shared_ptr<ViamChannel> channel);
+    static std::shared_ptr<RobotClient> with_channel(const std::shared_ptr<ViamChannel>& channel,
+                                                     const Options& options);
+    RobotClient(const std::shared_ptr<ViamChannel>& channel);
     std::vector<ResourceName>* resource_names();
 
     /// @brief Lookup and return a `shared_ptr` to a resource.

--- a/src/viam/sdk/robot/client.hpp
+++ b/src/viam/sdk/robot/client.hpp
@@ -51,14 +51,16 @@ class RobotClient {
     /// @brief Create a robot client connected to the robot at the provided address.
     /// @param address The address of the robot (IP address, URI, URL, etc.)
     /// @param options Options for connecting and refreshing.
-    static std::shared_ptr<RobotClient> at_address(std::string address, Options options);
+    static std::shared_ptr<RobotClient> at_address(const std::string& address,
+                                                   const Options& options);
 
     /// @brief Creates a robot client connected to the robot at the provided local socket.
     /// @param address The local socket of the robot (a .sock file, etc.).
     /// @param options Options for connecting and refreshing.
     /// Creates a direct connection to the robot using the `unix://` scheme.
     /// Only useful for connecting to robots across Unix sockets.
-    static std::shared_ptr<RobotClient> at_local_socket(std::string address, Options options);
+    static std::shared_ptr<RobotClient> at_local_socket(const std::string& address,
+                                                        const Options& options);
 
     /// @brief Creates a robot client connected to the provided channel.
     /// @param channel The channel to connect with.
@@ -103,7 +105,7 @@ class RobotClient {
     /// @brief Get the configuration of the frame system of the given robot.
     /// @return The configuration of the calling robot's frame system.
     std::vector<FrameSystemConfig> get_frame_system_config(
-        std::vector<Transform> additional_transforms = std::vector<Transform>());
+        const std::vector<Transform>& additional_transforms = std::vector<Transform>());
 
     /// @brief Get the list of operations currently running on a robot.
     /// @return The list of operations currently running on the calling robot.
@@ -119,7 +121,7 @@ class RobotClient {
     std::vector<Status> get_status();
 
     std::vector<viam::robot::v1::Discovery> discover_components(
-        std::vector<viam::robot::v1::DiscoveryQuery> queries);
+        const std::vector<viam::robot::v1::DiscoveryQuery>& queries);
 
     /// @brief Transform a given `Pose` to a new specified destination which is a reference frame.
     /// @param query The pose that should be transformed.
@@ -128,7 +130,7 @@ class RobotClient {
     viam::common::v1::PoseInFrame transform_pose(
         viam::common::v1::PoseInFrame query,
         std::string destination,
-        std::vector<Transform> additional_transforms = std::vector<Transform>());
+        const std::vector<Transform>& additional_transforms = std::vector<Transform>());
 
     /// @brief Blocks on the specified operation of the robot, returning when it is complete.
     /// @param id The ID of the operation to block on.
@@ -139,10 +141,11 @@ class RobotClient {
 
     /// @brief Cancel all operations for the robot and stop all actuators and movement.
     /// @param extra Any extra params to pass to resources' `stop` methods, keyed by `ResourceName`.
-    void stop_all(std::unordered_map<ResourceName,
-                                     std::unordered_map<std::string, std::shared_ptr<ProtoType>>,
-                                     ResourceNameHasher,
-                                     ResourceNameEqual> extra);
+    void stop_all(
+        const std::unordered_map<ResourceName,
+                                 std::unordered_map<std::string, std::shared_ptr<ProtoType>>,
+                                 ResourceNameHasher,
+                                 ResourceNameEqual>& extra);
 
     /// @brief Cancel a specified operation on the robot.
     /// @param id The ID of the operation to cancel.

--- a/src/viam/sdk/robot/client.hpp
+++ b/src/viam/sdk/robot/client.hpp
@@ -96,7 +96,7 @@ class RobotClient {
     /// @param options Options for connecting and refreshing.
     /// Connects directly to a pre-existing channel. A robot created this way must be
     /// `close()`d manually.
-    static std::shared_ptr<RobotClient> with_channel(const std::shared_ptr<ViamChannel>& channel,
+    static std::shared_ptr<RobotClient> with_channel(std::shared_ptr<ViamChannel> channel,
                                                      const Options& options);
     RobotClient(std::shared_ptr<ViamChannel> channel);
     std::vector<Name> resource_names() const;

--- a/src/viam/sdk/robot/service.cpp
+++ b/src/viam/sdk/robot/service.cpp
@@ -30,7 +30,7 @@ using google::protobuf::RepeatedPtrField;
 using viam::common::v1::ResourceName;
 using viam::robot::v1::Status;
 
-RobotService_::RobotService_(std::shared_ptr<ResourceManager> manager, Server& server)
+RobotService_::RobotService_(const std::shared_ptr<ResourceManager>& manager, Server& server)
     : ResourceServer(manager) {
     server.register_service(this);
     // register all managed resources with the appropriate resource servers.
@@ -39,7 +39,7 @@ RobotService_::RobotService_(std::shared_ptr<ResourceManager> manager, Server& s
     }
 }
 
-std::vector<ResourceName> RobotService_::generate_metadata() {
+std::vector<ResourceName> RobotService_::generate_metadata_() {
     std::vector<ResourceName> metadata;
     for (const auto& key_and_val : resource_manager()->resources()) {
         for (const ResourceName& resource : resource_names_for_resource(key_and_val.second)) {
@@ -49,7 +49,8 @@ std::vector<ResourceName> RobotService_::generate_metadata() {
     return metadata;
 }
 
-std::vector<Status> RobotService_::generate_status(RepeatedPtrField<ResourceName> resource_names) {
+std::vector<Status> RobotService_::generate_status_(
+    const RepeatedPtrField<ResourceName>& resource_names) {
     std::vector<Status> statuses;
     for (const auto& cmp : resource_manager()->resources()) {
         const std::shared_ptr<Resource> resource = cmp.second;
@@ -58,7 +59,7 @@ std::vector<Status> RobotService_::generate_status(RepeatedPtrField<ResourceName
             if (registration->api().resource_subtype() == resource->api().resource_subtype()) {
                 bool resource_present = false;
                 const ResourceName name = resource->get_resource_name(resource->name());
-                for (auto& resource_name : resource_names) {
+                for (const auto& resource_name : resource_names) {
                     if (ResourceNameEqual::check_equal(name, resource_name)) {
                         resource_present = true;
                         break;
@@ -76,7 +77,7 @@ std::vector<Status> RobotService_::generate_status(RepeatedPtrField<ResourceName
     std::vector<Status> returnable_statuses;
     for (auto& status : statuses) {
         bool status_name_is_known = false;
-        for (auto& resource_name : resource_names) {
+        for (const auto& resource_name : resource_names) {
             if (status.name().SerializeAsString() == resource_name.SerializeAsString()) {
                 status_name_is_known = true;
                 break;
@@ -97,7 +98,7 @@ std::vector<Status> RobotService_::generate_status(RepeatedPtrField<ResourceName
                               "Called [ResourceNames] without a request");
     };
     RepeatedPtrField<ResourceName>* p = response->mutable_resources();
-    for (const ResourceName& name : generate_metadata()) {
+    for (const ResourceName& name : generate_metadata_()) {
         *p->Add() = name;
     }
 
@@ -113,7 +114,7 @@ std::vector<Status> RobotService_::generate_status(RepeatedPtrField<ResourceName
     };
 
     RepeatedPtrField<Status>* response_status = response->mutable_status();
-    const std::vector<Status> statuses = generate_status(request->resource_names());
+    const std::vector<Status> statuses = generate_status_(request->resource_names());
     for (const Status& status : statuses) {
         *response_status->Add() = status;
     }
@@ -126,7 +127,7 @@ void RobotService_::stream_status(
     ::grpc::ServerWriter<::viam::robot::v1::StreamStatusResponse>* writer,
     int interval) {
     while (true) {
-        const std::vector<Status> statuses = generate_status(request->resource_names());
+        const std::vector<Status> statuses = generate_status_(request->resource_names());
         viam::robot::v1::StreamStatusResponse response;
         RepeatedPtrField<Status>* response_status = response.mutable_status();
         for (const Status& status : statuses) {
@@ -202,7 +203,7 @@ void RobotService_::stream_status(
     return grpc::Status(status, status_message);
 }
 
-std::shared_ptr<Resource> RobotService_::resource_by_name(Name name) {
+std::shared_ptr<Resource> RobotService_::resource_by_name(const Name& name) {
     std::shared_ptr<Resource> r;
     const std::lock_guard<std::mutex> lock(lock_);
     auto resources = resource_manager()->resources();

--- a/src/viam/sdk/robot/service.hpp
+++ b/src/viam/sdk/robot/service.hpp
@@ -32,8 +32,8 @@ using viam::robot::v1::Status;
 /// @ingroup Robot
 class RobotService_ : public ResourceServer, public viam::robot::v1::RobotService::Service {
    public:
-    explicit RobotService_(std::shared_ptr<ResourceManager> manager, Server& server);
-    std::shared_ptr<Resource> resource_by_name(Name name);
+    explicit RobotService_(const std::shared_ptr<ResourceManager>& manager, Server& server);
+    std::shared_ptr<Resource> resource_by_name(const Name& name);
     ::grpc::Status ResourceNames(::grpc::ServerContext* context,
                                  const ::viam::robot::v1::ResourceNamesRequest* request,
                                  ::viam::robot::v1::ResourceNamesResponse* response) override;
@@ -50,8 +50,8 @@ class RobotService_ : public ResourceServer, public viam::robot::v1::RobotServic
 
    private:
     std::mutex lock_;
-    std::vector<ResourceName> generate_metadata();
-    std::vector<Status> generate_status(RepeatedPtrField<ResourceName> resource_names);
+    std::vector<ResourceName> generate_metadata_();
+    std::vector<Status> generate_status_(const RepeatedPtrField<ResourceName>& resource_names);
 
     void stream_status(const ::viam::robot::v1::StreamStatusRequest* request,
                        ::grpc::ServerWriter<::viam::robot::v1::StreamStatusResponse>* writer,

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -47,16 +47,16 @@ const std::string& Credentials::payload() const {
 }
 
 ViamChannel::ViamChannel(std::shared_ptr<grpc::Channel> channel, const char* path, void* runtime)
-    : channel_(channel), path_(path), closed_(false), rust_runtime_(runtime) {}
+    : channel_(std::move(channel)), path_(path), closed_(false), rust_runtime_(runtime) {}
 
 DialOptions::DialOptions() = default;
 
 void DialOptions::set_credentials(boost::optional<Credentials> creds) {
-    credentials_ = creds;
+    credentials_ = std::move(creds);
 }
 
 void DialOptions::set_entity(boost::optional<std::string> entity) {
-    auth_entity_ = entity;
+    auth_entity_ = std::move(entity);
 }
 
 void DialOptions::set_timeout(std::chrono::duration<float> timeout) {
@@ -84,7 +84,7 @@ bool DialOptions::allows_insecure_downgrade() const {
 }
 
 std::shared_ptr<ViamChannel> ViamChannel::dial(const char* uri,
-                                               boost::optional<DialOptions> options) {
+                                               const boost::optional<DialOptions>& options) {
     void* ptr = init_rust_runtime();
     const DialOptions opts = options.get_value_or(DialOptions());
     const std::chrono::duration<float> float_timeout = opts.timeout();

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -14,7 +14,8 @@ class ViamChannel {
    public:
     void close();
     ViamChannel(std::shared_ptr<grpc::Channel> channel, const char* path, void* runtime);
-    static std::shared_ptr<ViamChannel> dial(const char* uri, boost::optional<DialOptions> options);
+    static std::shared_ptr<ViamChannel> dial(const char* uri,
+                                             const boost::optional<DialOptions>& options);
 
     const std::shared_ptr<grpc::Channel>& channel() const;
 

--- a/src/viam/sdk/rpc/server.cpp
+++ b/src/viam/sdk/rpc/server.cpp
@@ -39,7 +39,7 @@ void Server::register_service(grpc::Service* service) {
     builder_->RegisterService(service);
 }
 
-void Server::add_resource(std::shared_ptr<Resource> resource) {
+void Server::add_resource(const std::shared_ptr<Resource>& resource) {
     auto api = resource->api();
     if (managed_servers_.find(api) == managed_servers_.end()) {
         std::ostringstream buffer;
@@ -60,7 +60,7 @@ void Server::start() {
     builder_ = nullptr;
 }
 
-void Server::add_listening_port(std::string address,
+void Server::add_listening_port(const std::string& address,
                                 std::shared_ptr<grpc::ServerCredentials> creds) {
     if (!builder_) {
         throw std::runtime_error("Cannot add a listening port after server has started");
@@ -70,7 +70,7 @@ void Server::add_listening_port(std::string address,
         creds = grpc::InsecureServerCredentials();
     }
 
-    builder_->AddListeningPort(address, creds);
+    builder_->AddListeningPort(address, std::move(creds));
 }
 
 void Server::wait() {

--- a/src/viam/sdk/rpc/server.hpp
+++ b/src/viam/sdk/rpc/server.hpp
@@ -45,13 +45,13 @@ class Server {
     /// @brief Adds a specific managed resource to the associated resource server
     /// @param resource The resource to add
     /// @throws `std::runtime_error` if a matching `ResourceServer` doesn't exist in the server.
-    void add_resource(std::shared_ptr<Resource> resource);
+    void add_resource(const std::shared_ptr<Resource>& resource);
 
     /// @brief Adds a listening port to the server.
     /// @param address The address to listen at.
     /// @param creds The server credentials; defaults to a insecure server credentials.
     /// @throws `std::runtime_error` if called after the server has been `start`ed.
-    void add_listening_port(std::string address,
+    void add_listening_port(const std::string& address,
                             std::shared_ptr<grpc::ServerCredentials> creds = nullptr);
 
     /// @brief waits on server close, only returning when the server is closed.

--- a/src/viam/sdk/services/motion/server.cpp
+++ b/src/viam/sdk/services/motion/server.cpp
@@ -99,6 +99,9 @@ MotionServer::MotionServer(std::shared_ptr<ResourceManager> manager)
     });
 }
 
+// CR erodkin: no lint here only because we already fixed this in the other clang-tidy PR.
+// Just do that one first, delete this, then rebase.
+// NOLINTBEGIN
 ::grpc::Status MotionServer::GetPose(
     ::grpc::ServerContext* context,
     const ::viam::service::motion::v1::GetPoseRequest* request,
@@ -135,6 +138,7 @@ MotionServer::MotionServer(std::shared_ptr<ResourceManager> manager)
 
     return ::grpc::Status();
 };
+// NOLINTEND
 
 ::grpc::Status MotionServer::GetPlan(
     ::grpc::ServerContext* context,

--- a/src/viam/sdk/spatialmath/orientation.cpp
+++ b/src/viam/sdk/spatialmath/orientation.cpp
@@ -25,7 +25,7 @@ OrientationConfig::OrientationConfig() {
     orientation_ = quat;
 }
 
-OrientationConfig OrientationConfig::from_proto(proto::Orientation proto) {
+OrientationConfig OrientationConfig::from_proto(const proto::Orientation& proto) {
     OrientationConfig cfg;
     switch (proto.type_case()) {
         case proto::Orientation::TypeCase::kAxisAngles: {

--- a/src/viam/sdk/spatialmath/orientation.hpp
+++ b/src/viam/sdk/spatialmath/orientation.hpp
@@ -19,7 +19,7 @@ typedef boost::
 class OrientationConfig {
    public:
     viam::app::v1::Orientation to_proto() const;
-    static OrientationConfig from_proto(viam::app::v1::Orientation proto);
+    static OrientationConfig from_proto(const viam::app::v1::Orientation& proto);
     OrientationConfig(OrientationType type_,
                       std::vector<std::uint8_t> value,
                       orientation orientation)


### PR DESCRIPTION
- adds performance-unnecessary-value-param checks to clang-tidy
- (flyby) implement a previously-unimplemented `to_proto` method
- (flyby) change `Vector3::to_proto` to no longer be static