### PR TITLE
RSDK-8829: Add frame_rate to cpp sdk

### DIFF
--- a/src/viam/sdk/components/camera.cpp
+++ b/src/viam/sdk/components/camera.cpp
@@ -255,7 +255,7 @@ viam::component::camera::v1::DistortionParameters Camera::to_proto(
     return proto;
 }
 
-Camera::Camera(std::string name) : Component(std::move(name)) {};
+Camera::Camera(std::string name) : Component(std::move(name)){};
 
 bool operator==(const Camera::point_cloud& lhs, const Camera::point_cloud& rhs) {
     return lhs.mime_type == rhs.mime_type && lhs.pc == rhs.pc;

--- a/src/viam/sdk/components/camera.cpp
+++ b/src/viam/sdk/components/camera.cpp
@@ -232,7 +232,7 @@ Camera::properties Camera::from_proto(
             from_proto(proto.intrinsic_parameters()),
             from_proto(proto.distortion_parameters()),
             {proto.mime_types().begin(), proto.mime_types().end()},
-            from_proto(proto.frame_rate())};
+            (proto.frame_rate())};
 }
 
 viam::component::camera::v1::IntrinsicParameters Camera::to_proto(

--- a/src/viam/sdk/components/camera.cpp
+++ b/src/viam/sdk/components/camera.cpp
@@ -231,7 +231,8 @@ Camera::properties Camera::from_proto(
     return {proto.supports_pcd(),
             from_proto(proto.intrinsic_parameters()),
             from_proto(proto.distortion_parameters()),
-            {proto.mime_types().begin(), proto.mime_types().end()}};
+            {proto.mime_types().begin(), proto.mime_types().end()},
+            from_proto(proto.frame_rate())};
 }
 
 viam::component::camera::v1::IntrinsicParameters Camera::to_proto(
@@ -254,7 +255,7 @@ viam::component::camera::v1::DistortionParameters Camera::to_proto(
     return proto;
 }
 
-Camera::Camera(std::string name) : Component(std::move(name)){};
+Camera::Camera(std::string name) : Component(std::move(name)) {};
 
 bool operator==(const Camera::point_cloud& lhs, const Camera::point_cloud& rhs) {
     return lhs.mime_type == rhs.mime_type && lhs.pc == rhs.pc;
@@ -282,7 +283,8 @@ bool operator==(const Camera::distortion_parameters& lhs,
 bool operator==(const Camera::properties& lhs, const Camera::properties& rhs) {
     return lhs.supports_pcd == rhs.supports_pcd &&
            lhs.intrinsic_parameters == rhs.intrinsic_parameters &&
-           lhs.distortion_parameters == rhs.distortion_parameters;
+           lhs.distortion_parameters == rhs.distortion_parameters &&
+           lhs.frame_rate == rhs.frame_rate;
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/components/camera.hpp
+++ b/src/viam/sdk/components/camera.hpp
@@ -65,6 +65,9 @@ class Camera : public Component {
 
         /// @brief Contains the mime types the camera supports.
         Camera::mime_types mime_types;
+
+        /// @brief Contains the camera's frame rate.
+        float frame_rate;
     };
 
     /// @struct point_cloud

--- a/src/viam/sdk/components/private/camera_server.cpp
+++ b/src/viam/sdk/components/private/camera_server.cpp
@@ -15,7 +15,7 @@ namespace sdk {
 namespace impl {
 
 CameraServer::CameraServer(std::shared_ptr<ResourceManager> manager)
-    : ResourceServer(std::move(manager)) {};
+    : ResourceServer(std::move(manager)){};
 
 ::grpc::Status CameraServer::DoCommand(::grpc::ServerContext*,
                                        const ::viam::common::v1::DoCommandRequest* request,

--- a/src/viam/sdk/components/private/camera_server.cpp
+++ b/src/viam/sdk/components/private/camera_server.cpp
@@ -15,7 +15,7 @@ namespace sdk {
 namespace impl {
 
 CameraServer::CameraServer(std::shared_ptr<ResourceManager> manager)
-    : ResourceServer(std::move(manager)){};
+    : ResourceServer(std::move(manager)) {};
 
 ::grpc::Status CameraServer::DoCommand(::grpc::ServerContext*,
                                        const ::viam::common::v1::DoCommandRequest* request,
@@ -114,6 +114,7 @@ CameraServer::CameraServer(std::shared_ptr<ResourceManager> manager)
         *response->mutable_intrinsic_parameters() =
             Camera::to_proto(properties.intrinsic_parameters);
         response->set_supports_pcd(properties.supports_pcd);
+        response->set_frame_rate(properties.frame_rate);
     });
 }
 

--- a/src/viam/sdk/tests/mocks/camera_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.cpp
@@ -96,6 +96,7 @@ Camera::properties fake_properties() {
     properties.intrinsic_parameters = fake_intrinsic_parameters();
     properties.distortion_parameters = fake_distortion_parameters();
     properties.mime_types = fake_mime_types();
+    properties.frame_rate = 10.0;
     return properties;
 }
 


### PR DESCRIPTION
- Added support for mapping `frame_rate` from the GetPropertiesResponse proto to the Camera::properties struct in `Camera::from_proto `
- Added `frame_rate` to properties struct 
- Added `frame_rate` to `getPropertiesResponse` func in camera_server.cpp 
- Added `frame_rate` to fake_properties in camera_mocks.cpp to test 