### PR TITLE
[RSDK-7775]   Update Camera.Properties Response in C++ SDK to match API

### DIFF
--- a/src/viam/sdk/components/camera.cpp
+++ b/src/viam/sdk/components/camera.cpp
@@ -241,7 +241,7 @@ Camera::properties Camera::from_proto(
         proto.intrinsic_parameters();
     intrinsic_parameters = from_proto(intrinsic_parameters_proto);
 
-    mime_types.assign(proto.mime_types().begin(), proto.mime_types().end()); 
+    mime_types.assign(proto.mime_types().begin(), proto.mime_types().end());
 
     properties.distortion_parameters = distortion_parameters;
     properties.intrinsic_parameters = intrinsic_parameters;

--- a/src/viam/sdk/components/camera.cpp
+++ b/src/viam/sdk/components/camera.cpp
@@ -228,27 +228,10 @@ Camera::distortion_parameters Camera::from_proto(
 
 Camera::properties Camera::from_proto(
     const viam::component::camera::v1::GetPropertiesResponse& proto) {
-    Camera::distortion_parameters distortion_parameters;
-    Camera::intrinsic_parameters intrinsic_parameters;
-    Camera::mime_types mime_types;
-    Camera::properties properties;
-
-    const viam::component::camera::v1::DistortionParameters& distortion_parameters_proto =
-        proto.distortion_parameters();
-    distortion_parameters = from_proto(distortion_parameters_proto);
-
-    const viam::component::camera::v1::IntrinsicParameters& intrinsic_parameters_proto =
-        proto.intrinsic_parameters();
-    intrinsic_parameters = from_proto(intrinsic_parameters_proto);
-
-    mime_types.assign(proto.mime_types().begin(), proto.mime_types().end());
-
-    properties.distortion_parameters = distortion_parameters;
-    properties.intrinsic_parameters = intrinsic_parameters;
-    properties.mime_types = mime_types;
-    properties.supports_pcd = proto.supports_pcd();
-
-    return properties;
+    return {proto.supports_pcd(),
+            from_proto(proto.intrinsic_parameters()),
+            from_proto(proto.distortion_parameters()),
+            {proto.mime_types().begin(), proto.mime_types().end()}};
 }
 
 viam::component::camera::v1::IntrinsicParameters Camera::to_proto(

--- a/src/viam/sdk/components/camera.cpp
+++ b/src/viam/sdk/components/camera.cpp
@@ -230,6 +230,7 @@ Camera::properties Camera::from_proto(
     const viam::component::camera::v1::GetPropertiesResponse& proto) {
     Camera::distortion_parameters distortion_parameters;
     Camera::intrinsic_parameters intrinsic_parameters;
+    Camera::mime_types mime_types;
     Camera::properties properties;
 
     const viam::component::camera::v1::DistortionParameters& distortion_parameters_proto =
@@ -240,8 +241,11 @@ Camera::properties Camera::from_proto(
         proto.intrinsic_parameters();
     intrinsic_parameters = from_proto(intrinsic_parameters_proto);
 
+    mime_types.assign(proto.mime_types().begin(), proto.mime_types().end()); 
+
     properties.distortion_parameters = distortion_parameters;
     properties.intrinsic_parameters = intrinsic_parameters;
+    properties.mime_types = mime_types;
     properties.supports_pcd = proto.supports_pcd();
 
     return properties;
@@ -258,6 +262,7 @@ viam::component::camera::v1::IntrinsicParameters Camera::to_proto(
     proto.set_center_y_px(params.center_y_px);
     return proto;
 }
+
 viam::component::camera::v1::DistortionParameters Camera::to_proto(
     const Camera::distortion_parameters& params) {
     viam::component::camera::v1::DistortionParameters proto;

--- a/src/viam/sdk/components/camera.hpp
+++ b/src/viam/sdk/components/camera.hpp
@@ -48,16 +48,22 @@ class Camera : public Component {
         std::vector<double> parameters;
     };
 
+    /// @struct mime_types
+    /// @brief The supported mime types of the camera.
+    using mime_types = std::vector<std::string>
+
     /// @struct properties
     /// @brief The camera's supported features and settings.
     ///
     /// `supports_pcd` indicates whether the camera has a valid implementation of `get_point_cloud`.
     /// `intrinsic_parameters` contains the camera's intrinsic parameters.
     /// `distortion_parameters` contains the camera's distortion parameters.
+    /// `mime_types` contains the mime types the camera supports.
     struct properties {
         bool supports_pcd;
         struct intrinsic_parameters intrinsic_parameters;
         struct distortion_parameters distortion_parameters;
+        mime_types mime_types;
     };
 
     /// @struct point_cloud

--- a/src/viam/sdk/components/camera.hpp
+++ b/src/viam/sdk/components/camera.hpp
@@ -48,14 +48,14 @@ class Camera : public Component {
         std::vector<double> parameters;
     };
 
-    /// @struct mime_types
-    /// @brief The supported mime types of the camera.
-    using mime_types = std::vector<std::string>
+    /// @brief The supported mime types of the camera— a type alias.
+    using mime_types = std::vector<std::string>;
 
     /// @struct properties
     /// @brief The camera's supported features and settings.
     ///
-    /// `supports_pcd` indicates whether the camera has a valid implementation of `get_point_cloud`.
+    /// `supports_pcd` indicates whether the camera has a valid implementation of
+    /// `get_point_cloud`.
     /// `intrinsic_parameters` contains the camera's intrinsic parameters.
     /// `distortion_parameters` contains the camera's distortion parameters.
     /// `mime_types` contains the mime types the camera supports.
@@ -63,7 +63,7 @@ class Camera : public Component {
         bool supports_pcd;
         struct intrinsic_parameters intrinsic_parameters;
         struct distortion_parameters distortion_parameters;
-        mime_types mime_types;
+        Camera::mime_types mime_types;
     };
 
     /// @struct point_cloud

--- a/src/viam/sdk/components/camera.hpp
+++ b/src/viam/sdk/components/camera.hpp
@@ -53,16 +53,17 @@ class Camera : public Component {
 
     /// @struct properties
     /// @brief The camera's supported features and settings.
-    ///
-    /// `supports_pcd` indicates whether the camera has a valid implementation of
-    /// `get_point_cloud`.
-    /// `intrinsic_parameters` contains the camera's intrinsic parameters.
-    /// `distortion_parameters` contains the camera's distortion parameters.
-    /// `mime_types` contains the mime types the camera supports.
     struct properties {
+        /// @brief Indicates whether the camera has a valid implementation of `get_point_cloud`.
         bool supports_pcd;
+
+        /// @brief Contains the camera's intrinsic parameters.
         struct intrinsic_parameters intrinsic_parameters;
+
+        /// @brief Contains the camera's distortion parameters.
         struct distortion_parameters distortion_parameters;
+
+        /// @brief Contains the mime types the camera supports.
         Camera::mime_types mime_types;
     };
 

--- a/src/viam/sdk/tests/mocks/camera_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.cpp
@@ -86,12 +86,6 @@ Camera::distortion_parameters fake_distortion_parameters() {
     return distortion_parameters;
 }
 
-Camera::distortion_parameters fake_distortion_parameters() {
-    Camera::distortion_parameters distortion_parameters;
-    distortion_parameters.model = "no distortion";
-    return distortion_parameters;
-}
-
 Camera::mime_types fake_mime_types() {
     Camera::mime_types mime_types;
     mime_types.push_back("JPEG");

--- a/src/viam/sdk/tests/mocks/camera_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.cpp
@@ -87,9 +87,7 @@ Camera::distortion_parameters fake_distortion_parameters() {
 }
 
 Camera::mime_types fake_mime_types() {
-    Camera::mime_types mime_types;
-    mime_types.push_back("JPEG");
-    return mime_types;
+    return {"JPEG"};
 }
 
 Camera::properties fake_properties() {

--- a/src/viam/sdk/tests/mocks/camera_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.cpp
@@ -86,11 +86,24 @@ Camera::distortion_parameters fake_distortion_parameters() {
     return distortion_parameters;
 }
 
+Camera::distortion_parameters fake_distortion_parameters() {
+    Camera::distortion_parameters distortion_parameters;
+    distortion_parameters.model = "no distortion";
+    return distortion_parameters;
+}
+
+Camera::mime_types fake_mime_types() {
+    Camera::mime_types mime_types;
+    mime_types.push_back("JPEG");
+    return mime_types;
+}
+
 Camera::properties fake_properties() {
     Camera::properties properties;
     properties.supports_pcd = true;
     properties.intrinsic_parameters = fake_intrinsic_parameters();
     properties.distortion_parameters = fake_distortion_parameters();
+    properties.mime_types = fake_mime_types();
     return properties;
 }
 


### PR DESCRIPTION
[RSDK-7775](https://viam.atlassian.net/browse/RSDK-7775)

[RSDK-7775]: https://viam.atlassian.net/browse/RSDK-7775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

From Jira^: Right now, we’re not returning the mime type. Update the C++ SDK wrapper to match the Properties API method

In this PR, I add `mime_types` to the camera component files, extracting the data from the proto when `Camera::properties Camera::from_proto` is called, adding it to the new `mime_types` field in camera properties. I added an appropriate test to make sure this happens correctly.