### PR TITLE
Fix aarch build

### DIFF
--- a/src/viam/sdk/common/proto_value.hpp
+++ b/src/viam/sdk/common/proto_value.hpp
@@ -223,6 +223,7 @@ class ProtoValue {
     storage self_;
 };
 
+// Pre c++17 this is still required
 template <typename T>
 constexpr ProtoValue::vtable ProtoValue::model<T>::vtable_;
 

--- a/src/viam/sdk/common/proto_value.hpp
+++ b/src/viam/sdk/common/proto_value.hpp
@@ -223,6 +223,9 @@ class ProtoValue {
     storage self_;
 };
 
+template <typename T>
+constexpr ProtoValue::vtable ProtoValue::model<T>::vtable_;
+
 /// @brief Alias declaration for map of string to type-erased ProtoValue representing
 /// google::protobuf::Struct.
 /// This stores structured data as a map where the keys can be thought of as member names.


### PR DESCRIPTION
This should fix failures seen it the latest draft release, see eg 
https://github.com/viamrobotics/viam-cpp-sdk/actions/runs/10457244069/job/28956432798#step:7:326
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54483#c13

For whatever reason this was only failing on the aarch c++14 linux builds, although it seems they were correct to fail it. 