### PR TITLE
RSDK-7939: Add arm component

### DIFF
--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -141,6 +141,10 @@ if (VIAMCPPSDK_USE_DYNAMIC_PROTOS)
     ${PROTO_GEN_DIR}/common/v1/common.grpc.pb.h
     ${PROTO_GEN_DIR}/common/v1/common.pb.cc
     ${PROTO_GEN_DIR}/common/v1/common.pb.h
+    ${PROTO_GEN_DIR}/component/arm/v1/arm.grpc.pb.cc
+    ${PROTO_GEN_DIR}/component/arm/v1/arm.grpc.pb.h
+    ${PROTO_GEN_DIR}/component/arm/v1/arm.pb.cc
+    ${PROTO_GEN_DIR}/component/arm/v1/arm.pb.h
     ${PROTO_GEN_DIR}/component/base/v1/base.grpc.pb.cc
     ${PROTO_GEN_DIR}/component/base/v1/base.grpc.pb.h
     ${PROTO_GEN_DIR}/component/base/v1/base.pb.cc
@@ -270,6 +274,8 @@ target_sources(viamapi
     ${PROTO_GEN_DIR}/app/v1/robot.pb.cc
     ${PROTO_GEN_DIR}/common/v1/common.grpc.pb.cc
     ${PROTO_GEN_DIR}/common/v1/common.pb.cc
+    ${PROTO_GEN_DIR}/component/arm/v1/arm.grpc.pb.cc
+    ${PROTO_GEN_DIR}/component/arm/v1/arm.pb.cc
     ${PROTO_GEN_DIR}/component/base/v1/base.grpc.pb.cc
     ${PROTO_GEN_DIR}/component/base/v1/base.pb.cc
     ${PROTO_GEN_DIR}/component/board/v1/board.grpc.pb.cc
@@ -318,6 +324,8 @@ target_sources(viamapi
       ${PROTO_GEN_DIR}/../../viam/api/app/v1/robot.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/common/v1/common.grpc.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/common/v1/common.pb.h
+      ${PROTO_GEN_DIR}/../../viam/api/component/arm/v1/arm.grpc.pb.h
+      ${PROTO_GEN_DIR}/../../viam/api/component/arm/v1/arm.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/base/v1/base.grpc.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/base/v1/base.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/board/v1/board.grpc.pb.h

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources(viamsdk
     common/service_helper.cpp
     common/utils.cpp
     common/world_state.cpp
+    components/arm.cpp
     components/base.cpp
     components/board.cpp
     components/camera.cpp
@@ -118,6 +119,7 @@ target_sources(viamsdk
       ../../viam/sdk/common/service_helper.hpp
       ../../viam/sdk/common/utils.hpp
       ../../viam/sdk/common/world_state.hpp
+      ../../viam/sdk/components/arm.hpp
       ../../viam/sdk/components/base.hpp
       ../../viam/sdk/components/board.hpp
       ../../viam/sdk/components/camera.hpp

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -55,6 +55,7 @@ target_sources(viamsdk
     components/movement_sensor.cpp
     components/power_sensor.cpp
     components/private/arm_client.cpp
+    components/private/arm_server.cpp
     components/private/base_client.cpp
     components/private/base_server.cpp
     components/private/board_client.cpp

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -54,6 +54,7 @@ target_sources(viamsdk
     components/motor.cpp
     components/movement_sensor.cpp
     components/power_sensor.cpp
+    components/private/arm_client.cpp
     components/private/base_client.cpp
     components/private/base_server.cpp
     components/private/board_client.cpp

--- a/src/viam/sdk/components/arm.cpp
+++ b/src/viam/sdk/components/arm.cpp
@@ -16,9 +16,9 @@ Arm::KinematicsData Arm::from_proto(const viam::common::v1::GetKinematicsRespons
                                      proto.kinematics_data().end());
     switch (proto.format()) {
         case common::v1::KinematicsFileFormat::KINEMATICS_FILE_FORMAT_SVA:
-            return Arm::KinematicsDataSVA{{std::move(bytes)}};
+            return Arm::KinematicsDataSVA(std::move(bytes));
         case common::v1::KinematicsFileFormat::KINEMATICS_FILE_FORMAT_URDF:
-            return Arm::KinematicsDataURDF{{std::move(bytes)}};
+            return Arm::KinematicsDataURDF(std::move(bytes));
         case common::v1::KinematicsFileFormat::KINEMATICS_FILE_FORMAT_UNSPECIFIED:  // fallthrough
         default:
             return Arm::KinematicsDataUnspecified{};

--- a/src/viam/sdk/components/arm.cpp
+++ b/src/viam/sdk/components/arm.cpp
@@ -1,0 +1,31 @@
+#include <viam/sdk/components/arm.hpp>
+
+namespace viam {
+namespace sdk {
+
+API Arm::api() const {
+    return API::get<Arm>();
+}
+
+API API::traits<Arm>::api() {
+    return {kRDK, kComponent, "arm"};
+}
+
+Arm::KinematicsData Arm::from_proto(const viam::common::v1::GetKinematicsResponse& proto) {
+    std::vector<unsigned char> bytes(proto.kinematics_data().begin(),
+                                     proto.kinematics_data().end());
+    switch (proto.format()) {
+        case common::v1::KinematicsFileFormat::KINEMATICS_FILE_FORMAT_SVA:
+            return Arm::KinematicsDataSVA{{std::move(bytes)}};
+        case common::v1::KinematicsFileFormat::KINEMATICS_FILE_FORMAT_URDF:
+            return Arm::KinematicsDataURDF{{std::move(bytes)}};
+        case common::v1::KinematicsFileFormat::KINEMATICS_FILE_FORMAT_UNSPECIFIED:  // fallthrough
+        default:
+            return Arm::KinematicsDataUnspecified{};
+    }
+}
+
+Arm::Arm(std::string name) : Component(std::move(name)) {}
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/arm.hpp
+++ b/src/viam/sdk/components/arm.hpp
@@ -31,7 +31,7 @@ class Arm : public Component, public Stoppable {
     struct RawBytes {
         // Pre c++17 our derived classes aren't aggregate initializable so we need to define
         // and using declare some ctors
-        
+
         RawBytes() = default;
         RawBytes(std::vector<unsigned char> b) : bytes(std::move(b)) {}
 

--- a/src/viam/sdk/components/arm.hpp
+++ b/src/viam/sdk/components/arm.hpp
@@ -64,13 +64,14 @@ class Arm : public Component, public Stoppable {
     static KinematicsData from_proto(const viam::common::v1::GetKinematicsResponse& proto);
 
     /// @brief Get the current position of the end of the arm.
+    /// @return The `pose` representing the end position of the arm.
     inline pose get_end_position() {
         return get_end_position({});
     }
 
     /// @brief Get the current position of the end of the arm.
-    /// @param pose The destination pose for the arm.
     /// @param extra Any additional arguments to the method.
+    /// @return The `pose` representing the end position of the arm.
     virtual pose get_end_position(const AttributeMap& extra) = 0;
 
     /// @brief Move the end of the arm to @param pose.

--- a/src/viam/sdk/components/arm.hpp
+++ b/src/viam/sdk/components/arm.hpp
@@ -29,7 +29,13 @@ class Arm : public Component, public Stoppable {
     // Base class for use below in defining kinematics data strong typedefs
     template <class Tag>
     struct RawBytes {
-        std::vector<unsigned char> bytes;
+        // Pre c++17 our derived classes aren't aggregate initializable so we need to define
+        // and using declare some ctors
+        
+        RawBytes() = default;
+        RawBytes(std::vector<unsigned char> b) : bytes(std::move(b)) {}
+
+        std::vector<unsigned char> bytes{};
     };
 
     // Comparison operator helper for the data types below
@@ -43,8 +49,12 @@ class Arm : public Component, public Stoppable {
    public:
     struct KinematicsDataUnspecified : RawBytes<KinematicsDataUnspecified>,
                                        EqCompare<KinematicsDataUnspecified> {};
-    struct KinematicsDataSVA : RawBytes<KinematicsDataSVA>, EqCompare<KinematicsDataSVA> {};
-    struct KinematicsDataURDF : RawBytes<KinematicsDataURDF>, EqCompare<KinematicsDataURDF> {};
+    struct KinematicsDataSVA : RawBytes<KinematicsDataSVA>, EqCompare<KinematicsDataSVA> {
+        using RawBytes<KinematicsDataSVA>::RawBytes;
+    };
+    struct KinematicsDataURDF : RawBytes<KinematicsDataURDF>, EqCompare<KinematicsDataURDF> {
+        using RawBytes<KinematicsDataURDF>::RawBytes;
+    };
 
     /// @brief The kinematics of the component.
     /// @returns The data in Viam's Spatial Vector Algebra (SVA) format, or URDF.

--- a/src/viam/sdk/components/arm.hpp
+++ b/src/viam/sdk/components/arm.hpp
@@ -1,0 +1,119 @@
+/// @file components/arm.hpp
+///
+/// @brief Defines an `Arm` component
+#pragma once
+
+#include <string>
+
+#include <boost/variant/variant.hpp>
+
+#include <viam/api/common/v1/common.pb.h>
+#include <viam/api/component/arm/v1/arm.pb.h>
+
+#include <viam/sdk/common/pose.hpp>
+#include <viam/sdk/resource/stoppable.hpp>
+#include <viam/sdk/spatialmath/geometry.hpp>
+
+namespace viam {
+namespace sdk {
+
+/// @defgroup Arm Classes related to the Arm component.
+
+/// @class Arm arm.hpp "components/arm.hpp"
+/// @brief An `Arm` represents a physical robot arm that exists in three-dimensional space.
+/// @ingroup Arm
+///
+/// This acts as an abstract parent class to be inherited from by any drivers representing
+/// specific arm implementations. This class cannot be used on its own.
+class Arm : public Component, public Stoppable {
+    // Base class for use below in defining kinematics data strong typedefs
+    template <class Tag>
+    struct RawBytes {
+        std::vector<unsigned char> bytes;
+    };
+
+    // Comparison operator helper for the data types below
+    template <class DataType>
+    struct EqCompare {
+        inline friend bool operator==(const DataType& lhs, const DataType& rhs) {
+            return lhs.bytes == rhs.bytes;
+        }
+    };
+
+   public:
+    struct KinematicsDataUnspecified : RawBytes<KinematicsDataUnspecified>,
+                                       EqCompare<KinematicsDataUnspecified> {};
+    struct KinematicsDataSVA : RawBytes<KinematicsDataSVA>, EqCompare<KinematicsDataSVA> {};
+    struct KinematicsDataURDF : RawBytes<KinematicsDataURDF>, EqCompare<KinematicsDataURDF> {};
+
+    /// @brief The kinematics of the component.
+    /// @returns The data in Viam's Spatial Vector Algebra (SVA) format, or URDF.
+    using KinematicsData =
+        boost::variant<KinematicsDataUnspecified, KinematicsDataSVA, KinematicsDataURDF>;
+
+    static KinematicsData from_proto(const viam::common::v1::GetKinematicsResponse& proto);
+
+    /// @brief Get the current position of the end of the arm.
+    inline pose get_end_position() {
+        return get_end_position({});
+    }
+
+    /// @brief Get the current position of the end of the arm.
+    /// @param pose The destination pose for the arm.
+    /// @param extra Any additional arguments to the method.
+    virtual pose get_end_position(const AttributeMap& extra) = 0;
+
+    /// @brief Move the end of the arm to @param pose.
+    inline void move_to_position(const pose& pose) {
+        move_to_position(pose, {});
+    }
+
+    /// @brief Move the end of the arm to @param pose.
+    /// @param pose The destination pose for the arm.
+    /// @param extra Any additional arguments to the method.
+    virtual void move_to_position(const pose& pose, const AttributeMap& extra) = 0;
+
+    /// @brief Lists the joint positions in degrees of every joint on a robot arm
+    inline std::vector<double> get_joint_positions() {
+        return get_joint_positions({});
+    }
+
+    /// @brief Lists the joint positions in degrees of every joint on a robot arm
+    /// @param extra Any additional arguments to the method.
+    virtual std::vector<double> get_joint_positions(const AttributeMap& extra) = 0;
+
+    /// @brief Move each joint on the arm to the corresponding angle specified in @param positions
+    /// @param extra Any additional arguments to the method.
+    virtual void move_to_joint_positions(const std::vector<double>& positions,
+                                         const AttributeMap& extra) = 0;
+
+    /// @brief Reports if the arm is in motion.
+    virtual bool is_moving() = 0;
+
+    /// @brief Send/receive arbitrary commands to the resource.
+    /// @param Command the command to execute.
+    /// @return The result of the executed command.
+    virtual AttributeMap do_command(const AttributeMap& command) = 0;
+
+    /// @brief Returns `GeometryConfig`s associated with the calling arm
+    inline std::vector<GeometryConfig> get_geometries() {
+        return get_geometries({});
+    }
+
+    /// @brief Returns `GeometryConfig`s associated with the calling arm
+    /// @param extra Any additional arguments to the method
+    virtual std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) = 0;
+
+    API api() const override;
+
+   protected:
+    explicit Arm(std::string name);
+};
+
+template <>
+struct API::traits<Arm> {
+    static API api();
+};
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/arm.hpp
+++ b/src/viam/sdk/components/arm.hpp
@@ -28,12 +28,12 @@ namespace sdk {
 class Arm : public Component, public Stoppable {
     // Base class for use below in defining kinematics data strong typedefs
     template <class Tag>
-    struct RawBytes {
+    struct raw_bytes {
         // Pre c++17 our derived classes aren't aggregate initializable so we need to define
         // and using declare some ctors
 
-        RawBytes() = default;
-        RawBytes(std::vector<unsigned char> b) : bytes(std::move(b)) {}
+        raw_bytes() = default;
+        raw_bytes(std::vector<unsigned char> b) : bytes(std::move(b)) {}
 
         std::vector<unsigned char> bytes{};
     };
@@ -47,13 +47,13 @@ class Arm : public Component, public Stoppable {
     };
 
    public:
-    struct KinematicsDataUnspecified : RawBytes<KinematicsDataUnspecified>,
+    struct KinematicsDataUnspecified : raw_bytes<KinematicsDataUnspecified>,
                                        EqCompare<KinematicsDataUnspecified> {};
-    struct KinematicsDataSVA : RawBytes<KinematicsDataSVA>, EqCompare<KinematicsDataSVA> {
-        using RawBytes<KinematicsDataSVA>::RawBytes;
+    struct KinematicsDataSVA : raw_bytes<KinematicsDataSVA>, EqCompare<KinematicsDataSVA> {
+        using raw_bytes<KinematicsDataSVA>::raw_bytes;
     };
-    struct KinematicsDataURDF : RawBytes<KinematicsDataURDF>, EqCompare<KinematicsDataURDF> {
-        using RawBytes<KinematicsDataURDF>::RawBytes;
+    struct KinematicsDataURDF : raw_bytes<KinematicsDataURDF>, EqCompare<KinematicsDataURDF> {
+        using raw_bytes<KinematicsDataURDF>::raw_bytes;
     };
 
     /// @brief The kinematics of the component.

--- a/src/viam/sdk/components/arm.hpp
+++ b/src/viam/sdk/components/arm.hpp
@@ -95,6 +95,19 @@ class Arm : public Component, public Stoppable {
     /// @return The result of the executed command.
     virtual AttributeMap do_command(const AttributeMap& command) = 0;
 
+    /// @brief Get the kinematics data associated with the arm.
+    /// @param extra Any additional arguments to the method.
+    /// @return A variant of kinematics data, with bytes field containing the raw bytes of the file
+    /// and the object's type indicating the file format.
+    virtual KinematicsData get_kinematics(const AttributeMap& extra) = 0;
+
+    /// @brief Get the kinematics data associated with the arm.
+    /// @return A variant of kinematics data, with bytes field containing the raw bytes of the file
+    /// and the object's type indicating the file format.
+    inline KinematicsData get_kinematics() {
+        return get_kinematics({});
+    }
+
     /// @brief Returns `GeometryConfig`s associated with the calling arm
     inline std::vector<GeometryConfig> get_geometries() {
         return get_geometries({});

--- a/src/viam/sdk/components/private/arm_client.cpp
+++ b/src/viam/sdk/components/private/arm_client.cpp
@@ -40,9 +40,8 @@ void ArmClient::move_to_joint_positions(const std::vector<double>& positions,
     return make_client_helper(this, *stub_, &StubType::MoveToJointPositions)
         .with(extra,
               [&](auto& request) {
-                  (request.mutable_positions())
-                      ->mutable_values()
-                      ->Assign(positions.begin(), positions.end());
+                  *(request.mutable_positions()->mutable_values()) = {positions.begin(),
+                                                                      positions.end()};
               })
         .invoke();
 }

--- a/src/viam/sdk/components/private/arm_client.cpp
+++ b/src/viam/sdk/components/private/arm_client.cpp
@@ -1,0 +1,74 @@
+#include <viam/sdk/components/private/arm_client.hpp>
+
+#include <viam/api/component/arm/v1/arm.grpc.pb.h>
+#include <viam/api/component/arm/v1/arm.pb.h>
+
+#include <viam/sdk/common/client_helper.hpp>
+
+namespace viam {
+namespace sdk {
+namespace impl {
+
+ArmClient::ArmClient(std::string name, std::shared_ptr<grpc::Channel> channel)
+    : Arm(std::move(name)),
+      stub_(viam::component::arm::v1::ArmService::NewStub(channel)),
+      channel_(std::move(channel)) {}
+
+pose ArmClient::get_end_position(const AttributeMap& extra) {
+    return make_client_helper(this, *stub_, &StubType::GetEndPosition)
+        .with(extra)
+        .invoke([&](auto& response) { return pose::from_proto(response.pose()); });
+}
+
+void ArmClient::move_to_position(const pose& pose, const AttributeMap& extra) {
+    return make_client_helper(this, *stub_, &StubType::MoveToPosition)
+        .with(extra, [&](auto& request) { *request.mutable_to() = pose.to_proto(); })
+        .invoke();
+}
+
+std::vector<double> ArmClient::get_joint_positions(const AttributeMap& extra) {
+    return make_client_helper(this, *stub_, &StubType::GetJointPositions)
+        .with(extra)
+        .invoke([](auto& response) {
+            return std::vector<double>(response.positions().values().begin(),
+                                       response.positions().values().end());
+        });
+}
+
+void ArmClient::move_to_joint_positions(const std::vector<double>& positions,
+                                        const AttributeMap& extra) {
+    return make_client_helper(this, *stub_, &StubType::MoveToJointPositions)
+        .with(extra,
+              [&](auto& request) {
+                  (request.mutable_positions())
+                      ->mutable_values()
+                      ->Assign(positions.begin(), positions.end());
+              })
+        .invoke();
+}
+
+bool ArmClient::is_moving() {
+    return make_client_helper(this, *stub_, &StubType::IsMoving).invoke([](auto& response) {
+        return response.is_moving();
+    });
+}
+
+void ArmClient::stop(const AttributeMap& extra) {
+    return make_client_helper(this, *stub_, &StubType::Stop).with(extra).invoke();
+}
+
+AttributeMap ArmClient::do_command(const AttributeMap& command) {
+    return make_client_helper(this, *stub_, &StubType::DoCommand)
+        .with([&](auto& request) { *request.mutable_command() = map_to_struct(command); })
+        .invoke([](auto& response) { return struct_to_map(response.result()); });
+}
+
+std::vector<GeometryConfig> ArmClient::get_geometries(const AttributeMap& extra) {
+    return make_client_helper(this, *stub_, &StubType::GetGeometries)
+        .with(extra)
+        .invoke([](auto& response) { return GeometryConfig::from_proto(response); });
+}
+
+}  // namespace impl
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/private/arm_client.cpp
+++ b/src/viam/sdk/components/private/arm_client.cpp
@@ -63,6 +63,12 @@ AttributeMap ArmClient::do_command(const AttributeMap& command) {
         .invoke([](auto& response) { return struct_to_map(response.result()); });
 }
 
+Arm::KinematicsData ArmClient::get_kinematics(const AttributeMap& extra) {
+    return make_client_helper(this, *stub_, &StubType::GetKinematics)
+        .with(extra)
+        .invoke([](auto& response) { return Arm::from_proto(response); });
+}
+
 std::vector<GeometryConfig> ArmClient::get_geometries(const AttributeMap& extra) {
     return make_client_helper(this, *stub_, &StubType::GetGeometries)
         .with(extra)

--- a/src/viam/sdk/components/private/arm_client.hpp
+++ b/src/viam/sdk/components/private/arm_client.hpp
@@ -24,23 +24,23 @@ class ArmClient : public Arm {
     pose get_end_position(const AttributeMap& extra) override;
     void move_to_position(const pose& pose, const AttributeMap& extra) override;
     std::vector<double> get_joint_positions(const AttributeMap& extra) override;
-    void move_to_joint_positions(const std::vector<double>& positions, const AttributeMap& extra) override;
+    void move_to_joint_positions(const std::vector<double>& positions,
+                                 const AttributeMap& extra) override;
     bool is_moving() override;
     void stop(const AttributeMap& extra) override;
     AttributeMap do_command(const AttributeMap& command) override;
     Arm::KinematicsData get_kinematics(const AttributeMap& extra) override;
     std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) override;
 
-
-    // Using declarations to introduce convenience overloads of interface which do not need to be passed the 
-    // AttributeMap parameter. 
+    // Using declarations to introduce convenience overloads of interface which do not need to be
+    // passed the AttributeMap parameter.
     using Arm::get_end_position;
-    using Arm::move_to_position;
-    using Arm::get_joint_positions;
-    using Arm::move_to_joint_positions;
-    using Arm::stop;
-    using Arm::get_kinematics;
     using Arm::get_geometries;
+    using Arm::get_joint_positions;
+    using Arm::get_kinematics;
+    using Arm::move_to_joint_positions;
+    using Arm::move_to_position;
+    using Arm::stop;
 
    private:
     using StubType = viam::component::arm::v1::ArmService::StubInterface;

--- a/src/viam/sdk/components/private/arm_client.hpp
+++ b/src/viam/sdk/components/private/arm_client.hpp
@@ -1,0 +1,51 @@
+/// @file components/private/arm_client.hpp
+///
+/// @brief Implements a gRPC client for the `Arm` component
+#pragma once
+
+#include <grpcpp/channel.h>
+
+#include <viam/api/component/arm/v1/arm.grpc.pb.h>
+
+#include <viam/sdk/components/arm.hpp>
+
+namespace viam {
+namespace sdk {
+namespace impl {
+
+/// @class ArmClient
+/// @brief gRPC client implementation of an `Arm` component.
+/// @ingroup Arm
+class ArmClient : public Arm {
+   public:
+    using interface_type = Arm;
+    ArmClient(std::string name, std::shared_ptr<grpc::Channel> channel);
+
+    pose get_end_position(const AttributeMap& extra) override;
+    void move_to_position(const pose& pose, const AttributeMap& extra) override;
+    std::vector<double> get_joint_positions(const AttributeMap& extra) override;
+    void move_to_joint_positions(const std::vector<double>& positions, const AttributeMap& extra) override;
+    bool is_moving() override;
+    void stop(const AttributeMap& extra) override;
+    AttributeMap do_command(const AttributeMap& command) override;
+    std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) override;
+
+
+    // Using declarations to introduce convenience overloads of interface which do not need to be passed the 
+    // AttributeMap parameter. 
+    using Arm::get_end_position;
+    using Arm::move_to_position;
+    using Arm::get_joint_positions;
+    using Arm::move_to_joint_positions;
+    using Arm::stop;
+    using Arm::get_geometries;
+
+   private:
+    using StubType = viam::component::arm::v1::ArmService::StubInterface;
+    std::unique_ptr<StubType> stub_;
+    std::shared_ptr<grpc::Channel> channel_;
+};
+
+}  // namespace impl
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/private/arm_client.hpp
+++ b/src/viam/sdk/components/private/arm_client.hpp
@@ -28,6 +28,7 @@ class ArmClient : public Arm {
     bool is_moving() override;
     void stop(const AttributeMap& extra) override;
     AttributeMap do_command(const AttributeMap& command) override;
+    Arm::KinematicsData get_kinematics(const AttributeMap& extra) override;
     std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) override;
 
 
@@ -38,6 +39,7 @@ class ArmClient : public Arm {
     using Arm::get_joint_positions;
     using Arm::move_to_joint_positions;
     using Arm::stop;
+    using Arm::get_kinematics;
     using Arm::get_geometries;
 
    private:

--- a/src/viam/sdk/components/private/arm_server.cpp
+++ b/src/viam/sdk/components/private/arm_server.cpp
@@ -1,0 +1,127 @@
+#include <viam/sdk/components/private/arm_server.hpp>
+
+#include <viam/sdk/common/service_helper.hpp>
+
+namespace viam {
+namespace sdk {
+namespace impl {
+
+ArmServer::ArmServer(std::shared_ptr<ResourceManager> manager)
+    : ResourceServer(std::move(manager)) {}
+
+::grpc::Status ArmServer::GetEndPosition(
+    ::grpc::ServerContext* context,
+    const ::viam::component::arm::v1::GetEndPositionRequest* request,
+    ::viam::component::arm::v1::GetEndPositionResponse* response) noexcept {
+    return make_service_helper<Arm>(
+        "ArmServer::GetEndPosition", this, request)([&](auto& helper, auto& arm) {
+        const pose p = arm->get_end_position(helper.getExtra());
+        *response->mutable_pose() = p.to_proto();
+    });
+}
+
+::grpc::Status ArmServer::MoveToPosition(
+    ::grpc::ServerContext* context,
+    const ::viam::component::arm::v1::MoveToPositionRequest* request,
+    ::viam::component::arm::v1::MoveToPositionResponse* response) noexcept {
+    return make_service_helper<Arm>(
+        "ArmServer::MoveToPosition", this, request)([&](auto& helper, auto& arm) {
+        arm->move_to_position(pose::from_proto(request->to()), helper.getExtra());
+    });
+}
+
+::grpc::Status ArmServer::GetJointPositions(
+    ::grpc::ServerContext* context,
+    const ::viam::component::arm::v1::GetJointPositionsRequest* request,
+    ::viam::component::arm::v1::GetJointPositionsResponse* response) noexcept {
+    return make_service_helper<Arm>(
+        "ArmServer::GetJointPositions", this, request)([&](auto& helper, auto& arm) {
+        const std::vector<double> positions = arm->get_joint_positions(helper.getExtra());
+        response->mutable_positions()->mutable_values()->Assign(positions.begin(), positions.end());
+    });
+}
+
+::grpc::Status ArmServer::MoveToJointPositions(
+    ::grpc::ServerContext* context,
+    const ::viam::component::arm::v1::MoveToJointPositionsRequest* request,
+    ::viam::component::arm::v1::MoveToJointPositionsResponse* response) noexcept {
+    return make_service_helper<Arm>(
+        "ArmServer::MoveToJointPositions", this, request)([&](auto& helper, auto& arm) {
+        arm->move_to_joint_positions(
+            {request->positions().values().begin(), request->positions().values().end()},
+            helper.getExtra());
+    });
+}
+
+::grpc::Status ArmServer::Stop(::grpc::ServerContext* context,
+                               const ::viam::component::arm::v1::StopRequest* request,
+                               ::viam::component::arm::v1::StopResponse* response) noexcept {
+    return make_service_helper<Arm>("ArmServer::Stop", this, request)(
+        [&](auto& helper, auto& arm) { arm->stop(helper.getExtra()); });
+}
+
+::grpc::Status ArmServer::IsMoving(
+    ::grpc::ServerContext* context,
+    const ::viam::component::arm::v1::IsMovingRequest* request,
+    ::viam::component::arm::v1::IsMovingResponse* response) noexcept {
+    return make_service_helper<Arm>("ArmServer::IsMoving", this, request)(
+        [&](auto&, auto& arm) { response->set_is_moving(arm->is_moving()); });
+}
+
+::grpc::Status ArmServer::DoCommand(::grpc::ServerContext* context,
+                                    const ::viam::common::v1::DoCommandRequest* request,
+                                    ::viam::common::v1::DoCommandResponse* response) noexcept {
+    return make_service_helper<Arm>("ArmServer::DoCommand", this, request)([&](auto&, auto& arm) {
+        const AttributeMap result = arm->do_command(struct_to_map(request->command()));
+        *response->mutable_result() = map_to_struct(result);
+    });
+}
+
+::grpc::Status ArmServer::GetKinematics(
+    ::grpc::ServerContext* context,
+    const ::viam::common::v1::GetKinematicsRequest* request,
+    ::viam::common::v1::GetKinematicsResponse* response) noexcept {
+    return make_service_helper<Arm>(
+        "ArmServer::GetKinematics", this, request)([&](auto& helper, auto& arm) {
+        const Arm::KinematicsData result = arm->get_kinematics(helper.getExtra());
+
+        struct Visitor {
+            using FileFormat = common::v1::KinematicsFileFormat;
+            auto operator()(const Arm::KinematicsDataUnspecified&) const noexcept {
+                return FileFormat::KINEMATICS_FILE_FORMAT_UNSPECIFIED;
+            }
+
+            auto operator()(const Arm::KinematicsDataSVA&) const noexcept {
+                return FileFormat::KINEMATICS_FILE_FORMAT_SVA;
+            }
+
+            auto operator()(const Arm::KinematicsDataURDF&) const noexcept {
+                return FileFormat::KINEMATICS_FILE_FORMAT_URDF;
+            }
+        } visitor;
+
+        boost::apply_visitor(
+            [&](const auto& v) {
+                response->set_format(visitor(v));
+                response->mutable_kinematics_data()->assign(v.bytes.begin(), v.bytes.end());
+            },
+            result);
+    });
+}
+
+::grpc::Status ArmServer::GetGeometries(
+    ::grpc::ServerContext* context,
+    const ::viam::common::v1::GetGeometriesRequest* request,
+    ::viam::common::v1::GetGeometriesResponse* response) noexcept {
+    return make_service_helper<Arm>(
+        "ArmServer::GetGeometries", this, request)([&](auto& helper, auto& arm) {
+        const std::vector<GeometryConfig> geometries = arm->get_geometries(helper.getExtra());
+        for (const auto& geometry : geometries) {
+            *response->mutable_geometries()->Add() = geometry.to_proto();
+        }
+    });
+}
+
+}  // namespace impl
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/private/arm_server.cpp
+++ b/src/viam/sdk/components/private/arm_server.cpp
@@ -37,7 +37,7 @@ ArmServer::ArmServer(std::shared_ptr<ResourceManager> manager)
     return make_service_helper<Arm>(
         "ArmServer::GetJointPositions", this, request)([&](auto& helper, auto& arm) {
         const std::vector<double> positions = arm->get_joint_positions(helper.getExtra());
-        response->mutable_positions()->mutable_values()->Assign(positions.begin(), positions.end());
+        *(response->mutable_positions()->mutable_values()) = {positions.begin(), positions.end()};
     });
 }
 

--- a/src/viam/sdk/components/private/arm_server.cpp
+++ b/src/viam/sdk/components/private/arm_server.cpp
@@ -10,7 +10,7 @@ ArmServer::ArmServer(std::shared_ptr<ResourceManager> manager)
     : ResourceServer(std::move(manager)) {}
 
 ::grpc::Status ArmServer::GetEndPosition(
-    ::grpc::ServerContext* context,
+    ::grpc::ServerContext*,
     const ::viam::component::arm::v1::GetEndPositionRequest* request,
     ::viam::component::arm::v1::GetEndPositionResponse* response) noexcept {
     return make_service_helper<Arm>(
@@ -21,9 +21,9 @@ ArmServer::ArmServer(std::shared_ptr<ResourceManager> manager)
 }
 
 ::grpc::Status ArmServer::MoveToPosition(
-    ::grpc::ServerContext* context,
+    ::grpc::ServerContext*,
     const ::viam::component::arm::v1::MoveToPositionRequest* request,
-    ::viam::component::arm::v1::MoveToPositionResponse* response) noexcept {
+    ::viam::component::arm::v1::MoveToPositionResponse*) noexcept {
     return make_service_helper<Arm>(
         "ArmServer::MoveToPosition", this, request)([&](auto& helper, auto& arm) {
         arm->move_to_position(pose::from_proto(request->to()), helper.getExtra());
@@ -31,7 +31,7 @@ ArmServer::ArmServer(std::shared_ptr<ResourceManager> manager)
 }
 
 ::grpc::Status ArmServer::GetJointPositions(
-    ::grpc::ServerContext* context,
+    ::grpc::ServerContext*,
     const ::viam::component::arm::v1::GetJointPositionsRequest* request,
     ::viam::component::arm::v1::GetJointPositionsResponse* response) noexcept {
     return make_service_helper<Arm>(
@@ -42,9 +42,9 @@ ArmServer::ArmServer(std::shared_ptr<ResourceManager> manager)
 }
 
 ::grpc::Status ArmServer::MoveToJointPositions(
-    ::grpc::ServerContext* context,
+    ::grpc::ServerContext*,
     const ::viam::component::arm::v1::MoveToJointPositionsRequest* request,
-    ::viam::component::arm::v1::MoveToJointPositionsResponse* response) noexcept {
+    ::viam::component::arm::v1::MoveToJointPositionsResponse*) noexcept {
     return make_service_helper<Arm>(
         "ArmServer::MoveToJointPositions", this, request)([&](auto& helper, auto& arm) {
         arm->move_to_joint_positions(
@@ -53,22 +53,22 @@ ArmServer::ArmServer(std::shared_ptr<ResourceManager> manager)
     });
 }
 
-::grpc::Status ArmServer::Stop(::grpc::ServerContext* context,
+::grpc::Status ArmServer::Stop(::grpc::ServerContext*,
                                const ::viam::component::arm::v1::StopRequest* request,
-                               ::viam::component::arm::v1::StopResponse* response) noexcept {
+                               ::viam::component::arm::v1::StopResponse*) noexcept {
     return make_service_helper<Arm>("ArmServer::Stop", this, request)(
         [&](auto& helper, auto& arm) { arm->stop(helper.getExtra()); });
 }
 
 ::grpc::Status ArmServer::IsMoving(
-    ::grpc::ServerContext* context,
+    ::grpc::ServerContext*,
     const ::viam::component::arm::v1::IsMovingRequest* request,
     ::viam::component::arm::v1::IsMovingResponse* response) noexcept {
     return make_service_helper<Arm>("ArmServer::IsMoving", this, request)(
         [&](auto&, auto& arm) { response->set_is_moving(arm->is_moving()); });
 }
 
-::grpc::Status ArmServer::DoCommand(::grpc::ServerContext* context,
+::grpc::Status ArmServer::DoCommand(::grpc::ServerContext*,
                                     const ::viam::common::v1::DoCommandRequest* request,
                                     ::viam::common::v1::DoCommandResponse* response) noexcept {
     return make_service_helper<Arm>("ArmServer::DoCommand", this, request)([&](auto&, auto& arm) {
@@ -78,7 +78,7 @@ ArmServer::ArmServer(std::shared_ptr<ResourceManager> manager)
 }
 
 ::grpc::Status ArmServer::GetKinematics(
-    ::grpc::ServerContext* context,
+    ::grpc::ServerContext*,
     const ::viam::common::v1::GetKinematicsRequest* request,
     ::viam::common::v1::GetKinematicsResponse* response) noexcept {
     return make_service_helper<Arm>(
@@ -110,7 +110,7 @@ ArmServer::ArmServer(std::shared_ptr<ResourceManager> manager)
 }
 
 ::grpc::Status ArmServer::GetGeometries(
-    ::grpc::ServerContext* context,
+    ::grpc::ServerContext*,
     const ::viam::common::v1::GetGeometriesRequest* request,
     ::viam::common::v1::GetGeometriesResponse* response) noexcept {
     return make_service_helper<Arm>(

--- a/src/viam/sdk/components/private/arm_server.hpp
+++ b/src/viam/sdk/components/private/arm_server.hpp
@@ -1,0 +1,73 @@
+/// @file components/private/arm_server.hpp
+///
+/// @brief Implements a gRPC server for the `Arm` component
+#pragma once
+
+#include <viam/api/component/arm/v1/arm.grpc.pb.h>
+#include <viam/api/component/arm/v1/arm.pb.h>
+
+#include <viam/sdk/components/arm.hpp>
+#include <viam/sdk/resource/resource_manager.hpp>
+#include <viam/sdk/resource/resource_server_base.hpp>
+
+namespace viam {
+namespace sdk {
+namespace impl {
+
+/// @class ArmServer
+/// @brief gRPC server implementation of an `Arm` component.
+/// @ingroup Arm
+class ArmServer : public ResourceServer, public viam::component::arm::v1::ArmService::Service {
+   public:
+    using interface_type = Arm;
+    using service_type = component::arm::v1::ArmService::Service;
+
+    explicit ArmServer(std::shared_ptr<ResourceManager> manager);
+
+    ::grpc::Status GetEndPosition(
+        ::grpc::ServerContext* context,
+        const ::viam::component::arm::v1::GetEndPositionRequest* request,
+        ::viam::component::arm::v1::GetEndPositionResponse* response) noexcept override;
+
+    ::grpc::Status MoveToPosition(
+        ::grpc::ServerContext* context,
+        const ::viam::component::arm::v1::MoveToPositionRequest* request,
+        ::viam::component::arm::v1::MoveToPositionResponse* response) noexcept override;
+
+    ::grpc::Status GetJointPositions(
+        ::grpc::ServerContext* context,
+        const ::viam::component::arm::v1::GetJointPositionsRequest* request,
+        ::viam::component::arm::v1::GetJointPositionsResponse* response) noexcept override;
+
+    ::grpc::Status MoveToJointPositions(
+        ::grpc::ServerContext* context,
+        const ::viam::component::arm::v1::MoveToJointPositionsRequest* request,
+        ::viam::component::arm::v1::MoveToJointPositionsResponse* response) noexcept override;
+
+    ::grpc::Status Stop(::grpc::ServerContext* context,
+                        const ::viam::component::arm::v1::StopRequest* request,
+                        ::viam::component::arm::v1::StopResponse* response) noexcept override;
+
+    ::grpc::Status IsMoving(
+        ::grpc::ServerContext* context,
+        const ::viam::component::arm::v1::IsMovingRequest* request,
+        ::viam::component::arm::v1::IsMovingResponse* response) noexcept override;
+
+    ::grpc::Status DoCommand(::grpc::ServerContext* context,
+                             const ::viam::common::v1::DoCommandRequest* request,
+                             ::viam::common::v1::DoCommandResponse* response) noexcept override;
+
+    ::grpc::Status GetKinematics(
+        ::grpc::ServerContext* context,
+        const ::viam::common::v1::GetKinematicsRequest* request,
+        ::viam::common::v1::GetKinematicsResponse* response) noexcept override;
+
+    ::grpc::Status GetGeometries(
+        ::grpc::ServerContext* context,
+        const ::viam::common::v1::GetGeometriesRequest* request,
+        ::viam::common::v1::GetGeometriesResponse* response) noexcept override;
+};
+
+}  // namespace impl
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/components/private/arm_server.hpp
+++ b/src/viam/sdk/components/private/arm_server.hpp
@@ -20,7 +20,7 @@ namespace impl {
 class ArmServer : public ResourceServer, public viam::component::arm::v1::ArmService::Service {
    public:
     using interface_type = Arm;
-    using service_type = component::arm::v1::ArmService::Service;
+    using service_type = component::arm::v1::ArmService;
 
     explicit ArmServer(std::shared_ptr<ResourceManager> manager);
 

--- a/src/viam/sdk/registry/registry.cpp
+++ b/src/viam/sdk/registry/registry.cpp
@@ -12,6 +12,8 @@
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 
 #include <viam/sdk/common/exception.hpp>
+#include <viam/sdk/components/private/arm_client.hpp>
+#include <viam/sdk/components/private/arm_server.hpp>
 #include <viam/sdk/components/private/base_client.hpp>
 #include <viam/sdk/components/private/base_server.hpp>
 #include <viam/sdk/components/private/board_client.hpp>
@@ -163,6 +165,7 @@ const google::protobuf::ServiceDescriptor* ResourceServerRegistration::service_d
 
 void register_resources() {
     // Register all components
+    Registry::register_resource<impl::ArmClient, impl::ArmServer>();
     Registry::register_resource<impl::BaseClient, impl::BaseServer>();
     Registry::register_resource<impl::BoardClient, impl::BoardServer>();
     Registry::register_resource<impl::CameraClient, impl::CameraServer>();

--- a/src/viam/sdk/rpc/server.cpp
+++ b/src/viam/sdk/rpc/server.cpp
@@ -45,7 +45,7 @@ void Server::add_resource(std::shared_ptr<Resource> resource) {
     if (managed_servers_.find(api) == managed_servers_.end()) {
         std::ostringstream buffer;
         buffer << "Attempted to add resource with API: " << api
-               << " but no matching resource server as found";
+               << " but no matching resource server was found";
         throw Exception(ErrorCondition::k_resource_not_found, buffer.str());
     }
     auto resource_server = managed_servers_.at(api);

--- a/src/viam/sdk/tests/CMakeLists.txt
+++ b/src/viam/sdk/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(viamsdk_test
     mocks/camera_mocks.cpp
     mocks/generic_mocks.cpp
     mocks/mlmodel_mocks.cpp
+    mocks/mock_arm.cpp
     mocks/mock_base.cpp
     mocks/mock_board.cpp
     mocks/mock_encoder.cpp
@@ -39,6 +40,7 @@ target_link_libraries(viamsdk_test
   PUBLIC viam-cpp-sdk::viamsdk
 )
 
+viamcppsdk_add_boost_test(test_arm.cpp)
 viamcppsdk_add_boost_test(test_base.cpp)
 viamcppsdk_add_boost_test(test_board.cpp)
 viamcppsdk_add_boost_test(test_camera.cpp)

--- a/src/viam/sdk/tests/mocks/mock_arm.cpp
+++ b/src/viam/sdk/tests/mocks/mock_arm.cpp
@@ -1,0 +1,57 @@
+#include <viam/sdk/tests/mocks/mock_arm.hpp>
+
+#include <viam/sdk/tests/test_utils.hpp>
+
+namespace viam {
+namespace sdktests {
+namespace arm {
+
+sdk::Arm::KinematicsData fake_kinematics() {
+    return sdk::Arm::KinematicsDataSVA{{std::vector<unsigned char>{1, 2, 3, 4}}};
+}
+
+sdk::pose MockArm::get_end_position(const sdk::AttributeMap& extra) {
+    return current_location;
+}
+
+std::shared_ptr<MockArm> MockArm::get_mock_arm()
+{
+    return std::make_shared<MockArm>("mock_arm");
+}
+
+void MockArm::move_to_position(const sdk::pose& pose, const sdk::AttributeMap&) {
+    current_location = pose;
+}
+
+std::vector<double> MockArm::get_joint_positions(const sdk::AttributeMap&) {
+    return joint_positions;
+}
+
+void MockArm::move_to_joint_positions(const std::vector<double>& positions,
+                                      const sdk::AttributeMap&) {
+    joint_positions = positions;
+}
+
+void MockArm::stop(const sdk::AttributeMap&) {
+    peek_stop_called = true;
+}
+
+bool MockArm::is_moving() {
+    return false;
+}
+
+sdk::AttributeMap MockArm::do_command(const sdk::AttributeMap& command) {
+    return (peek_command = command);
+}
+
+sdk::Arm::KinematicsData MockArm::get_kinematics(const sdk::AttributeMap&) {
+    return fake_kinematics();
+}
+
+std::vector<sdk::GeometryConfig> MockArm::get_geometries(const sdk::AttributeMap&) {
+    return fake_geometries();
+}
+
+}  // namespace arm
+}  // namespace sdktests
+}  // namespace viam

--- a/src/viam/sdk/tests/mocks/mock_arm.cpp
+++ b/src/viam/sdk/tests/mocks/mock_arm.cpp
@@ -14,8 +14,7 @@ sdk::pose MockArm::get_end_position(const sdk::AttributeMap& extra) {
     return current_location;
 }
 
-std::shared_ptr<MockArm> MockArm::get_mock_arm()
-{
+std::shared_ptr<MockArm> MockArm::get_mock_arm() {
     return std::make_shared<MockArm>("mock_arm");
 }
 

--- a/src/viam/sdk/tests/mocks/mock_arm.hpp
+++ b/src/viam/sdk/tests/mocks/mock_arm.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <viam/sdk/components/arm.hpp>
+
+namespace viam {
+namespace sdktests {
+namespace arm {
+
+sdk::Arm::KinematicsData fake_kinematics();
+
+class MockArm : public sdk::Arm {
+   public:
+    MockArm(std::string name) : Arm(std::move(name)) {}
+
+    static std::shared_ptr<MockArm> get_mock_arm();
+
+    sdk::pose get_end_position(const sdk::AttributeMap&) override;
+    void move_to_position(const sdk::pose& pose, const sdk::AttributeMap&) override;
+    std::vector<double> get_joint_positions(const sdk::AttributeMap&) override;
+    void move_to_joint_positions(const std::vector<double>& positions,
+                                 const sdk::AttributeMap&) override;
+    void stop(const sdk::AttributeMap&) override;
+    bool is_moving() override;
+    sdk::AttributeMap do_command(const sdk::AttributeMap& command) override;
+    sdk::Arm::KinematicsData get_kinematics(const sdk::AttributeMap&) override;
+    std::vector<sdk::GeometryConfig> get_geometries(const sdk::AttributeMap&) override;
+
+    sdk::pose current_location;
+    std::vector<double> joint_positions;
+    bool peek_stop_called;
+    sdk::AttributeMap peek_command;
+};
+
+}  // namespace arm
+}  // namespace sdktests
+}  // namespace viam

--- a/src/viam/sdk/tests/test_arm.cpp
+++ b/src/viam/sdk/tests/test_arm.cpp
@@ -1,0 +1,99 @@
+#define BOOST_TEST_MODULE test module test_arm
+
+#include <boost/qvm/all.hpp>
+#include <boost/test/included/unit_test.hpp>
+
+#include <viam/sdk/components/arm.hpp>
+#include <viam/sdk/tests/mocks/mock_arm.hpp>
+#include <viam/sdk/tests/test_utils.hpp>
+
+BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<viam::sdk::GeometryConfig>)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<double>)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(viam::sdk::Arm::KinematicsData)
+
+namespace viam {
+namespace sdktests {
+
+using namespace arm;
+
+using namespace viam::sdk;
+
+BOOST_AUTO_TEST_SUITE(test_arm)
+
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    const MockArm arm("mock_arm");
+    auto api = arm.api();
+    auto static_api = API::get<Arm>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "arm");
+}
+
+BOOST_AUTO_TEST_CASE(test_positions) {
+    std::shared_ptr<MockArm> mock = MockArm::get_mock_arm();
+    client_to_mock_pipeline<Arm>(mock, [&](Arm& client) {
+        pose p{{2, 3, 4}, {5, 6, 7}, 8};
+        client.move_to_position(p);
+        BOOST_CHECK_EQUAL(mock->current_location, p);
+        BOOST_CHECK_EQUAL(mock->get_end_position({}), p);
+    });
+}
+
+BOOST_AUTO_TEST_CASE(joint_positions) {
+    std::shared_ptr<MockArm> mock = MockArm::get_mock_arm();
+    client_to_mock_pipeline<Arm>(mock, [&](Arm& client) {
+        std::vector<double> positions{{1.0, 2.0, 3.0, 4.0}};
+        client.move_to_joint_positions(positions, {});
+        BOOST_CHECK_EQUAL(client.get_joint_positions(), positions);
+        BOOST_CHECK_EQUAL(mock->joint_positions, positions);
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_stop) {
+    std::shared_ptr<MockArm> mock = MockArm::get_mock_arm();
+    client_to_mock_pipeline<Arm>(mock, [&](Arm& client) {
+        mock->peek_stop_called = false;
+        client.stop();
+        BOOST_CHECK(mock->peek_stop_called);
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_get_geometries) {
+    std::shared_ptr<MockArm> mock = MockArm::get_mock_arm();
+    client_to_mock_pipeline<Arm>(mock, [](Arm& client) {
+        const auto& geometries = client.get_geometries();
+        BOOST_CHECK_EQUAL(geometries, fake_geometries());
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_get_kinematics) {
+    std::shared_ptr<MockArm> mock = MockArm::get_mock_arm();
+    client_to_mock_pipeline<Arm>(mock, [](Arm& client) {
+        const auto& kinematics = client.get_kinematics();
+        BOOST_CHECK_EQUAL(kinematics, fake_kinematics());
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_is_moving) {
+    std::shared_ptr<MockArm> mock = MockArm::get_mock_arm();
+    client_to_mock_pipeline<Arm>(mock, [](Arm& client) { BOOST_CHECK(!client.is_moving()); });
+}
+
+BOOST_AUTO_TEST_CASE(test_do_command) {
+    std::shared_ptr<MockArm> mock = MockArm::get_mock_arm();
+    client_to_mock_pipeline<Arm>(mock, [](Arm& client) {
+        AttributeMap expected = fake_map();
+
+        AttributeMap command = fake_map();
+        AttributeMap result_map = client.do_command(command);
+
+        ProtoType expected_pt = *(expected->at(std::string("test")));
+        ProtoType result_pt = *(result_map->at(std::string("test")));
+        BOOST_CHECK(result_pt == expected_pt);
+    });
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace sdktests
+}  // namespace viam


### PR DESCRIPTION
See [RSDK-7939](https://viam.atlassian.net/browse/RSDK-7939)

Maybe the only odd thing about this is the `KinematicsData` variant, a design I arrived at after discussion with @acmorrow 

It's an adaptation of https://github.com/viamrobotics/api/blob/main/proto/viam/common/v1/common.proto#L194

The variant is meant to introduce different types for different file types. In the case of unspecified data we do not store the bytes, but maybe there is a compelling reason to do so. 

Note also that this is technically part of common but I put it in the arm module code because it's not being used elsewhere, but I can move it if that's an issue

[RSDK-7939]: https://viam.atlassian.net/browse/RSDK-7939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ