### PR TITLE
Streamable client helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 # Please try to keep this file as empty as possible,
 # and document what cannot be avoided.
 
-# Give users an ignored place to build
-/build/*
+# Give users an ignored place to build, either a /build/ directory or one with 
+# config parameters such as /build-arm-Debug/
+/build*/*
 
 # For now, ignore any viam_rust_utils library in the root.
 /libviam_rust_utils*
@@ -12,3 +13,6 @@
 
 # ignore doxygen output
 /etc/docs/api/*
+
+# ignore vscode customization
+/.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 # Please try to keep this file as empty as possible,
 # and document what cannot be avoided.
 
-# Give users an ignored place to build, either a /build/ directory or one with 
-# config parameters such as /build-arm-Debug/
-/build*/*
+# Give users an ignored place to build
+/build/*
 
 # For now, ignore any viam_rust_utils library in the root.
 /libviam_rust_utils*
@@ -13,6 +12,3 @@
 
 # ignore doxygen output
 /etc/docs/api/*
-
-# ignore vscode customization
-/.vscode/*

--- a/src/viam/sdk/common/client_helper.hpp
+++ b/src/viam/sdk/common/client_helper.hpp
@@ -14,14 +14,16 @@ namespace client_helper_details {
 [[noreturn]] void errorHandlerReturnedUnexpectedly(const ::grpc::Status&) noexcept;
 }  // namespace client_helper_details
 
-template <class StubType, class RequestType, class ResponseType>
-using StreamingMethodType = std::unique_ptr<::grpc::ClientReaderInterface<ResponseType>> (
-    StubType::*)(::grpc::ClientContext*, const RequestType&);
-
+// Method type for a gRPC call that returns a response message type.
 template <class StubType, class RequestType, class ResponseType>
 using SyncMethodType = ::grpc::Status (StubType::*)(::grpc::ClientContext*,
                                                     const RequestType&,
                                                     ResponseType*);
+
+// Method type for a gRPC call that returns a stream of response message type.
+template <class StubType, class RequestType, class ResponseType>
+using StreamingMethodType = std::unique_ptr<::grpc::ClientReaderInterface<ResponseType>> (
+    StubType::*)(::grpc::ClientContext*, const RequestType&);
 
 template <typename ClientType,
           typename StubType,

--- a/src/viam/sdk/common/client_helper.hpp
+++ b/src/viam/sdk/common/client_helper.hpp
@@ -77,6 +77,9 @@ class ClientHelper {
         client_helper_details::errorHandlerReturnedUnexpectedly(result);
     }
 
+    // A version of invoke for gRPC calls returning `(stream ResponseType)`.
+    // ResponseHandlerCallable will be called for every response in the reader, and should return
+    // false to indicate it is no longer interested in the stream.
     template <typename ResponseHandlerCallable>
     auto invoke_stream(ResponseHandlerCallable rhc) {
         *request_.mutable_name() = client_->name();

--- a/src/viam/sdk/common/client_helper.hpp
+++ b/src/viam/sdk/common/client_helper.hpp
@@ -87,10 +87,7 @@ class ClientHelper {
 
         auto reader = (stub_->*pfn_)(ctx, request_);
 
-        while (reader->Read(&response_)) {
-            if (!rhc(response_)) {
-                break;
-            }
+        while (reader->Read(&response_) && rhc(response_)) {
         }
     }
 

--- a/src/viam/sdk/common/client_helper.hpp
+++ b/src/viam/sdk/common/client_helper.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <grpcpp/client_context.h>
+#include <grpcpp/support/sync_stream.h>
+
 #include <viam/sdk/common/exception.hpp>
 #include <viam/sdk/common/proto_type.hpp>
 #include <viam/sdk/common/utils.hpp>
@@ -12,7 +14,20 @@ namespace client_helper_details {
 [[noreturn]] void errorHandlerReturnedUnexpectedly(const ::grpc::Status&) noexcept;
 }  // namespace client_helper_details
 
-template <typename ClientType, typename StubType, typename RequestType, typename ResponseType>
+template <class StubType, class RequestType, class ResponseType>
+using StreamingMethodType = std::unique_ptr<::grpc::ClientReaderInterface<ResponseType>> (
+    StubType::*)(::grpc::ClientContext*, const RequestType&);
+
+template <class StubType, class RequestType, class ResponseType>
+using SyncMethodType = ::grpc::Status (StubType::*)(::grpc::ClientContext*,
+                                                    const RequestType&,
+                                                    ResponseType*);
+
+template <typename ClientType,
+          typename StubType,
+          typename RequestType,
+          typename ResponseType,
+          typename MethodType>
 class ClientHelper {
     static void default_rsc_(RequestType&) {}
     static void default_rhc_(const ResponseType&) {}
@@ -21,10 +36,7 @@ class ClientHelper {
     }
 
    public:
-    using PFn = ::grpc::Status (StubType::*)(::grpc::ClientContext*,
-                                             const RequestType&,
-                                             ResponseType*);
-    explicit ClientHelper(ClientType* client, StubType* stub, PFn pfn)
+    explicit ClientHelper(ClientType* client, StubType* stub, MethodType pfn)
         : client_(client), stub_(stub), pfn_(pfn) {}
 
     ClientHelper& with(const AttributeMap& extra) {
@@ -63,10 +75,24 @@ class ClientHelper {
         client_helper_details::errorHandlerReturnedUnexpectedly(result);
     }
 
+    template <typename ResponseHandlerCallable>
+    auto invoke_stream(ResponseHandlerCallable rhc) {
+        *request_.mutable_name() = client_->name();
+        ClientContext ctx;
+
+        auto reader = (stub_->*pfn_)(ctx, request_);
+
+        while (reader->Read(&response_)) {
+            if (!rhc(response_)) {
+                break;
+            }
+        }
+    }
+
    private:
     ClientType* client_;
     StubType* stub_;
-    PFn pfn_;
+    MethodType pfn_;
     RequestType request_;
     ResponseType response_;
 };
@@ -74,10 +100,24 @@ class ClientHelper {
 template <typename ClientType, typename StubType, typename RequestType, typename ResponseType>
 auto make_client_helper(ClientType* client,
                         StubType& stub,
-                        ::grpc::Status (StubType::*method)(::grpc::ClientContext*,
-                                                           const RequestType&,
-                                                           ResponseType*)) {
-    return ClientHelper<ClientType, StubType, RequestType, ResponseType>(client, &stub, method);
+                        SyncMethodType<StubType, RequestType, ResponseType> method) {
+    return ClientHelper<ClientType,
+                        StubType,
+                        RequestType,
+                        ResponseType,
+                        SyncMethodType<StubType, RequestType, ResponseType>>(client, &stub, method);
+}
+
+template <typename ClientType, typename StubType, typename RequestType, typename ResponseType>
+auto make_client_helper(ClientType* client,
+                        StubType& stub,
+                        StreamingMethodType<StubType, RequestType, ResponseType> method) {
+    return ClientHelper<ClientType,
+                        StubType,
+                        RequestType,
+                        ResponseType,
+                        StreamingMethodType<StubType, RequestType, ResponseType>>(
+        client, &stub, method);
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/common/client_helper.hpp
+++ b/src/viam/sdk/common/client_helper.hpp
@@ -15,13 +15,13 @@ namespace client_helper_details {
 }  // namespace client_helper_details
 
 // Method type for a gRPC call that returns a response message type.
-template <class StubType, class RequestType, class ResponseType>
+template <typename StubType, typename RequestType, typename ResponseType>
 using SyncMethodType = ::grpc::Status (StubType::*)(::grpc::ClientContext*,
                                                     const RequestType&,
                                                     ResponseType*);
 
 // Method type for a gRPC call that returns a stream of response message type.
-template <class StubType, class RequestType, class ResponseType>
+template <typename StubType, typename RequestType, typename ResponseType>
 using StreamingMethodType = std::unique_ptr<::grpc::ClientReaderInterface<ResponseType>> (
     StubType::*)(::grpc::ClientContext*, const RequestType&);
 


### PR DESCRIPTION
Modifies `ClientHelper` to be able to handle streaming requests such as `Board::stream_ticks` or forthcoming `InputController::stream_events`. This work was factored out of the input controller branch, and the new method is able to handle both of them. 

`ClientHelper` is now templated on the stub PMF type, which is one of two introduced alias declarations, either `SyncMethodType` or `StreamingMethodType`. This replaces the `using PFn` declaration. Rather than do this, I would love to be able to write something like
```cpp
using PFn = std::conditional_t<
    is_sync_response_v<ResponseType>
    SyncMethodType<...>,
    StreamingMethodType<...>
>
```

but at a glance it does not appear possible to do through anything gRPC gives us on response types. 

Note it would be possible to forgo the `SyncMethodType` and `StreamingMethodType` alias decls entirely and just have a single `make_client_helper` which is templated on `typename MethodType` and let type deduction do the rest, but following the previous implementation I decided to opt for a more verbose but more explicit approach where the helper overloads make it clear which template parameters are accepted. 

Based on the return type of stream responses it seems that an `ErrorHandlerCallable` version is not required but I could be wrong. 