### PR TITLE
[RSDK-7151] Update analog reader responses to include accuracy data

### DIFF
--- a/src/viam/sdk/components/board.cpp
+++ b/src/viam/sdk/components/board.cpp
@@ -23,14 +23,7 @@ API API::traits<Board>::api() {
 Board::status Board::from_proto(const viam::component::board::v1::Status& proto) {
     Board::status status;
     for (const auto& analog : proto.analogs()) {
-        Board::analog_value result;
-        result.value = analog.second;
-        // The status does not contain the extra data to describe the accuracy of the reader. We
-        // fill those in with 0's instead.
-        result.min_range = 0.0;
-        result.max_range = 0.0;
-        result.step_size = 0.0;
-        status.analog_reader_values.emplace(analog.first, result);
+        status.analog_reader_values.emplace(analog.first, analog.second);
     }
     for (const auto& digital : proto.digital_interrupts()) {
         status.digital_interrupt_values.emplace(digital.first, digital.second);
@@ -57,7 +50,7 @@ Board::power_mode Board::from_proto(viam::component::board::v1::PowerMode proto)
 viam::component::board::v1::Status Board::to_proto(const status& status) {
     viam::component::board::v1::Status proto;
     for (const auto& analog : status.analog_reader_values) {
-        proto.mutable_analogs()->insert({analog.first, analog.second.value});
+        proto.mutable_analogs()->insert({analog.first, analog.second});
     }
 
     for (const auto& digital : status.digital_interrupt_values) {
@@ -85,11 +78,6 @@ Board::Board(std::string name) : Component(std::move(name)){};
 bool operator==(const Board::status& lhs, const Board::status& rhs) {
     return (lhs.analog_reader_values == rhs.analog_reader_values &&
             lhs.digital_interrupt_values == rhs.digital_interrupt_values);
-}
-
-bool operator==(const Board::analog_value& lhs, const Board::analog_value& rhs) {
-    return (lhs.value == rhs.value && lhs.min_range == rhs.min_range &&
-            lhs.max_range == rhs.max_range && lhs.step_size == rhs.step_size);
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/components/board.cpp
+++ b/src/viam/sdk/components/board.cpp
@@ -80,5 +80,12 @@ bool operator==(const Board::status& lhs, const Board::status& rhs) {
             lhs.digital_interrupt_values == rhs.digital_interrupt_values);
 }
 
+bool operator==(const Board::analog_value& lhs, const Board::analog_value& rhs) {
+    return (lhs.value == rhs.value &&
+            lhs.min == rhs.min &&
+            lhs.max == rhs.max &&
+            lhs.step_size == rhs.step_size);
+}
+
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/board.cpp
+++ b/src/viam/sdk/components/board.cpp
@@ -23,13 +23,13 @@ API API::traits<Board>::api() {
 Board::status Board::from_proto(const viam::component::board::v1::Status& proto) {
     Board::status status;
     for (const auto& analog : proto.analogs()) {
-		Board::analog_value result;
-		result.value = analog.second;
-		// The status does not contain the extra data to describe the accuracy of the reader. We
-		// fill those in with 0's instead.
-		result.min_range = 0.0;
-		result.max_range = 0.0;
-		result.step_size = 0.0;
+        Board::analog_value result;
+        result.value = analog.second;
+        // The status does not contain the extra data to describe the accuracy of the reader. We
+        // fill those in with 0's instead.
+        result.min_range = 0.0;
+        result.max_range = 0.0;
+        result.step_size = 0.0;
         status.analog_reader_values.emplace(analog.first, result);
     }
     for (const auto& digital : proto.digital_interrupts()) {
@@ -88,10 +88,8 @@ bool operator==(const Board::status& lhs, const Board::status& rhs) {
 }
 
 bool operator==(const Board::analog_value& lhs, const Board::analog_value& rhs) {
-    return (lhs.value == rhs.value &&
-            lhs.min_range == rhs.min_range &&
-            lhs.max_range == rhs.max_range &&
-            lhs.step_size == rhs.step_size);
+    return (lhs.value == rhs.value && lhs.min_range == rhs.min_range &&
+            lhs.max_range == rhs.max_range && lhs.step_size == rhs.step_size);
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/components/board.cpp
+++ b/src/viam/sdk/components/board.cpp
@@ -23,7 +23,14 @@ API API::traits<Board>::api() {
 Board::status Board::from_proto(const viam::component::board::v1::Status& proto) {
     Board::status status;
     for (const auto& analog : proto.analogs()) {
-        status.analog_reader_values.emplace(analog.first, analog.second);
+		Board::analog_value result;
+		result.value = analog.second;
+		// The status does not contain the extra data to describe the accuracy of the reader. We
+		// fill those in with 0's instead.
+		result.min_range = 0.0;
+		result.max_range = 0.0;
+		result.step_size = 0.0;
+        status.analog_reader_values.emplace(analog.first, result);
     }
     for (const auto& digital : proto.digital_interrupts()) {
         status.digital_interrupt_values.emplace(digital.first, digital.second);
@@ -82,8 +89,8 @@ bool operator==(const Board::status& lhs, const Board::status& rhs) {
 
 bool operator==(const Board::analog_value& lhs, const Board::analog_value& rhs) {
     return (lhs.value == rhs.value &&
-            lhs.min == rhs.min &&
-            lhs.max == rhs.max &&
+            lhs.min_range == rhs.min_range &&
+            lhs.max_range == rhs.max_range &&
             lhs.step_size == rhs.step_size);
 }
 

--- a/src/viam/sdk/components/board.cpp
+++ b/src/viam/sdk/components/board.cpp
@@ -50,7 +50,7 @@ Board::power_mode Board::from_proto(viam::component::board::v1::PowerMode proto)
 viam::component::board::v1::Status Board::to_proto(const status& status) {
     viam::component::board::v1::Status proto;
     for (const auto& analog : status.analog_reader_values) {
-        proto.mutable_analogs()->insert({analog.first, analog.second});
+        proto.mutable_analogs()->insert({analog.first, analog.second.value});
     }
 
     for (const auto& digital : status.digital_interrupt_values) {

--- a/src/viam/sdk/components/board.hpp
+++ b/src/viam/sdk/components/board.hpp
@@ -32,8 +32,8 @@ class Board : public Component {
     /// more details.
     struct analog_value {
 		int32_t value;
-		float min; // Minimum possible voltage read by the analog reader
-		float max; // Maximum possible voltage read by the analog reader
+		float min_range; // Minimum possible voltage read by the analog reader
+		float max_range; // Maximum possible voltage read by the analog reader
 		float step_size; // Volts represented in each step in the value
 	};
 

--- a/src/viam/sdk/components/board.hpp
+++ b/src/viam/sdk/components/board.hpp
@@ -26,15 +26,15 @@ namespace sdk {
 class Board : public Component {
    public:
     /// @brief Represents the raw value received by the registered analog to digital converter
-	/// (ADC). The range and conversion mechanism to voltage will vary depending on the specific
-	/// ADC registered to the pin.
-	using analog_value = int32_t;
+    /// (ADC). The range and conversion mechanism to voltage will vary depending on the specific
+    /// ADC registered to the pin.
+    using analog_value = int32_t;
 
-	/// @brief Represents the response received when reading the registered analog to digital
-	/// converter (ADC). The range and conversion mechanism to voltage will vary depending on the
-	/// specific ADC registered to the pin, though the min and max voltages and step_size can often
-	/// help with this conversion. Consult your ADC's documentation and Viam's `Board`
-	/// documentation for more details.
+    /// @brief Represents the response received when reading the registered analog to digital
+    /// converter (ADC). The range and conversion mechanism to voltage will vary depending on the
+    /// specific ADC registered to the pin, though the min and max voltages and step_size can often
+    /// help with this conversion. Consult your ADC's documentation and Viam's `Board`
+    /// documentation for more details.
     struct analog_response {
         analog_value value;
         float min_range;  // Minimum possible voltage read by the analog reader

--- a/src/viam/sdk/components/board.hpp
+++ b/src/viam/sdk/components/board.hpp
@@ -27,9 +27,15 @@ class Board : public Component {
    public:
     /// @brief Represents the value received by the registered analog to digital converter (ADC).
     /// The range and conversion mechanism to voltage will vary depending on the specific ADC
-    /// registered to the pin. Consult your ADC's documentation and Viam's `Board` documentation for
+	/// registered to the pin, though the min and max voltages and step_size can often help with
+	/// this conversion. Consult your ADC's documentation and Viam's `Board` documentation for
     /// more details.
-    using analog_value = int32_t;
+    struct analog_value {
+		int32_t value;
+		float min; // Minimum possible voltage read by the analog reader
+		float max; // Maximum possible voltage read by the analog reader
+		float step_size; // Volts represented in each step in the value
+	};
 
     /// @brief Depending on the type of digital interrupt, this can have different meanings. If a
     /// `basic` (default) interrupt is configured, then this is the total interrupt count. If a

--- a/src/viam/sdk/components/board.hpp
+++ b/src/viam/sdk/components/board.hpp
@@ -25,13 +25,18 @@ namespace sdk {
 /// specific board implementations. This class cannot be used on its own.
 class Board : public Component {
    public:
-    /// @brief Represents the value received by the registered analog to digital converter (ADC).
-    /// The range and conversion mechanism to voltage will vary depending on the specific ADC
-    /// registered to the pin, though the min and max voltages and step_size can often help with
-    /// this conversion. Consult your ADC's documentation and Viam's `Board` documentation for
-    /// more details.
-    struct analog_value {
-        int32_t value;
+    /// @brief Represents the raw value received by the registered analog to digital converter
+	/// (ADC). The range and conversion mechanism to voltage will vary depending on the specific
+	/// ADC registered to the pin.
+	using analog_value = int32_t;
+
+	/// @brief Represents the response received when reading the registered analog to digital
+	/// converter (ADC). The range and conversion mechanism to voltage will vary depending on the
+	/// specific ADC registered to the pin, though the min and max voltages and step_size can often
+	/// help with this conversion. Consult your ADC's documentation and Viam's `Board`
+	/// documentation for more details.
+    struct analog_response {
+        analog_value value;
         float min_range;  // Minimum possible voltage read by the analog reader
         float max_range;  // Maximum possible voltage read by the analog reader
         float step_size;  // Volts represented in each step in the value
@@ -166,7 +171,7 @@ class Board : public Component {
     /// @brief Reads off the current value of an analog reader on a board. Consult your ADC's docs
     /// or Viam's `Board` docs for more information.
     /// @param analog_reader_name analog reader to read from
-    inline analog_value read_analog(const std::string& analog_reader_name) {
+    inline analog_response read_analog(const std::string& analog_reader_name) {
         return read_analog(analog_reader_name, {});
     }
 
@@ -174,8 +179,8 @@ class Board : public Component {
     /// or Viam's `Board` docs for more information.
     /// @param analog_reader_name analog reader to read from
     /// @param extra Any additional arguments to the method
-    virtual analog_value read_analog(const std::string& analog_reader_name,
-                                     const AttributeMap& extra) = 0;
+    virtual analog_response read_analog(const std::string& analog_reader_name,
+                                        const AttributeMap& extra) = 0;
 
     /// @brief Writes the value to the analog writer of the board.
     /// @param pin the pin to write to
@@ -267,7 +272,6 @@ struct API::traits<Board> {
 };
 
 bool operator==(const Board::status& lhs, const Board::status& rhs);
-bool operator==(const Board::analog_value& lhs, const Board::analog_value& rhs);
 
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/board.hpp
+++ b/src/viam/sdk/components/board.hpp
@@ -27,15 +27,15 @@ class Board : public Component {
    public:
     /// @brief Represents the value received by the registered analog to digital converter (ADC).
     /// The range and conversion mechanism to voltage will vary depending on the specific ADC
-	/// registered to the pin, though the min and max voltages and step_size can often help with
-	/// this conversion. Consult your ADC's documentation and Viam's `Board` documentation for
+    /// registered to the pin, though the min and max voltages and step_size can often help with
+    /// this conversion. Consult your ADC's documentation and Viam's `Board` documentation for
     /// more details.
     struct analog_value {
-		int32_t value;
-		float min_range; // Minimum possible voltage read by the analog reader
-		float max_range; // Maximum possible voltage read by the analog reader
-		float step_size; // Volts represented in each step in the value
-	};
+        int32_t value;
+        float min_range; // Minimum possible voltage read by the analog reader
+        float max_range; // Maximum possible voltage read by the analog reader
+        float step_size; // Volts represented in each step in the value
+    };
 
     /// @brief Depending on the type of digital interrupt, this can have different meanings. If a
     /// `basic` (default) interrupt is configured, then this is the total interrupt count. If a

--- a/src/viam/sdk/components/board.hpp
+++ b/src/viam/sdk/components/board.hpp
@@ -32,9 +32,9 @@ class Board : public Component {
     /// more details.
     struct analog_value {
         int32_t value;
-        float min_range; // Minimum possible voltage read by the analog reader
-        float max_range; // Maximum possible voltage read by the analog reader
-        float step_size; // Volts represented in each step in the value
+        float min_range;  // Minimum possible voltage read by the analog reader
+        float max_range;  // Maximum possible voltage read by the analog reader
+        float step_size;  // Volts represented in each step in the value
     };
 
     /// @brief Depending on the type of digital interrupt, this can have different meanings. If a

--- a/src/viam/sdk/components/board.hpp
+++ b/src/viam/sdk/components/board.hpp
@@ -267,6 +267,7 @@ struct API::traits<Board> {
 };
 
 bool operator==(const Board::status& lhs, const Board::status& rhs);
+bool operator==(const Board::analog_value& lhs, const Board::analog_value& rhs);
 
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/private/board_client.cpp
+++ b/src/viam/sdk/components/private/board_client.cpp
@@ -100,7 +100,7 @@ Board::analog_response BoardClient::read_analog(const std::string& analog_reader
         throw GRPCException(status);
     }
     return Board::analog_response{
-		response.value(), response.min_range(), response.max_range(), response.step_size()};
+        response.value(), response.min_range(), response.max_range(), response.step_size()};
 }
 
 void BoardClient::write_analog(const std::string& pin, int value, const AttributeMap& extra) {

--- a/src/viam/sdk/components/private/board_client.cpp
+++ b/src/viam/sdk/components/private/board_client.cpp
@@ -85,7 +85,7 @@ AttributeMap BoardClient::do_command(const AttributeMap& command) {
 
 // TODO(RSDK-6048) update `client_wrapper` to allow for requests without a `mutable_name()` method,
 // then wrap here.
-Board::analog_value BoardClient::read_analog(const std::string& analog_reader_name,
+Board::analog_result BoardClient::read_analog(const std::string& analog_reader_name,
                                              const AttributeMap& extra) {
     viam::component::board::v1::ReadAnalogReaderRequest request;
     viam::component::board::v1::ReadAnalogReaderResponse response;
@@ -99,12 +99,7 @@ Board::analog_value BoardClient::read_analog(const std::string& analog_reader_na
     if (!status.ok()) {
         throw GRPCException(status);
     }
-    Board::analog_value result = {};
-    result.value = response.value();
-    result.min_range = response.min_range();
-    result.max_range = response.max_range();
-    result.step_size = response.step_size();
-    return result;
+    return {response.value(), response.min_range(), response.max_range, response.step_size()};
 }
 
 void BoardClient::write_analog(const std::string& pin, int value, const AttributeMap& extra) {

--- a/src/viam/sdk/components/private/board_client.cpp
+++ b/src/viam/sdk/components/private/board_client.cpp
@@ -99,7 +99,12 @@ Board::analog_value BoardClient::read_analog(const std::string& analog_reader_na
     if (!status.ok()) {
         throw GRPCException(status);
     }
-    return response.value();
+	Board::analog_value result = {};
+	result.value = response.value();
+	result.min = response.min();
+	result.max = response.max();
+	result.step_size = response.step_size();
+    return result;
 }
 
 void BoardClient::write_analog(const std::string& pin, int value, const AttributeMap& extra) {

--- a/src/viam/sdk/components/private/board_client.cpp
+++ b/src/viam/sdk/components/private/board_client.cpp
@@ -99,11 +99,11 @@ Board::analog_value BoardClient::read_analog(const std::string& analog_reader_na
     if (!status.ok()) {
         throw GRPCException(status);
     }
-	Board::analog_value result = {};
-	result.value = response.value();
-	result.min_range = response.min_range();
-	result.max_range = response.max_range();
-	result.step_size = response.step_size();
+    Board::analog_value result = {};
+    result.value = response.value();
+    result.min_range = response.min_range();
+    result.max_range = response.max_range();
+    result.step_size = response.step_size();
     return result;
 }
 

--- a/src/viam/sdk/components/private/board_client.cpp
+++ b/src/viam/sdk/components/private/board_client.cpp
@@ -101,8 +101,8 @@ Board::analog_value BoardClient::read_analog(const std::string& analog_reader_na
     }
 	Board::analog_value result = {};
 	result.value = response.value();
-	result.min = response.min();
-	result.max = response.max();
+	result.min_range = response.min_range();
+	result.max_range = response.max_range();
 	result.step_size = response.step_size();
     return result;
 }

--- a/src/viam/sdk/components/private/board_client.cpp
+++ b/src/viam/sdk/components/private/board_client.cpp
@@ -85,8 +85,8 @@ AttributeMap BoardClient::do_command(const AttributeMap& command) {
 
 // TODO(RSDK-6048) update `client_wrapper` to allow for requests without a `mutable_name()` method,
 // then wrap here.
-Board::analog_result BoardClient::read_analog(const std::string& analog_reader_name,
-                                             const AttributeMap& extra) {
+Board::analog_response BoardClient::read_analog(const std::string& analog_reader_name,
+                                                const AttributeMap& extra) {
     viam::component::board::v1::ReadAnalogReaderRequest request;
     viam::component::board::v1::ReadAnalogReaderResponse response;
     ClientContext ctx;
@@ -99,7 +99,8 @@ Board::analog_result BoardClient::read_analog(const std::string& analog_reader_n
     if (!status.ok()) {
         throw GRPCException(status);
     }
-    return {response.value(), response.min_range(), response.max_range, response.step_size()};
+    return Board::analog_response{
+		response.value(), response.min_range(), response.max_range(), response.step_size()};
 }
 
 void BoardClient::write_analog(const std::string& pin, int value, const AttributeMap& extra) {

--- a/src/viam/sdk/components/private/board_client.hpp
+++ b/src/viam/sdk/components/private/board_client.hpp
@@ -34,8 +34,8 @@ class BoardClient : public Board {
     void set_pwm_frequency(const std::string& pin,
                            uint64_t frequency_hz,
                            const AttributeMap& extra) override;
-    analog_result read_analog(const std::string& analog_reader_name,
-                              const AttributeMap& extra) override;
+    analog_response read_analog(const std::string& analog_reader_name,
+                                const AttributeMap& extra) override;
     void write_analog(const std::string& pin, int value, const AttributeMap& extra) override;
     digital_value read_digital_interrupt(const std::string& digital_interrupt_name,
                                          const AttributeMap& extra) override;

--- a/src/viam/sdk/components/private/board_client.hpp
+++ b/src/viam/sdk/components/private/board_client.hpp
@@ -34,8 +34,8 @@ class BoardClient : public Board {
     void set_pwm_frequency(const std::string& pin,
                            uint64_t frequency_hz,
                            const AttributeMap& extra) override;
-    analog_value read_analog(const std::string& analog_reader_name,
-                             const AttributeMap& extra) override;
+    analog_result read_analog(const std::string& analog_reader_name,
+                              const AttributeMap& extra) override;
     void write_analog(const std::string& pin, int value, const AttributeMap& extra) override;
     digital_value read_digital_interrupt(const std::string& digital_interrupt_name,
                                          const AttributeMap& extra) override;

--- a/src/viam/sdk/components/private/board_server.cpp
+++ b/src/viam/sdk/components/private/board_server.cpp
@@ -105,8 +105,8 @@ BoardServer::BoardServer(std::shared_ptr<ResourceManager> manager)
 
     const Board::analog_value result = board->read_analog(request->analog_reader_name(), extra);
     response->set_value(result.value);
-    response->set_min(result.min);
-    response->set_max(result.max);
+    response->set_min_range(result.min_range);
+    response->set_max_range(result.max_range);
     response->set_step_size(result.step_size);
 
     return ::grpc::Status();

--- a/src/viam/sdk/components/private/board_server.cpp
+++ b/src/viam/sdk/components/private/board_server.cpp
@@ -103,7 +103,7 @@ BoardServer::BoardServer(std::shared_ptr<ResourceManager> manager)
         extra = struct_to_map(request->extra());
     }
 
-    const Board::analog_value result = board->read_analog(request->analog_reader_name(), extra);
+    const Board::analog_response result = board->read_analog(request->analog_reader_name(), extra);
     response->set_value(result.value);
     response->set_min_range(result.min_range);
     response->set_max_range(result.max_range);

--- a/src/viam/sdk/components/private/board_server.cpp
+++ b/src/viam/sdk/components/private/board_server.cpp
@@ -104,7 +104,10 @@ BoardServer::BoardServer(std::shared_ptr<ResourceManager> manager)
     }
 
     const Board::analog_value result = board->read_analog(request->analog_reader_name(), extra);
-    response->set_value(result);
+    response->set_value(result.value);
+    response->set_min(result.min);
+    response->set_max(result.max);
+    response->set_step_size(result.step_size);
 
     return ::grpc::Status();
 }

--- a/src/viam/sdk/tests/mocks/mock_board.cpp
+++ b/src/viam/sdk/tests/mocks/mock_board.cpp
@@ -50,8 +50,8 @@ AttributeMap MockBoard::do_command(const AttributeMap& command) {
     return command;
 }
 
-Board::analog_value MockBoard::read_analog(const std::string& analog_reader_name,
-                                           const AttributeMap&) {
+Board::analog_response MockBoard::read_analog(const std::string& analog_reader_name,
+                                              const AttributeMap&) {
     this->peek_analog_reader_name = analog_reader_name;
     return this->peek_read_analog_ret;
 }

--- a/src/viam/sdk/tests/mocks/mock_board.hpp
+++ b/src/viam/sdk/tests/mocks/mock_board.hpp
@@ -22,8 +22,8 @@ class MockBoard : public viam::sdk::Board {
                            uint64_t frequency_hz,
                            const sdk::AttributeMap& extra) override;
     viam::sdk::AttributeMap do_command(const viam::sdk::AttributeMap& command) override;
-    Board::analog_value read_analog(const std::string& analog_reader_name,
-                                    const sdk::AttributeMap& extra) override;
+    Board::analog_response read_analog(const std::string& analog_reader_name,
+                                       const sdk::AttributeMap& extra) override;
     void write_analog(const std::string& pin, int value, const sdk::AttributeMap& extra) override;
     Board::digital_value read_digital_interrupt(const std::string& digital_interrupt_name,
                                                 const sdk::AttributeMap& extra) override;
@@ -44,7 +44,7 @@ class MockBoard : public viam::sdk::Board {
     double peek_set_pwm_duty_cycle_pct;
     uint64_t peek_get_pwm_frequency_ret;
     uint64_t peek_set_pwm_frequency_hz;
-    Board::analog_value peek_read_analog_ret;
+    Board::analog_response peek_read_analog_ret;
     Board::digital_value peek_read_digital_interrupt_ret;
     Board::power_mode peek_set_power_mode_power_mode;
     boost::optional<std::chrono::microseconds> peek_set_power_mode_duration;

--- a/src/viam/sdk/tests/test_board.cpp
+++ b/src/viam/sdk/tests/test_board.cpp
@@ -107,11 +107,11 @@ BOOST_AUTO_TEST_CASE(test_do_command) {
 BOOST_AUTO_TEST_CASE(test_read_analog) {
     const auto mock = std::make_shared<MockBoard>("mock_board");
     client_to_mock_pipeline<Board>(mock, [&](Board& client) {
-		sdk::Board::analog_value result = {}
+		sdk::Board::analog_value result;
 		result.value = 5150;
-		result.min = 1.0;
-		result.max = 5.0;
-		result.step_size = 0.01
+		result.min_range = 1.0;
+		result.max_range = 5.0;
+		result.step_size = 0.01;
         mock->peek_read_analog_ret = result;
         BOOST_CHECK_EQUAL(result, client.read_analog("t1"));
         BOOST_CHECK_EQUAL("t1", mock->peek_analog_reader_name);

--- a/src/viam/sdk/tests/test_board.cpp
+++ b/src/viam/sdk/tests/test_board.cpp
@@ -107,13 +107,9 @@ BOOST_AUTO_TEST_CASE(test_do_command) {
 BOOST_AUTO_TEST_CASE(test_read_analog) {
     const auto mock = std::make_shared<MockBoard>("mock_board");
     client_to_mock_pipeline<Board>(mock, [&](Board& client) {
-        sdk::Board::analog_value expected_result;
-        expected_result.value = 5150;
-        expected_result.min_range = 1.0;
-        expected_result.max_range = 5.0;
-        expected_result.step_size = 0.01;
+        sdk::Board::analog_response expected_result = {5150, 1.0, 5.0, 0.01};
         mock->peek_read_analog_ret = expected_result;
-        sdk::Board::analog_value result = client.read_analog("t1");
+        sdk::Board::analog_response result = client.read_analog("t1");
         BOOST_CHECK_EQUAL(expected_result.value, result.value);
         BOOST_CHECK_EQUAL(expected_result.min_range, result.min_range);
         BOOST_CHECK_EQUAL(expected_result.max_range, result.max_range);

--- a/src/viam/sdk/tests/test_board.cpp
+++ b/src/viam/sdk/tests/test_board.cpp
@@ -107,13 +107,13 @@ BOOST_AUTO_TEST_CASE(test_do_command) {
 BOOST_AUTO_TEST_CASE(test_read_analog) {
     const auto mock = std::make_shared<MockBoard>("mock_board");
     client_to_mock_pipeline<Board>(mock, [&](Board& client) {
-		sdk::Board::analog_value expected_result;
-		expected_result.value = 5150;
-		expected_result.min_range = 1.0;
-		expected_result.max_range = 5.0;
-		expected_result.step_size = 0.01;
+        sdk::Board::analog_value expected_result;
+        expected_result.value = 5150;
+        expected_result.min_range = 1.0;
+        expected_result.max_range = 5.0;
+        expected_result.step_size = 0.01;
         mock->peek_read_analog_ret = expected_result;
-		sdk::Board::analog_value result = client.read_analog("t1");
+        sdk::Board::analog_value result = client.read_analog("t1");
         BOOST_CHECK_EQUAL(expected_result.value, result.value);
         BOOST_CHECK_EQUAL(expected_result.min_range, result.min_range);
         BOOST_CHECK_EQUAL(expected_result.max_range, result.max_range);

--- a/src/viam/sdk/tests/test_board.cpp
+++ b/src/viam/sdk/tests/test_board.cpp
@@ -107,13 +107,17 @@ BOOST_AUTO_TEST_CASE(test_do_command) {
 BOOST_AUTO_TEST_CASE(test_read_analog) {
     const auto mock = std::make_shared<MockBoard>("mock_board");
     client_to_mock_pipeline<Board>(mock, [&](Board& client) {
-		sdk::Board::analog_value result;
-		result.value = 5150;
-		result.min_range = 1.0;
-		result.max_range = 5.0;
-		result.step_size = 0.01;
-        mock->peek_read_analog_ret = result;
-        BOOST_CHECK_EQUAL(result, client.read_analog("t1"));
+		sdk::Board::analog_value expected_result;
+		expected_result.value = 5150;
+		expected_result.min_range = 1.0;
+		expected_result.max_range = 5.0;
+		expected_result.step_size = 0.01;
+        mock->peek_read_analog_ret = expected_result;
+		sdk::Board::analog_value result = client.read_analog("t1");
+        BOOST_CHECK_EQUAL(expected_result.value, result.value);
+        BOOST_CHECK_EQUAL(expected_result.min_range, result.min_range);
+        BOOST_CHECK_EQUAL(expected_result.max_range, result.max_range);
+        BOOST_CHECK_EQUAL(expected_result.step_size, result.step_size);
         BOOST_CHECK_EQUAL("t1", mock->peek_analog_reader_name);
     });
 }

--- a/src/viam/sdk/tests/test_board.cpp
+++ b/src/viam/sdk/tests/test_board.cpp
@@ -107,8 +107,13 @@ BOOST_AUTO_TEST_CASE(test_do_command) {
 BOOST_AUTO_TEST_CASE(test_read_analog) {
     const auto mock = std::make_shared<MockBoard>("mock_board");
     client_to_mock_pipeline<Board>(mock, [&](Board& client) {
-        mock->peek_read_analog_ret = 5150;
-        BOOST_CHECK_EQUAL(5150, client.read_analog("t1"));
+		sdk::Board::analog_value result = {}
+		result.value = 5150;
+		result.min = 1.0;
+		result.max = 5.0;
+		result.step_size = 0.01
+        mock->peek_read_analog_ret = result;
+        BOOST_CHECK_EQUAL(result, client.read_analog("t1"));
         BOOST_CHECK_EQUAL("t1", mock->peek_analog_reader_name);
     });
 }


### PR DESCRIPTION
Surprisingly, we don't need a protobuf update (from https://github.com/viamrobotics/api/pull/492) because we're already using the new protobufs and have just been ignoring the extra data they hold!

Everything compiles and the tests all pass, though I haven't tried it out more than that.