### PR TITLE
RSDK-4735: Allow selective building and installing of unit tests and examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,6 @@ option(BUILD_SHARED_LIBS "If enabled, build shared libraries" ON)
 
 # Configure project-global options:
 
-
 # - `VIAMCPPSDK_ENFORCE_COMPILER_MINIMA`
 #
 # The user can elect to disable enforcement of compiler minima (at

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ project(viam-cpp-sdk
 #
 option(BUILD_SHARED_LIBS "If enabled, build shared libraries" ON)
 
-
 # Configure project-global options:
+
 
 # - `VIAMCPPSDK_ENFORCE_COMPILER_MINIMA`
 #
@@ -127,6 +127,18 @@ option(VIAMCPPSDK_SANITIZED_BUILD "Build with address and UB sanitizers (less pe
 #
 option(VIAMCPPSDK_CLANG_TIDY "Run the clang-tidy linter" OFF)
 
+# The following options are only defined if this project is not being included as a subproject
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  include(CMakeDependentOption)
+  option(VIAMCPPSDK_BUILD_EXAMPLES "Build the example executables (requires building tests too)" ON)
+
+  # Note that the complex module example requires the testing library and adds its tests to the unit
+  # test suite. Thus you can only disable tests if examples are also disabled.
+  # The call below says don't give the user the option to disable tests unless examples are already
+  # disabled, and default to building the tests in either case.
+  cmake_dependent_option(VIAMCPPSDK_BUILD_TESTS "Build the unit test suite" ON "NOT VIAMCPPSDK_BUILD_EXAMPLES" ON)
+endif()
+
 
 # Enforce known toolchains and toolchain minima unless asked not to.
 if (VIAMCPPSDK_ENFORCE_COMPILER_MINIMA)
@@ -186,6 +198,11 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
   ${PROJECT_SOURCE_DIR}/src/viam/cmake
 )
+if (VIAMCPPSDK_BUILD_TESTS OR VIAMCPPSDK_BUILD_EXAMPLES)
+  # We maybe could include this unconditionally, but technically only tests or examples need it
+  include(viamcppsdk_utils)
+endif()
+
 
 
 # Configure how the SDK will manage runtime paths. This is important
@@ -441,8 +458,10 @@ add_custom_target(
   DEPENDS all
 )
 
-add_custom_target(
-  install-examples
-  COMMAND ${CMAKE_COMMAND} -DCOMPONENT=viam-cpp-sdk_examples -P ${CMAKE_BINARY_DIR}/cmake_install.cmake
-  DEPENDS all
-)
+if (VIAMCPPSDK_BUILD_EXAMPLES)
+  add_custom_target(
+    install-examples
+    COMMAND ${CMAKE_COMMAND} -DCOMPONENT=viam-cpp-sdk_examples -P ${CMAKE_BINARY_DIR}/cmake_install.cmake
+    DEPENDS all
+  )
+endif()

--- a/src/viam/CMakeLists.txt
+++ b/src/viam/CMakeLists.txt
@@ -14,7 +14,10 @@
 
 add_subdirectory(api)
 add_subdirectory(sdk)
-add_subdirectory(examples)
+
+if (VIAMCPPSDK_BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif()
 
 # Generate CMake configs to enable importing this project
 # into others via `find_package`.

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -285,5 +285,6 @@ install(FILES
   COMPONENT viam-cpp-sdk_dev
 )
 
-
-add_subdirectory(tests)
+if (VIAMCPPSDK_BUILD_TESTS)
+  add_subdirectory(tests)
+endif()

--- a/src/viam/sdk/tests/CMakeLists.txt
+++ b/src/viam/sdk/tests/CMakeLists.txt
@@ -14,7 +14,6 @@
 
 enable_testing()
 
-include(viamcppsdk_utils)
 add_library(viamsdk_test)
 
 target_sources(viamsdk_test


### PR DESCRIPTION
Lets the user control building of tests/examples. Some features worth remark:
- these examples are never exposed for subproject builds
- examples and tests are dependent, so it is not possible, for example, to specify building the examples but not the tests. 

These options could be decoupled but that is probably out of scope for this ticket