### PR TITLE
RSDK-6726 - update client types in c++ code samples

### DIFF
--- a/codesamples/apis.json
+++ b/codesamples/apis.json
@@ -1,43 +1,43 @@
 {
     "base": {
-        "client": "BaseClient",
+        "client": "Base",
         "func": "is_moving",
         "args": []
     },
     "camera": {
-        "client": "CameraClient",
+        "client": "Camera",
         "func": "get_image",
         "args": [ "std::string(\"image/png\")" ],
         "comment": "Note that the supplied MIME type is just a placeholder. Please update as necessary."
     },
     "encoder": {
-        "client": "EncoderClient",
+        "client": "Encoder",
         "func": "get_properties",
         "args": []
     },
     "motion": {
-        "client": "MotionClient",
+        "client": "Motion",
         "func": "get_pose",
         "args": ["{{\"rdk\", \"component\", \"fake\"}, \"\", \"component\"}", "<destination-frame>", "{}", "nullptr"],
         "comment": "Update with correct component name, destination frame, supplemental transforms, and extra params"
     },
     "motor": {
-        "client": "MotorClient",
+        "client": "Motor",
         "func": "is_moving",
         "args": []
     },
     "movement_sensor": {
-        "client": "MovementSensorClient",
+        "client": "MovementSensor",
         "func": "get_linear_velocity",
         "args": []
     },
     "power_sensor": {
-        "client": "PowerSensorClient",
+        "client": "PowerSensor",
         "func": "get_voltage",
         "args": []
     },
     "sensor": {
-        "client": "SensorClient",
+        "client": "Sensor",
         "func": "get_readings",
         "args": []
     }

--- a/src/viam/examples/dial/example_dial.cpp
+++ b/src/viam/examples/dial/example_dial.cpp
@@ -43,7 +43,7 @@ int main() {
     std::vector<Name> resource_names = robot->resource_names();
     std::cout << "Resources" << std::endl;
     for (const Name& resource : resource_names) {
-        std::cout << "\t" << resource << "\n" << std::endl;
+        std::cout << "\t" << resource << "\n";
     }
 
     // ensure we can query statuses

--- a/src/viam/examples/dial_api_key/example_dial_api_key.cpp
+++ b/src/viam/examples/dial_api_key/example_dial_api_key.cpp
@@ -44,7 +44,7 @@ int main() {
     std::vector<Name> resource_names = robot->resource_names();
     std::cout << "Resources" << std::endl;
     for (const Name& resource : resource_names) {
-        std::cout << "\t" << resource << "\n" << std::endl;
+        std::cout << "\t" << resource << "\n";
     }
 
     // ensure we can query statuses

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -311,7 +311,9 @@ RobotClient::RobotClient(std::shared_ptr<ViamChannel> channel)
     : channel_(channel->channel()),
       viam_channel_(std::move(channel)),
       should_close_channel_(false),
-      impl_(std::make_unique<impl>(RobotService::NewStub(channel_))) {}
+      impl_(std::make_unique<impl>(RobotService::NewStub(channel_))) {
+    Registry::initialize();
+}
 
 std::vector<Name> RobotClient::resource_names() const {
     const std::lock_guard<std::mutex> lock(lock_);


### PR DESCRIPTION
`apis.json` was still passing `FooClient` as the client type for code samples, leading to `resource_by_name<FooClient>(...)` rather than the now-correct `resource_by_name<Foo>(...)`. This PR fixes that.