### PR TITLE
[RSDK-7310] Update the board interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # ignore doxygen output
 /etc/docs/api/*
+
+# Vim temporary swap files
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,3 @@
 
 # ignore doxygen output
 /etc/docs/api/*
-
-# Vim temporary swap files
-*.swp

--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -341,6 +341,7 @@ target_sources(viamapi
       ${PROTO_GEN_DIR}/../../viam/api/google/api/annotations.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/google/api/http.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/google/api/httpbody.pb.h
+      ${PROTO_GEN_DIR}/../../viam/api/google/rpc/status.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/module/v1/module.grpc.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/module/v1/module.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/robot/v1/robot.grpc.pb.h

--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -181,12 +181,98 @@ if (VIAMCPPSDK_USE_DYNAMIC_PROTOS)
     ${PROTO_GEN_DIR}/component/servo/v1/servo.grpc.pb.h
     ${PROTO_GEN_DIR}/component/servo/v1/servo.pb.cc
     ${PROTO_GEN_DIR}/component/servo/v1/servo.pb.h
+    ${PROTO_GEN_DIR}/google/api/annotations.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/annotations.grpc.pb.h
     ${PROTO_GEN_DIR}/google/api/annotations.pb.cc
     ${PROTO_GEN_DIR}/google/api/annotations.pb.h
-    ${PROTO_GEN_DIR}/google/api/httpbody.pb.cc
-    ${PROTO_GEN_DIR}/google/api/httpbody.pb.h
+    ${PROTO_GEN_DIR}/google/api/client.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/client.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/client.pb.cc
+    ${PROTO_GEN_DIR}/google/api/client.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/checked.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/checked.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/checked.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/checked.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/eval.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/eval.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/eval.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/eval.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/explain.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/explain.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/explain.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/explain.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/syntax.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/syntax.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/syntax.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/syntax.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/value.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/value.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/value.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/value.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/decl.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/decl.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/decl.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/decl.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/eval.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/eval.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/eval.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/eval.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/expr.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/expr.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/expr.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/expr.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/source.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/source.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/source.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/source.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/value.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/value.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/value.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/value.pb.h
+    ${PROTO_GEN_DIR}/google/api/field_behavior.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/field_behavior.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/field_behavior.pb.cc
+    ${PROTO_GEN_DIR}/google/api/field_behavior.pb.h
+    ${PROTO_GEN_DIR}/google/api/field_info.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/field_info.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/field_info.pb.cc
+    ${PROTO_GEN_DIR}/google/api/field_info.pb.h
+    ${PROTO_GEN_DIR}/google/api/http.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/http.grpc.pb.h
     ${PROTO_GEN_DIR}/google/api/http.pb.cc
     ${PROTO_GEN_DIR}/google/api/http.pb.h
+    ${PROTO_GEN_DIR}/google/api/httpbody.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/httpbody.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/httpbody.pb.cc
+    ${PROTO_GEN_DIR}/google/api/httpbody.pb.h
+    ${PROTO_GEN_DIR}/google/api/launch_stage.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/launch_stage.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/launch_stage.pb.cc
+    ${PROTO_GEN_DIR}/google/api/launch_stage.pb.h
+    ${PROTO_GEN_DIR}/google/api/resource.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/resource.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/resource.pb.cc
+    ${PROTO_GEN_DIR}/google/api/resource.pb.h
+    ${PROTO_GEN_DIR}/google/api/visibility.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/visibility.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/api/visibility.pb.cc
+    ${PROTO_GEN_DIR}/google/api/visibility.pb.h
+    ${PROTO_GEN_DIR}/google/rpc/code.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/code.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/rpc/code.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/code.pb.h
+    ${PROTO_GEN_DIR}/google/rpc/context/attribute_context.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/context/attribute_context.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/rpc/context/attribute_context.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/context/attribute_context.pb.h
+    ${PROTO_GEN_DIR}/google/rpc/error_details.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/error_details.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/rpc/error_details.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/error_details.pb.h
+    ${PROTO_GEN_DIR}/google/rpc/status.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/status.grpc.pb.h
+    ${PROTO_GEN_DIR}/google/rpc/status.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/status.pb.h
     ${PROTO_GEN_DIR}/module/v1/module.grpc.pb.cc
     ${PROTO_GEN_DIR}/module/v1/module.grpc.pb.h
     ${PROTO_GEN_DIR}/module/v1/module.pb.cc
@@ -288,9 +374,52 @@ target_sources(viamapi
     ${PROTO_GEN_DIR}/component/sensor/v1/sensor.pb.cc
     ${PROTO_GEN_DIR}/component/servo/v1/servo.grpc.pb.cc
     ${PROTO_GEN_DIR}/component/servo/v1/servo.pb.cc
+    ${PROTO_GEN_DIR}/google/api/annotations.grpc.pb.cc
     ${PROTO_GEN_DIR}/google/api/annotations.pb.cc
+    ${PROTO_GEN_DIR}/google/api/client.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/client.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/checked.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/checked.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/eval.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/eval.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/explain.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/explain.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/syntax.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/syntax.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/value.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/value.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/decl.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/decl.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/eval.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/eval.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/expr.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/expr.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/source.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/source.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/value.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/value.pb.cc
+    ${PROTO_GEN_DIR}/google/api/field_behavior.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/field_behavior.pb.cc
+    ${PROTO_GEN_DIR}/google/api/field_info.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/field_info.pb.cc
+    ${PROTO_GEN_DIR}/google/api/http.grpc.pb.cc
     ${PROTO_GEN_DIR}/google/api/http.pb.cc
+    ${PROTO_GEN_DIR}/google/api/httpbody.grpc.pb.cc
     ${PROTO_GEN_DIR}/google/api/httpbody.pb.cc
+    ${PROTO_GEN_DIR}/google/api/launch_stage.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/launch_stage.pb.cc
+    ${PROTO_GEN_DIR}/google/api/resource.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/resource.pb.cc
+    ${PROTO_GEN_DIR}/google/api/visibility.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/api/visibility.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/code.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/code.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/context/attribute_context.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/context/attribute_context.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/error_details.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/error_details.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/status.grpc.pb.cc
+    ${PROTO_GEN_DIR}/google/rpc/status.pb.cc
     ${PROTO_GEN_DIR}/module/v1/module.grpc.pb.cc
     ${PROTO_GEN_DIR}/module/v1/module.pb.cc
     ${PROTO_GEN_DIR}/robot/v1/robot.grpc.pb.cc
@@ -357,6 +486,8 @@ set_target_properties(
   SOVERSION noabi
   VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}
 )
+
+target_link_options(viamapi PRIVATE "LINKER:-z,defs")
 
 target_include_directories(viamapi
   PUBLIC

--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -487,8 +487,6 @@ set_target_properties(
   VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}
 )
 
-target_link_options(viamapi PRIVATE "LINKER:-z,defs")
-
 target_include_directories(viamapi
   PUBLIC
     # Unfortunately, the generated protos don't say 'viam/api' at

--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -189,46 +189,6 @@ if (VIAMCPPSDK_USE_DYNAMIC_PROTOS)
     ${PROTO_GEN_DIR}/google/api/client.grpc.pb.h
     ${PROTO_GEN_DIR}/google/api/client.pb.cc
     ${PROTO_GEN_DIR}/google/api/client.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/checked.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/checked.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/checked.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/checked.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/eval.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/eval.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/eval.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/eval.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/explain.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/explain.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/explain.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/explain.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/syntax.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/syntax.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/syntax.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/syntax.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/value.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/value.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/value.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/value.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/decl.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/decl.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/decl.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/decl.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/eval.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/eval.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/eval.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/eval.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/expr.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/expr.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/expr.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/expr.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/source.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/source.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/source.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/source.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/value.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/value.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/value.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/value.pb.h
     ${PROTO_GEN_DIR}/google/api/field_behavior.grpc.pb.cc
     ${PROTO_GEN_DIR}/google/api/field_behavior.grpc.pb.h
     ${PROTO_GEN_DIR}/google/api/field_behavior.pb.cc
@@ -378,26 +338,6 @@ target_sources(viamapi
     ${PROTO_GEN_DIR}/google/api/annotations.pb.cc
     ${PROTO_GEN_DIR}/google/api/client.grpc.pb.cc
     ${PROTO_GEN_DIR}/google/api/client.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/checked.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/checked.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/eval.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/eval.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/explain.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/explain.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/syntax.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/syntax.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/value.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1alpha1/value.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/decl.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/decl.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/eval.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/eval.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/expr.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/expr.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/source.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/source.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/value.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/expr/v1beta1/value.pb.cc
     ${PROTO_GEN_DIR}/google/api/field_behavior.grpc.pb.cc
     ${PROTO_GEN_DIR}/google/api/field_behavior.pb.cc
     ${PROTO_GEN_DIR}/google/api/field_info.grpc.pb.cc

--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -19,6 +19,7 @@ if (VIAMCPPSDK_USE_DYNAMIC_PROTOS)
 endif()
 
 set(BUF_PROTO_COMPONENTS
+  app/mltraining
   app/packages
   app/v1
   common
@@ -124,6 +125,8 @@ if (VIAMCPPSDK_USE_DYNAMIC_PROTOS)
     # it sanely? We would need to filter out (or add in) the headers.
 
     # This list is needed for the core library.
+    ${PROTO_GEN_DIR}/app/mltraining/v1/ml_training.pb.cc
+    ${PROTO_GEN_DIR}/app/mltraining/v1/ml_training.pb.h
     ${PROTO_GEN_DIR}/app/packages/v1/packages.pb.cc
     ${PROTO_GEN_DIR}/app/packages/v1/packages.pb.h
     ${PROTO_GEN_DIR}/app/v1/app.grpc.pb.cc
@@ -257,6 +260,7 @@ add_library(viam-cpp-sdk::viamapi ALIAS viamapi)
 
 target_sources(viamapi
   PRIVATE
+    ${PROTO_GEN_DIR}/app/mltraining/v1/ml_training.pb.cc
     ${PROTO_GEN_DIR}/app/packages/v1/packages.pb.cc
     ${PROTO_GEN_DIR}/app/v1/app.grpc.pb.cc
     ${PROTO_GEN_DIR}/app/v1/app.pb.cc
@@ -303,6 +307,7 @@ target_sources(viamapi
     BASE_DIRS
       ${PROTO_GEN_DIR}/../..
     FILES
+      ${PROTO_GEN_DIR}/../../viam/api/app/mltraining/v1/ml_training.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/app/packages/v1/packages.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/app/v1/app.grpc.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/app/v1/app.pb.h

--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -187,20 +187,6 @@ if (VIAMCPPSDK_USE_DYNAMIC_PROTOS)
     ${PROTO_GEN_DIR}/google/api/httpbody.pb.h
     ${PROTO_GEN_DIR}/google/api/http.pb.cc
     ${PROTO_GEN_DIR}/google/api/http.pb.h
-    ${PROTO_GEN_DIR}/google/rpc/code.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/rpc/code.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/rpc/code.pb.cc
-    ${PROTO_GEN_DIR}/google/rpc/code.pb.h
-    ${PROTO_GEN_DIR}/google/rpc/context/attribute_context.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/rpc/context/attribute_context.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/rpc/context/attribute_context.pb.cc
-    ${PROTO_GEN_DIR}/google/rpc/context/attribute_context.pb.h
-    ${PROTO_GEN_DIR}/google/rpc/error_details.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/rpc/error_details.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/rpc/error_details.pb.cc
-    ${PROTO_GEN_DIR}/google/rpc/error_details.pb.h
-    ${PROTO_GEN_DIR}/google/rpc/status.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/rpc/status.grpc.pb.h
     ${PROTO_GEN_DIR}/google/rpc/status.pb.cc
     ${PROTO_GEN_DIR}/google/rpc/status.pb.h
     ${PROTO_GEN_DIR}/module/v1/module.grpc.pb.cc
@@ -307,13 +293,6 @@ target_sources(viamapi
     ${PROTO_GEN_DIR}/google/api/annotations.pb.cc
     ${PROTO_GEN_DIR}/google/api/http.pb.cc
     ${PROTO_GEN_DIR}/google/api/httpbody.pb.cc
-    ${PROTO_GEN_DIR}/google/rpc/code.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/rpc/code.pb.cc
-    ${PROTO_GEN_DIR}/google/rpc/context/attribute_context.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/rpc/context/attribute_context.pb.cc
-    ${PROTO_GEN_DIR}/google/rpc/error_details.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/rpc/error_details.pb.cc
-    ${PROTO_GEN_DIR}/google/rpc/status.grpc.pb.cc
     ${PROTO_GEN_DIR}/google/rpc/status.pb.cc
     ${PROTO_GEN_DIR}/module/v1/module.grpc.pb.cc
     ${PROTO_GEN_DIR}/module/v1/module.pb.cc

--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -181,42 +181,12 @@ if (VIAMCPPSDK_USE_DYNAMIC_PROTOS)
     ${PROTO_GEN_DIR}/component/servo/v1/servo.grpc.pb.h
     ${PROTO_GEN_DIR}/component/servo/v1/servo.pb.cc
     ${PROTO_GEN_DIR}/component/servo/v1/servo.pb.h
-    ${PROTO_GEN_DIR}/google/api/annotations.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/annotations.grpc.pb.h
     ${PROTO_GEN_DIR}/google/api/annotations.pb.cc
     ${PROTO_GEN_DIR}/google/api/annotations.pb.h
-    ${PROTO_GEN_DIR}/google/api/client.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/client.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/client.pb.cc
-    ${PROTO_GEN_DIR}/google/api/client.pb.h
-    ${PROTO_GEN_DIR}/google/api/field_behavior.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/field_behavior.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/field_behavior.pb.cc
-    ${PROTO_GEN_DIR}/google/api/field_behavior.pb.h
-    ${PROTO_GEN_DIR}/google/api/field_info.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/field_info.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/field_info.pb.cc
-    ${PROTO_GEN_DIR}/google/api/field_info.pb.h
-    ${PROTO_GEN_DIR}/google/api/http.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/http.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/http.pb.cc
-    ${PROTO_GEN_DIR}/google/api/http.pb.h
-    ${PROTO_GEN_DIR}/google/api/httpbody.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/httpbody.grpc.pb.h
     ${PROTO_GEN_DIR}/google/api/httpbody.pb.cc
     ${PROTO_GEN_DIR}/google/api/httpbody.pb.h
-    ${PROTO_GEN_DIR}/google/api/launch_stage.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/launch_stage.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/launch_stage.pb.cc
-    ${PROTO_GEN_DIR}/google/api/launch_stage.pb.h
-    ${PROTO_GEN_DIR}/google/api/resource.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/resource.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/resource.pb.cc
-    ${PROTO_GEN_DIR}/google/api/resource.pb.h
-    ${PROTO_GEN_DIR}/google/api/visibility.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/visibility.grpc.pb.h
-    ${PROTO_GEN_DIR}/google/api/visibility.pb.cc
-    ${PROTO_GEN_DIR}/google/api/visibility.pb.h
+    ${PROTO_GEN_DIR}/google/api/http.pb.cc
+    ${PROTO_GEN_DIR}/google/api/http.pb.h
     ${PROTO_GEN_DIR}/google/rpc/code.grpc.pb.cc
     ${PROTO_GEN_DIR}/google/rpc/code.grpc.pb.h
     ${PROTO_GEN_DIR}/google/rpc/code.pb.cc
@@ -334,24 +304,9 @@ target_sources(viamapi
     ${PROTO_GEN_DIR}/component/sensor/v1/sensor.pb.cc
     ${PROTO_GEN_DIR}/component/servo/v1/servo.grpc.pb.cc
     ${PROTO_GEN_DIR}/component/servo/v1/servo.pb.cc
-    ${PROTO_GEN_DIR}/google/api/annotations.grpc.pb.cc
     ${PROTO_GEN_DIR}/google/api/annotations.pb.cc
-    ${PROTO_GEN_DIR}/google/api/client.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/client.pb.cc
-    ${PROTO_GEN_DIR}/google/api/field_behavior.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/field_behavior.pb.cc
-    ${PROTO_GEN_DIR}/google/api/field_info.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/field_info.pb.cc
-    ${PROTO_GEN_DIR}/google/api/http.grpc.pb.cc
     ${PROTO_GEN_DIR}/google/api/http.pb.cc
-    ${PROTO_GEN_DIR}/google/api/httpbody.grpc.pb.cc
     ${PROTO_GEN_DIR}/google/api/httpbody.pb.cc
-    ${PROTO_GEN_DIR}/google/api/launch_stage.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/launch_stage.pb.cc
-    ${PROTO_GEN_DIR}/google/api/resource.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/resource.pb.cc
-    ${PROTO_GEN_DIR}/google/api/visibility.grpc.pb.cc
-    ${PROTO_GEN_DIR}/google/api/visibility.pb.cc
     ${PROTO_GEN_DIR}/google/rpc/code.grpc.pb.cc
     ${PROTO_GEN_DIR}/google/rpc/code.pb.cc
     ${PROTO_GEN_DIR}/google/rpc/context/attribute_context.grpc.pb.cc

--- a/src/viam/examples/modules/complex/proto/buf.lock
+++ b/src/viam/examples/modules/complex/proto/buf.lock
@@ -4,5 +4,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: ee48893a270147348e3edc6c1a03de0e
-    digest: shake256:a35b0576a2b55dad72747e786af05c03539c2b96be236c9de39fe10d551931ac252eb68445c0cef6bbd27fa20e8c26eee5b8a9fe9c2fde6f63a03e18f8cf980d
+    commit: 4ed3bc159a8b4ac68fe253218760d035

--- a/src/viam/examples/modules/complex/proto/buf.lock
+++ b/src/viam/examples/modules/complex/proto/buf.lock
@@ -4,4 +4,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 4ed3bc159a8b4ac68fe253218760d035
+    commit: 74015a8aeb8445aa9e3e1454cb54bc35

--- a/src/viam/sdk/components/board.cpp
+++ b/src/viam/sdk/components/board.cpp
@@ -73,13 +73,6 @@ viam::component::board::v1::PowerMode Board::to_proto(Board::power_mode power_mo
     }
 }
 
-std::unordered_map<std::string, Board::analog_value> Board::get_analog_readers() {
-    return this->get_status().analog_reader_values;
-}
-
-std::unordered_map<std::string, Board::digital_value> Board::get_digital_interrupts() {
-    return this->get_status().digital_interrupt_values;
-}
 Board::Board(std::string name) : Component(std::move(name)){};
 
 bool operator==(const Board::status& lhs, const Board::status& rhs) {

--- a/src/viam/sdk/components/board.cpp
+++ b/src/viam/sdk/components/board.cpp
@@ -73,26 +73,6 @@ viam::component::board::v1::PowerMode Board::to_proto(Board::power_mode power_mo
     }
 }
 
-std::vector<std::string> Board::get_analog_reader_names() {
-    std::vector<std::string> names;
-    auto status = this->get_status();
-    names.reserve(status.analog_reader_values.size());
-    for (const auto& kv : status.analog_reader_values) {
-        names.push_back(kv.first);
-    }
-    return names;
-}
-
-std::vector<std::string> Board::get_digital_interrupt_names() {
-    std::vector<std::string> names;
-    auto status = this->get_status();
-    names.reserve(status.digital_interrupt_values.size());
-    for (const auto& kv : status.digital_interrupt_values) {
-        names.push_back(kv.first);
-    }
-    return names;
-}
-
 std::unordered_map<std::string, Board::analog_value> Board::get_analog_readers() {
     return this->get_status().analog_reader_values;
 }

--- a/src/viam/sdk/components/board.cpp
+++ b/src/viam/sdk/components/board.cpp
@@ -20,13 +20,13 @@ API API::traits<Board>::api() {
     return {kRDK, kComponent, "board"};
 }
 
-Board::status Board::from_proto(const viam::common::v1::BoardStatus& proto) {
+Board::status Board::from_proto(const viam::component::board::v1::Status& proto) {
     Board::status status;
     for (const auto& analog : proto.analogs()) {
-        status.analog_reader_values.emplace(analog.first, analog.second.value());
+        status.analog_reader_values.emplace(analog.first, analog.second);
     }
     for (const auto& digital : proto.digital_interrupts()) {
-        status.digital_interrupt_values.emplace(digital.first, digital.second.value());
+        status.digital_interrupt_values.emplace(digital.first, digital.second);
     }
     return status;
 }
@@ -47,14 +47,14 @@ Board::power_mode Board::from_proto(viam::component::board::v1::PowerMode proto)
     }
 }
 
-viam::common::v1::BoardStatus Board::to_proto(const status& status) {
-    viam::common::v1::BoardStatus proto;
+viam::component::board::v1::Status Board::to_proto(const status& status) {
+    viam::component::board::v1::Status proto;
     for (const auto& analog : status.analog_reader_values) {
-        proto.mutable_analogs()->insert({analog.first, to_proto(analog.second)});
+        proto.mutable_analogs()->insert({analog.first, analog.second});
     }
 
     for (const auto& digital : status.digital_interrupt_values) {
-        proto.mutable_digital_interrupts()->insert({digital.first, to_proto(digital.second)});
+        proto.mutable_digital_interrupts()->insert({digital.first, digital.second});
     }
     return proto;
 }

--- a/src/viam/sdk/components/board.cpp
+++ b/src/viam/sdk/components/board.cpp
@@ -31,14 +31,6 @@ Board::status Board::from_proto(const viam::common::v1::BoardStatus& proto) {
     return status;
 }
 
-Board::analog_value Board::from_proto(const viam::common::v1::AnalogStatus& proto) {
-    return proto.value();
-}
-
-Board::digital_value Board::from_proto(const viam::common::v1::DigitalInterruptStatus& proto) {
-    return proto.value();
-}
-
 Board::power_mode Board::from_proto(viam::component::board::v1::PowerMode proto) {
     switch (proto) {
         case viam::component::board::v1::POWER_MODE_NORMAL: {
@@ -64,18 +56,6 @@ viam::common::v1::BoardStatus Board::to_proto(const status& status) {
     for (const auto& digital : status.digital_interrupt_values) {
         proto.mutable_digital_interrupts()->insert({digital.first, to_proto(digital.second)});
     }
-    return proto;
-}
-
-viam::common::v1::AnalogStatus Board::to_proto(analog_value analog_value) {
-    viam::common::v1::AnalogStatus proto;
-    proto.set_value(analog_value);
-    return proto;
-}
-
-viam::common::v1::DigitalInterruptStatus Board::to_proto(digital_value digital_value) {
-    viam::common::v1::DigitalInterruptStatus proto;
-    proto.set_value(digital_value);
     return proto;
 }
 

--- a/src/viam/sdk/components/board.hpp
+++ b/src/viam/sdk/components/board.hpp
@@ -77,14 +77,6 @@ class Board : public Component {
     /// @brief Converts a `power_mode` enum to its proto representation.
     static viam::component::board::v1::PowerMode to_proto(power_mode power_mode);
 
-    /// @brief Get all defined analog readers defined for this board
-    /// This information comes from calling `get_status()`
-    std::unordered_map<std::string, analog_value> get_analog_readers();
-
-    /// @brief Get all defined digital interrupts for this board
-    /// This information comes from calling `get_status()`
-    std::unordered_map<std::string, digital_value> get_digital_interrupts();
-
     /// @brief Gets the high/low state of the given pin on a board.
     /// @param pin board pin name
     /// @return high/low state of the given pin. High = on, low = off

--- a/src/viam/sdk/components/board.hpp
+++ b/src/viam/sdk/components/board.hpp
@@ -77,15 +77,6 @@ class Board : public Component {
     /// @brief Converts a `power_mode` enum to its proto representation.
     static viam::component::board::v1::PowerMode to_proto(power_mode power_mode);
 
-    /// @brief Get the status of all of the registered analog readers and digital interrupt readers
-    inline status get_status() {
-        return get_status({});
-    }
-
-    /// @brief Get the status of all of the registered analog readers and digital interrupt readers
-    /// @param extra Any additional arguments to the method
-    virtual status get_status(const AttributeMap& extra) = 0;
-
     /// @brief Get the names of the defined analog readers defined for this board
     /// This information comes from calling `get_status()`
     std::vector<std::string> get_analog_reader_names();

--- a/src/viam/sdk/components/board.hpp
+++ b/src/viam/sdk/components/board.hpp
@@ -77,14 +77,6 @@ class Board : public Component {
     /// @brief Converts a `power_mode` enum to its proto representation.
     static viam::component::board::v1::PowerMode to_proto(power_mode power_mode);
 
-    /// @brief Get the names of the defined analog readers defined for this board
-    /// This information comes from calling `get_status()`
-    std::vector<std::string> get_analog_reader_names();
-
-    /// @brief Get the names of the defined digital interrupts for this board
-    /// This information comes from calling `get_status()`
-    std::vector<std::string> get_digital_interrupt_names();
-
     /// @brief Get all defined analog readers defined for this board
     /// This information comes from calling `get_status()`
     std::unordered_map<std::string, analog_value> get_analog_readers();

--- a/src/viam/sdk/components/board.hpp
+++ b/src/viam/sdk/components/board.hpp
@@ -66,13 +66,13 @@ class Board : public Component {
     API api() const override;
 
     /// @brief Creates a `status` struct from its proto representation.
-    static status from_proto(const viam::common::v1::BoardStatus& proto);
+    static status from_proto(const viam::component::board::v1::Status& proto);
 
     /// @brief Creates a `power_mode` enum from its proto representation.
     static power_mode from_proto(viam::component::board::v1::PowerMode proto);
 
     /// @brief Converts a `status` struct to its proto representation.
-    static viam::common::v1::BoardStatus to_proto(const status& status);
+    static viam::component::board::v1::Status to_proto(const status& status);
 
     /// @brief Converts a `power_mode` enum to its proto representation.
     static viam::component::board::v1::PowerMode to_proto(power_mode power_mode);

--- a/src/viam/sdk/components/board.hpp
+++ b/src/viam/sdk/components/board.hpp
@@ -68,23 +68,11 @@ class Board : public Component {
     /// @brief Creates a `status` struct from its proto representation.
     static status from_proto(const viam::common::v1::BoardStatus& proto);
 
-    /// @brief Creates a `analog_value` struct from its proto representation.
-    static analog_value from_proto(const viam::common::v1::AnalogStatus& proto);
-
-    /// @brief Creates a `digital_value` struct from its proto representation.
-    static digital_value from_proto(const viam::common::v1::DigitalInterruptStatus& proto);
-
     /// @brief Creates a `power_mode` enum from its proto representation.
     static power_mode from_proto(viam::component::board::v1::PowerMode proto);
 
     /// @brief Converts a `status` struct to its proto representation.
     static viam::common::v1::BoardStatus to_proto(const status& status);
-
-    /// @brief Converts a `analog_value` struct to its proto representation.
-    static viam::common::v1::AnalogStatus to_proto(analog_value analog_value);
-
-    /// @brief Converts a `digital_value` struct to its proto representation.
-    static viam::common::v1::DigitalInterruptStatus to_proto(digital_value digital_value);
 
     /// @brief Converts a `power_mode` enum to its proto representation.
     static viam::component::board::v1::PowerMode to_proto(power_mode power_mode);

--- a/src/viam/sdk/components/private/board_client.cpp
+++ b/src/viam/sdk/components/private/board_client.cpp
@@ -25,12 +25,6 @@ BoardClient::BoardClient(std::string name, std::shared_ptr<grpc::Channel> channe
       stub_(viam::component::board::v1::BoardService::NewStub(channel)),
       channel_(std::move(channel)){};
 
-Board::status BoardClient::get_status(const AttributeMap& extra) {
-    return make_client_helper(this, *stub_, &StubType::Status)
-        .with(extra)
-        .invoke([](auto& response) { return from_proto(response.status()); });
-}
-
 void BoardClient::set_gpio(const std::string& pin, bool high, const AttributeMap& extra) {
     return make_client_helper(this, *stub_, &StubType::SetGPIO)
         .with(extra,

--- a/src/viam/sdk/components/private/board_client.hpp
+++ b/src/viam/sdk/components/private/board_client.hpp
@@ -24,7 +24,6 @@ class BoardClient : public Board {
     using interface_type = Board;
     BoardClient(std::string name, std::shared_ptr<grpc::Channel> channel);
     AttributeMap do_command(const AttributeMap& command) override;
-    status get_status(const AttributeMap& extra) override;
     void set_gpio(const std::string& pin, bool high, const AttributeMap& extra) override;
     bool get_gpio(const std::string& pin, const AttributeMap& extra) override;
     double get_pwm_duty_cycle(const std::string& pin, const AttributeMap& extra) override;
@@ -62,7 +61,6 @@ class BoardClient : public Board {
     using Board::get_gpio;
     using Board::get_pwm_duty_cycle;
     using Board::get_pwm_frequency;
-    using Board::get_status;
     using Board::read_analog;
     using Board::read_digital_interrupt;
     using Board::set_gpio;

--- a/src/viam/sdk/components/private/board_server.cpp
+++ b/src/viam/sdk/components/private/board_server.cpp
@@ -14,18 +14,6 @@ namespace impl {
 BoardServer::BoardServer(std::shared_ptr<ResourceManager> manager)
     : ResourceServer(std::move(manager)){};
 
-::grpc::Status BoardServer::Status(
-    ::grpc::ServerContext*,
-    const ::viam::component::board::v1::StatusRequest* request,
-    ::viam::component::board::v1::StatusResponse* response) noexcept {
-    return make_service_helper<Board>(
-        "BoardServer::Status", this, request)([&](auto& helper, auto& board) {
-        const viam::common::v1::BoardStatus status =
-            Board::to_proto(board->get_status(helper.getExtra()));
-        *response->mutable_status() = status;
-    });
-}
-
 ::grpc::Status BoardServer::SetGPIO(::grpc::ServerContext*,
                                     const ::viam::component::board::v1::SetGPIORequest* request,
                                     ::viam::component::board::v1::SetGPIOResponse*) noexcept {

--- a/src/viam/sdk/components/private/board_server.hpp
+++ b/src/viam/sdk/components/private/board_server.hpp
@@ -24,10 +24,6 @@ class BoardServer : public ResourceServer,
     using interface_type = Board;
     explicit BoardServer(std::shared_ptr<ResourceManager> manager);
 
-    ::grpc::Status Status(::grpc::ServerContext* context,
-                          const ::viam::component::board::v1::StatusRequest* request,
-                          ::viam::component::board::v1::StatusResponse* response) noexcept override;
-
     ::grpc::Status SetGPIO(
         ::grpc::ServerContext* context,
         const ::viam::component::board::v1::SetGPIORequest* request,

--- a/src/viam/sdk/tests/mocks/mock_board.cpp
+++ b/src/viam/sdk/tests/mocks/mock_board.cpp
@@ -12,10 +12,6 @@ using namespace viam::sdk;
 
 MockBoard::MockBoard(std::string name) : Board(std::move(name)){};
 
-Board::status MockBoard::get_status(const AttributeMap&) {
-    return this->peek_get_status_ret;
-}
-
 void MockBoard::set_gpio(const std::string& pin, bool high, const AttributeMap&) {
     this->peek_pin = pin;
     this->peek_set_gpio_high = high;

--- a/src/viam/sdk/tests/mocks/mock_board.hpp
+++ b/src/viam/sdk/tests/mocks/mock_board.hpp
@@ -11,7 +11,6 @@ namespace board {
 class MockBoard : public viam::sdk::Board {
    public:
     MockBoard(std::string name);
-    Board::status get_status(const sdk::AttributeMap& extra) override;
     void set_gpio(const std::string& pin, bool high, const sdk::AttributeMap& extra) override;
     bool get_gpio(const std::string& pin, const sdk::AttributeMap& extra) override;
     double get_pwm_duty_cycle(const std::string& pin, const sdk::AttributeMap& extra) override;
@@ -39,7 +38,6 @@ class MockBoard : public viam::sdk::Board {
     std::string peek_pin, peek_analog_reader_name, peek_digital_interrupt_name;
     int peek_pin_value;
     std::map<std::string, std::function<bool(Board::Tick tick)>> peek_callbacks;
-    Board::status peek_get_status_ret;
     bool peek_set_gpio_high;
     bool peek_get_gpio_ret;
     double peek_get_pwm_duty_cycle_ret;

--- a/src/viam/sdk/tests/test_board.cpp
+++ b/src/viam/sdk/tests/test_board.cpp
@@ -33,19 +33,6 @@ BOOST_AUTO_TEST_CASE(mock_get_api) {
     BOOST_CHECK_EQUAL(static_api.resource_subtype(), "board");
 }
 
-BOOST_AUTO_TEST_CASE(test_status) {
-    const auto mock = std::make_shared<MockBoard>("mock_board");
-    client_to_mock_pipeline<Board>(mock, [&](Board& client) {
-        std::unordered_map<std::string, Board::analog_value> analogs;
-        analogs.emplace("analog", 1);
-        std::unordered_map<std::string, Board::digital_value> digitals;
-        digitals.emplace("digital", 2);
-        mock->peek_get_status_ret = Board::status{analogs, digitals};
-
-        BOOST_CHECK(client.get_status() == mock->peek_get_status_ret);
-    });
-}
-
 BOOST_AUTO_TEST_CASE(test_set_gpio) {
     const auto mock = std::make_shared<MockBoard>("mock_board");
     client_to_mock_pipeline<Board>(mock, [&](Board& client) {
@@ -159,34 +146,6 @@ BOOST_AUTO_TEST_CASE(test_stream_ticks) {
         BOOST_CHECK_EQUAL(iterator->first, "t1");
         iterator++;
         BOOST_CHECK_EQUAL(iterator->first, "t2");
-    });
-}
-
-BOOST_AUTO_TEST_CASE(test_get_analog_reader_names) {
-    const auto mock = std::make_shared<MockBoard>("mock_board");
-    client_to_mock_pipeline<Board>(mock, [&](Board& client) {
-        std::unordered_map<std::string, Board::analog_value> analogs;
-        analogs.emplace("analog1", 2);
-        analogs.emplace("analog2", 2);
-        mock->peek_get_status_ret = Board::status{analogs, {}};
-        auto ret = client.get_analog_reader_names();
-        std::sort(ret.begin(), ret.end());
-        BOOST_CHECK_EQUAL(ret[0], "analog1");
-        BOOST_CHECK_EQUAL(ret[1], "analog2");
-    });
-}
-
-BOOST_AUTO_TEST_CASE(test_get_digital_interrupt_names) {
-    const auto mock = std::make_shared<MockBoard>("mock_board");
-    client_to_mock_pipeline<Board>(mock, [&](Board& client) {
-        std::unordered_map<std::string, Board::digital_value> digitals;
-        digitals.emplace("digital1", 2);
-        digitals.emplace("digital2", 2);
-        mock->peek_get_status_ret = Board::status{{}, digitals};
-        auto ret = client.get_digital_interrupt_names();
-        std::sort(ret.begin(), ret.end());
-        BOOST_CHECK_EQUAL(ret[0], "digital1");
-        BOOST_CHECK_EQUAL(ret[1], "digital2");
     });
 }
 


### PR DESCRIPTION
This turned out to be two problems combined! 1) update the SDK to use a more recent version of the protobufs in the API repo, and then 2) remove the `Status` RPC from the boards. The PR isn't quite done: I'm unsure how this should interact with https://github.com/viamrobotics/viam-cpp-sdk/pull/230, which is where the compiled version of the updated protos is. but the rest I think is ready for a look.

Updating the protobufs was harder than I expected: https://github.com/viamrobotics/api/pull/470 (unrelated to boards) added a new type that had not been used previously, which meant that getting it to work required updating CMakeLists.txt to include the Google libraries for the new type.

Changes to boards:
- `get_status` doesn't exist any more. You can get the standard status from a component the same way you would for a motor, but there isn't a special board-specific one any more.
- In the component status you _can_ get, analog and digital interrupt values are stored as ints, not wrappers around ints. No need to unwrap.
- `get_analog_names` and `get_digital_interrupt_names` can't easily be implemented any more. They don't exist in the Flutter and TypeScript SDKs, and are hopefully being removed from the Go and Python SDKs soon (they have a purpose on the server side, but no obvious use on the client side, so probably shouldn't be in these SDKs). So, I removed them. 
- Similarly, I removed `get_analog_readers` and `get_digital_interrupts`, as they're not present in the Go SDK and would be very hard to implement without the old status.

Everything compiles against a recent version of the API repo, but not against the protobufs copied into this repo itself. How should that be accomplished?