### PR TITLE
RSDK-7463 - Update Motion service in C++ SDK

### DIFF
--- a/src/viam/api/buf.lock
+++ b/src/viam/api/buf.lock
@@ -4,7 +4,8 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 9475e2896f8a46d09806149f9382e538
+    commit: b70d5bc6e99147928d9d4455fd60fc7a
+    digest: shake256:de26a277fc28b8b411ecf58729d78d32fcf15090ffd998a4469225b17889bfb51442eaab04bb7a8d88d203ecdf0a9febd4ffd52c18ed1c2229160c7bd353ca95
   - remote: buf.build
     owner: viamrobotics
     repository: api

--- a/src/viam/api/buf.lock
+++ b/src/viam/api/buf.lock
@@ -4,8 +4,7 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: b70d5bc6e99147928d9d4455fd60fc7a
-    digest: shake256:de26a277fc28b8b411ecf58729d78d32fcf15090ffd998a4469225b17889bfb51442eaab04bb7a8d88d203ecdf0a9febd4ffd52c18ed1c2229160c7bd353ca95
+    commit: 9475e2896f8a46d09806149f9382e538
   - remote: buf.build
     owner: viamrobotics
     repository: api

--- a/src/viam/examples/modules/complex/proto/buf.lock
+++ b/src/viam/examples/modules/complex/proto/buf.lock
@@ -4,4 +4,5 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 74015a8aeb8445aa9e3e1454cb54bc35
+    commit: b70d5bc6e99147928d9d4455fd60fc7a
+    digest: shake256:de26a277fc28b8b411ecf58729d78d32fcf15090ffd998a4469225b17889bfb51442eaab04bb7a8d88d203ecdf0a9febd4ffd52c18ed1c2229160c7bd353ca95

--- a/src/viam/sdk/services/motion.hpp
+++ b/src/viam/sdk/services/motion.hpp
@@ -293,7 +293,8 @@ class Motion : public Service {
     /// @param movement_sensor_name The name of the movement sensor used to check robot location.
     /// @param obstacles Obstacles to be considered for motion planning.
     /// @param motion_configuration Optional set of motion configuration options.
-    /// @param bounding_regions Set of obstacles which the robot must remain within while navigating.
+    /// @param bounding_regions Set of obstacles which the robot must remain within while
+    /// navigating.
     /// @return The execution ID of the move_on_globe request.
     inline std::string move_on_globe(
         const geo_point& destination,
@@ -320,7 +321,8 @@ class Motion : public Service {
     /// @param movement_sensor_name The name of the movement sensor used to check robot location.
     /// @param obstacles Obstacles to be considered for motion planning.
     /// @param motion_configuration Optional set of motion configuration options.
-    /// @param bounding_regions Set of obstacles which the robot must remain within while navigating.
+    /// @param bounding_regions Set of obstacles which the robot must remain within while
+    /// navigating.
     /// @param extra Any additional arguments to the method.
     /// @return The execution_id of the move_on_globe request.
     virtual std::string move_on_globe(

--- a/src/viam/sdk/services/motion.hpp
+++ b/src/viam/sdk/services/motion.hpp
@@ -293,14 +293,16 @@ class Motion : public Service {
     /// @param movement_sensor_name The name of the movement sensor used to check robot location.
     /// @param obstacles Obstacles to be considered for motion planning.
     /// @param motion_configuration Optional set of motion configuration options.
+    /// @param bounding_regions Set of obstacles which the robot must remain within while navigating.
     /// @return The execution ID of the move_on_globe request.
     inline std::string move_on_globe(
         const geo_point& destination,
         const boost::optional<double>& heading,
         const Name& component_name,
         const Name& movement_sensor_name,
-        const std::vector<geo_obstacle>& obstacles,
-        const std::shared_ptr<motion_configuration>& motion_configuration) {
+        const std::vector<geo_geometry>& obstacles,
+        const std::shared_ptr<motion_configuration>& motion_configuration,
+        const std::vector<geo_geometry>& bounding_regions) {
         return move_on_globe(destination,
                              heading,
                              component_name,
@@ -317,6 +319,7 @@ class Motion : public Service {
     /// @param movement_sensor_name The name of the movement sensor used to check robot location.
     /// @param obstacles Obstacles to be considered for motion planning.
     /// @param motion_configuration Optional set of motion configuration options.
+    /// @param bounding_regions Set of obstacles which the robot must remain within while navigating.
     /// @param extra Any additional arguments to the method.
     /// @return The execution_id of the move_on_globe request.
     virtual std::string move_on_globe(
@@ -324,8 +327,9 @@ class Motion : public Service {
         const boost::optional<double>& heading,
         const Name& component_name,
         const Name& movement_sensor_name,
-        const std::vector<geo_obstacle>& obstacles,
+        const std::vector<geo_geometry>& obstacles,
         const std::shared_ptr<motion_configuration>& motion_configuration,
+        const std::vector<geo_geometry>& bounding_regions,
         const AttributeMap& extra) = 0;
 
     /// @brief Get the pose of any component on the robot.

--- a/src/viam/sdk/services/motion.hpp
+++ b/src/viam/sdk/services/motion.hpp
@@ -309,6 +309,7 @@ class Motion : public Service {
                              movement_sensor_name,
                              obstacles,
                              motion_configuration,
+                             bounding_regions,
                              {});
     }
 

--- a/src/viam/sdk/services/private/motion_client.cpp
+++ b/src/viam/sdk/services/private/motion_client.cpp
@@ -71,8 +71,9 @@ std::string MotionClient::move_on_globe(
     const boost::optional<double>& heading,
     const Name& component_name,
     const Name& movement_sensor_name,
-    const std::vector<geo_obstacle>& obstacles,
+    const std::vector<geo_geometry>& obstacles,
     const std::shared_ptr<motion_configuration>& motion_configuration,
+    const std::vector<geo_geometry>& bounding_regions,
     const AttributeMap& extra) {
     return make_client_helper(this, *stub_, &StubType::MoveOnGlobe)
         .with(extra,
@@ -91,6 +92,10 @@ std::string MotionClient::move_on_globe(
 
                   if (motion_configuration) {
                       *request.mutable_motion_configuration() = motion_configuration->to_proto();
+                  }
+
+                  for (const auto& bounding_region : bounding_regions) {
+                      *request.mutable_bounding_regions()->Add() = bounding_region.to_proto();
                   }
               })
         .invoke([](auto& response) { return response.execution_id(); });

--- a/src/viam/sdk/services/private/motion_client.hpp
+++ b/src/viam/sdk/services/private/motion_client.hpp
@@ -37,8 +37,9 @@ class MotionClient : public Motion {
                               const boost::optional<double>& heading,
                               const Name& component_name,
                               const Name& movement_sensor_name,
-                              const std::vector<geo_obstacle>& obstacles,
+                              const std::vector<geo_geometry>& obstacles,
                               const std::shared_ptr<motion_configuration>& motion_configuration,
+                              const std::vector<geo_geometry>& bounding_regions,
                               const AttributeMap& extra) override;
 
     pose_in_frame get_pose(const Name& component_name,

--- a/src/viam/sdk/services/private/motion_server.cpp
+++ b/src/viam/sdk/services/private/motion_server.cpp
@@ -79,10 +79,11 @@ MotionServer::MotionServer(std::shared_ptr<ResourceManager> manager)
         const auto destination = geo_point::from_proto(request->destination());
         const auto component_name = Name::from_proto(request->component_name());
         const auto movement_sensor_name = Name::from_proto(request->movement_sensor_name());
-        std::vector<geo_obstacle> obstacles;
+        std::vector<geo_geometry> obstacles;
+        std::vector<geo_geometry> bounding_regions;
 
         for (const auto& obstacle : request->obstacles()) {
-            obstacles.push_back(geo_obstacle::from_proto(obstacle));
+            obstacles.push_back(geo_geometry::from_proto(obstacle));
         }
 
         boost::optional<double> heading;
@@ -96,12 +97,17 @@ MotionServer::MotionServer(std::shared_ptr<ResourceManager> manager)
                 motion_configuration::from_proto(request->motion_configuration()));
         }
 
+        for (const auto& bounding_region : request->bounding_regions()) {
+            bounding_regions.push_back(geo_geometry::from_proto(bounding_region));
+        }
+
         const std::string execution_id = motion->move_on_globe(destination,
                                                                heading,
                                                                component_name,
                                                                movement_sensor_name,
                                                                obstacles,
                                                                mc,
+                                                               bounding_regions,
                                                                helper.getExtra());
 
         *response->mutable_execution_id() = execution_id;

--- a/src/viam/sdk/spatialmath/geometry.cpp
+++ b/src/viam/sdk/spatialmath/geometry.cpp
@@ -292,8 +292,8 @@ geo_point geo_point::from_proto(const common::v1::GeoPoint& proto) {
     return geo_point;
 }
 
-common::v1::GeoObstacle geo_geometry::to_proto() const {
-    common::v1::GeoObstacle proto;
+common::v1::GeoGeometry geo_geometry::to_proto() const {
+    common::v1::GeoGeometry proto;
     *proto.mutable_location() = location.to_proto();
 
     for (const auto& geometry : geometries) {
@@ -303,7 +303,7 @@ common::v1::GeoObstacle geo_geometry::to_proto() const {
     return proto;
 }
 
-geo_geometry geo_geometry::from_proto(const common::v1::GeoObstacle& proto) {
+geo_geometry geo_geometry::from_proto(const common::v1::GeoGeometry& proto) {
     struct geo_geometry geo_geometry;
 
     geo_geometry.location = geo_point::from_proto(proto.location());

--- a/src/viam/sdk/spatialmath/geometry.cpp
+++ b/src/viam/sdk/spatialmath/geometry.cpp
@@ -272,7 +272,7 @@ bool operator==(const geo_point& lhs, const geo_point& rhs) {
     return lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude;
 }
 
-bool operator==(const geo_obstacle& lhs, const geo_obstacle& rhs) {
+bool operator==(const geo_geometry& lhs, const geo_geometry& rhs) {
     return lhs.location == rhs.location && lhs.geometries == rhs.geometries;
 }
 
@@ -292,7 +292,7 @@ geo_point geo_point::from_proto(const common::v1::GeoPoint& proto) {
     return geo_point;
 }
 
-common::v1::GeoObstacle geo_obstacle::to_proto() const {
+common::v1::GeoObstacle geo_geometry::to_proto() const {
     common::v1::GeoObstacle proto;
     *proto.mutable_location() = location.to_proto();
 
@@ -303,16 +303,16 @@ common::v1::GeoObstacle geo_obstacle::to_proto() const {
     return proto;
 }
 
-geo_obstacle geo_obstacle::from_proto(const common::v1::GeoObstacle& proto) {
-    struct geo_obstacle geo_obstacle;
+geo_geometry geo_geometry::from_proto(const common::v1::GeoObstacle& proto) {
+    struct geo_geometry geo_geometry;
 
-    geo_obstacle.location = geo_point::from_proto(proto.location());
+    geo_geometry.location = geo_point::from_proto(proto.location());
     for (const auto& proto_geometry : proto.geometries()) {
         auto geometry = GeometryConfig::from_proto(proto_geometry);
-        geo_obstacle.geometries.push_back(std::move(geometry));
+        geo_geometry.geometries.push_back(std::move(geometry));
     }
 
-    return geo_obstacle;
+    return geo_geometry;
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/spatialmath/geometry.hpp
+++ b/src/viam/sdk/spatialmath/geometry.hpp
@@ -86,13 +86,13 @@ struct geo_point {
     friend std::ostream& operator<<(std::ostream& os, const geo_point& v);
 };
 
-struct geo_obstacle {
+struct geo_geometry {
     geo_point location;
     std::vector<GeometryConfig> geometries;
 
-    common::v1::GeoObstacle to_proto() const;
-    static geo_obstacle from_proto(const common::v1::GeoObstacle& proto);
-    friend bool operator==(const geo_obstacle& lhs, const geo_obstacle& rhs);
+    common::v1::GeoGeometry to_proto() const;
+    static geo_geometry from_proto(const common::v1::GeoGeometry& proto);
+    friend bool operator==(const geo_geometry& lhs, const geo_geometry& rhs);
 };
 
 }  // namespace sdk

--- a/src/viam/sdk/tests/mocks/mock_motion.cpp
+++ b/src/viam/sdk/tests/mocks/mock_motion.cpp
@@ -58,7 +58,7 @@ std::string MockMotion::move_on_globe(
     this->peek_destination = destination;
     this->peek_obstacles = obstacles;
     this->peek_motion_configuration = motion_configuration;
-
+    this->peek_bounding_regions= bounding_regions;
     return "execution-id";
 }
 

--- a/src/viam/sdk/tests/mocks/mock_motion.cpp
+++ b/src/viam/sdk/tests/mocks/mock_motion.cpp
@@ -48,8 +48,9 @@ std::string MockMotion::move_on_globe(
     const boost::optional<double>& heading,
     const Name& component_name,
     const Name& movement_sensor_name,
-    const std::vector<geo_obstacle>& obstacles,
+    const std::vector<geo_geometry>& obstacles,
     const std::shared_ptr<motion_configuration>& motion_configuration,
+    const std::vector<geo_geometry>& bounding_regions,
     const AttributeMap&) {
     this->peek_heading = *heading;
     this->peek_component_name = component_name;
@@ -163,11 +164,22 @@ std::shared_ptr<motion_configuration> fake_motion_configuration() {
     return mc;
 }
 
-std::vector<geo_obstacle> fake_obstacles() {
+std::vector<geo_geometry> fake_obstacles() {
     GeometryConfig gc;
     gc.set_pose({{20, 25, 30}, {35, 40, 45}, 50});
     gc.set_geometry_type(sdk::sphere);
     struct sphere sphere({1});
+    gc.set_geometry_specifics(sphere);
+    gc.set_label("label");
+    gc.set_orientation_config({AxisAngles, {}, axis_angles{1, 2, 3, 4}});
+    return {{fake_geo_point(), {std::move(gc)}}};
+}
+
+std::vector<geo_geometry> fake_bounding_regions() {
+    GeometryConfig gc;
+    gc.set_pose({{1, 2, 3}, {0, 0, 0}, 90});
+    gc.set_geometry_type(sdk::sphere);
+    struct sphere sphere({2});
     gc.set_geometry_specifics(sphere);
     gc.set_label("label");
     gc.set_orientation_config({AxisAngles, {}, axis_angles{1, 2, 3, 4}});

--- a/src/viam/sdk/tests/mocks/mock_motion.cpp
+++ b/src/viam/sdk/tests/mocks/mock_motion.cpp
@@ -58,7 +58,7 @@ std::string MockMotion::move_on_globe(
     this->peek_destination = destination;
     this->peek_obstacles = obstacles;
     this->peek_motion_configuration = motion_configuration;
-    this->peek_bounding_regions= bounding_regions;
+    this->peek_bounding_regions = bounding_regions;
     return "execution-id";
 }
 

--- a/src/viam/sdk/tests/mocks/mock_motion.hpp
+++ b/src/viam/sdk/tests/mocks/mock_motion.hpp
@@ -17,8 +17,9 @@ sdk::Name fake_component_name();
 sdk::Name fake_slam_name();
 sdk::Name fake_movement_sensor_name();
 sdk::geo_point fake_geo_point();
-std::vector<sdk::geo_obstacle> fake_obstacles();
+std::vector<sdk::geo_geometry> fake_obstacles();
 std::shared_ptr<sdk::motion_configuration> fake_motion_configuration();
+std::vector<sdk::geo_geometry> fake_bounding_regions();
 
 class MockMotion : public sdk::Motion {
    public:
@@ -40,8 +41,9 @@ class MockMotion : public sdk::Motion {
         const boost::optional<double>& heading,
         const sdk::Name& component_name,
         const sdk::Name& movement_sensor_name,
-        const std::vector<sdk::geo_obstacle>& obstacles,
+        const std::vector<sdk::geo_geometry>& obstacles,
         const std::shared_ptr<sdk::motion_configuration>& motion_configuration,
+        const std::vector<sdk::geo_geometry>& bounding_regions,
         const sdk::AttributeMap& extra) override;
 
     sdk::pose_in_frame get_pose(
@@ -89,10 +91,11 @@ class MockMotion : public sdk::Motion {
     std::string peek_destination_frame;
     double peek_heading;
     bool peek_stop_plan_called = false;
-    std::vector<sdk::geo_obstacle> peek_obstacles;
+    std::vector<sdk::geo_geometry> peek_obstacles;
     std::vector<sdk::GeometryConfig> peek_map_obstacles;
     std::shared_ptr<constraints> peek_constraints;
     std::shared_ptr<sdk::motion_configuration> peek_motion_configuration;
+    std::vector<sdk::geo_geometry> peek_bounding_regions;
     std::shared_ptr<sdk::WorldState> peek_world_state;
 
     MockMotion(std::string name)

--- a/src/viam/sdk/tests/test_motion.cpp
+++ b/src/viam/sdk/tests/test_motion.cpp
@@ -10,7 +10,7 @@
 #include <viam/sdk/tests/test_utils.hpp>
 
 BOOST_TEST_DONT_PRINT_LOG_VALUE(viam::sdk::WorldState)
-BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<viam::sdk::geo_obstacle>)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<viam::sdk::geo_geometry>)
 BOOST_TEST_DONT_PRINT_LOG_VALUE(viam::sdk::Motion::plan_status_with_id)
 BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<viam::sdk::Motion::plan_status_with_id>)
 BOOST_TEST_DONT_PRINT_LOG_VALUE(viam::sdk::Motion::plan_with_status)
@@ -91,6 +91,7 @@ BOOST_AUTO_TEST_CASE(mock_move_on_globe) {
                                                      fake_movement_sensor_name(),
                                                      fake_obstacles(),
                                                      fake_motion_configuration(),
+                                                     fake_bounding_regions(),
                                                      fake_map());
 
     BOOST_CHECK_EQUAL(execution_id, "execution-id");
@@ -208,6 +209,7 @@ BOOST_AUTO_TEST_CASE(test_move_on_globe) {
                                                         fake_movement_sensor_name(),
                                                         fake_obstacles(),
                                                         fake_motion_configuration(),
+                                                        fake_bounding_regions(),
                                                         fake_map());
 
         BOOST_CHECK_EQUAL(execution_id, "execution-id");

--- a/src/viam/sdk/tests/test_motion.cpp
+++ b/src/viam/sdk/tests/test_motion.cpp
@@ -101,6 +101,7 @@ BOOST_AUTO_TEST_CASE(mock_move_on_globe) {
     BOOST_CHECK_EQUAL(motion->peek_movement_sensor_name, fake_movement_sensor_name());
     BOOST_CHECK_EQUAL(motion->peek_obstacles, fake_obstacles());
     BOOST_CHECK_EQUAL(*(motion->peek_motion_configuration), *(fake_motion_configuration()));
+    BOOST_CHECK_EQUAL(motion->peek_bounding_regions, fake_bounding_regions());
 }
 
 BOOST_AUTO_TEST_CASE(mock_get_plan) {


### PR DESCRIPTION
We are updating the python SDK to match the following changes made in API (https://github.com/viamrobotics/api/commit/503a9a41e4ef9c8e5c8399a8890c6b2ae923d96b)

We would like to also explicitly call out the changes reviewers should be aware of:

1. GeoObstacle has been renamed into GeoGeometry - we note that they store the same information and this is just a re-name.
This means that the return type of GetObstacles in the navigation service has changes from GeoObstacle into GeoGeometry, but the navigation service is not yet a thing in this SDK so nothing to worry about here :)
2. We have added an argument to the motion service method MoveOnGlobe. The argument is called bounding_regions and is a list of GeoGeometrys
3. The motion service method MoveOnGlobe also takes in a list of obstacles of type GeoObstacle. This has been updated to GeoGeometry