### PR TITLE
RSDK-7858 - lock in doxygen version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: install Doxygen
         uses: ssciwr/doxygen-install@v1
+        with:
+          version: "1.10.0"
 
       - name: create path
         run: mkdir -p etc/docs/api/current


### PR DESCRIPTION
Locks doxygen version at `1.10.0` to avoid `glibc` version conflicts.