### PR TITLE
build docker base images in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,5 +24,6 @@ jobs:
       with:
         context: .
         push: true
-        tags: ${{ inputs.image }}:${{ inputs.tag }}
+        tags: "${{ inputs.image }}:${{ inputs.tag }}"
+        file: etc/docker/base-images/${{ inputs.dockerfile }}
         labels: ${{ steps.meta.output.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,12 +1,25 @@
 on:
   workflow_dispatch:
     inputs:
-      image:
-        default: ghcr.io/viamrobotics/cpp-base
+      image-prefix:
+        description: "gets suffixed with 'base' and 'sdk' to create actual image name"
+        default: ghcr.io/viamrobotics/cpp-
       dockerfile:
         default: Dockerfile.debian.bullseye
       tag:
         default: bullseye-amd64
+      build-base:
+        description: "whether to build the base image. the base images change less often and may not be necessary to rebuild."
+        type: boolean
+        default: false
+      build-sdk:
+        description: "whether to build the SDK image. if this is true and no corresponding base image exists, the job will fail."
+        type: boolean
+        default: false
+      push:
+        description: "whether to push the images after building them"
+        type: boolean
+        default: false
 
 jobs:
   build-container:
@@ -16,14 +29,33 @@ jobs:
       packages: write
     steps:
     - uses: actions/checkout@v4
+
+    # build base (if inputs.build-base)
     - uses: docker/metadata-action@v5
-      id: meta
+      id: base-meta
+      if: inputs.build-base
       with:
-        images: ${{ inputs.image }}
+        images: ${{ inputs.image-prefix }}base
     - uses: docker/build-push-action@v5
+      if: inputs.build-base
       with:
-        context: .
-        push: true
-        tags: "${{ inputs.image }}:${{ inputs.tag }}"
+        push: ${{ inputs.push }}
+        tags: "${{ inputs.image-prefix }}base:${{ inputs.tag }}"
         file: etc/docker/base-images/${{ inputs.dockerfile }}
-        labels: ${{ steps.meta.output.labels }}
+        labels: ${{ steps.base-meta.output.labels }}
+
+    # build sdk (if inputs.build-sdk)
+    - uses: docker/metadata-action@v5
+      id: sdk-meta
+      if: inputs.build-sdk
+      with:
+        images: ${{ inputs.image-prefix }}sdk
+    - uses: docker/build-push-action@v5
+      if: inputs.build-sdk
+      with:
+        build-args: |
+          BASE_TAG=${{ inputs.image-prefix }}base:${{ inputs.tag }}
+        push: ${{ inputs.push }}
+        tags: "${{ inputs.image-prefix }}sdk:${{ inputs.tag }}"
+        file: etc/docker/Dockerfile.sdk-build
+        labels: ${{ steps.sdk-meta.output.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,28 @@
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        default: ghcr.io/viamrobotics/cpp-base
+      dockerfile:
+        default: Dockerfile.debian.bullseye
+      tag:
+        default: bullseye-amd64
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@v4
+    - uses: docker/metadata-action@v5
+      id: meta
+      with:
+        images: ${{ inputs.image }}
+    - uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: ${{ inputs.image }}:${{ inputs.tag }}
+        labels: ${{ steps.meta.output.labels }}


### PR DESCRIPTION
## What changed
- add CI yaml for uploading the docker base images to ghcr
## Why
Allow people to use these without having to build them on-laptop
## Note
Github CI requires a workflow to be on the main branch before it can be tested; this hasn't been tested and may require another PR. (Once the workflow has ever been on the main branch, it can then be run from other branches).