### PR TITLE
use docker base image in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     # build base (if inputs.build-base)
     - uses: docker/metadata-action@v5
       id: base-meta

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,26 +1,24 @@
 name: cpp-linter
 
-on: pull_request
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   cpp-linter:
     if: github.repository_owner == 'viamrobotics'
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64
+    container: ghcr.io/viamrobotics/cpp-base:bullseye-amd64
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: install clang-format
-        run: sudo apt install -y clang-format
       - name: verify no uncommitted changes
         run: |
           git init
           git add .
-          chown -R testbot .
-          sudo -u testbot bash -lc 'sh ./bin/run-clang-format.sh'
+          ./bin/run-clang-format.sh
           GEN_DIFF=$(git status -s)
 
           if [ -n "$GEN_DIFF" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,7 @@ jobs:
   run-tests:
     if: github.repository_owner == 'viamrobotics'
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64
+    container: ghcr.io/viamrobotics/cpp-base:bullseye-amd64
     strategy:
       matrix:
         include:
@@ -17,20 +16,20 @@ jobs:
           - BUILD_SHARED: OFF
     steps:
       - uses: actions/checkout@v4
-      ###########################################
-      #     necessary installs for building     #
-      ###########################################
-      - name: build-docker-test
+      - name: cmake
         run: |
-          docker build -t cpp . -f etc/docker/base-images/Dockerfile.debian.bullseye
-          docker build -t cpp-test . -f etc/docker/Dockerfile.sdk-build \
-            --build-arg BASE_TAG=cpp \
-            --build-arg REPO_SETUP=copy \
-            --build-arg BUILD_SHARED=${{ matrix.BUILD_SHARED }} \
-            --build-arg BUILD_TESTS=ON \
-            --build-arg BUILD_EXAMPLES=ON \
-            --build-arg "EXTRA_CMAKE_ARGS=\
-              -DVIAMCPPSDK_CLANG_TIDY=ON \
-              -DVIAMCPPSDK_SANITIZED_BUILD=${{ matrix.BUILD_SHARED }}"
-
-          docker run -w /viam-cpp-sdk/build -t --entrypoint /viam-cpp-sdk/etc/docker/tests/run_test.sh cpp-test /bin/bash
+          mkdir build
+          cd build
+          cmake .. -G Ninja \
+            -DBUILD_SHARED_LIBS=${{ matrix.BUILD_SHARED }} \
+            -DVIAMCPPSDK_OFFLINE_PROTO_GENERATION=ON \
+            -DVIAMCPPSDK_BUILD_TESTS=ON \
+            -DVIAMCPPSDK_BUILD_EXAMPLES=ON \
+            -DVIAMCPPSDK_CLANG_TIDY=ON \
+            -DVIAMCPPSDK_SANITIZED_BUILD=${{ matrix.BUILD_SHARED }}
+      - name: build
+        run: |
+          cmake --build build --target install
+          cmake --install build
+      - name: test
+        run: etc/docker/tests/run_test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,4 +36,5 @@ jobs:
           cmake --build build --target install
           cmake --install build
       - name: test
+        working-directory: build
         run: etc/docker/tests/run_test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,10 @@ name: Test
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      clang-tidy:
+        type: boolean
+        default: true
 
 jobs:
   run-tests:
@@ -25,7 +29,7 @@ jobs:
             -DVIAMCPPSDK_OFFLINE_PROTO_GENERATION=ON \
             -DVIAMCPPSDK_BUILD_TESTS=ON \
             -DVIAMCPPSDK_BUILD_EXAMPLES=ON \
-            -DVIAMCPPSDK_CLANG_TIDY=ON \
+            -DVIAMCPPSDK_CLANG_TIDY=${{ inputs.clang-tidy && 'ON' || 'OFF' }} \
             -DVIAMCPPSDK_SANITIZED_BUILD=${{ matrix.BUILD_SHARED }}
       - name: build
         run: |

--- a/etc/docker/base-images/Dockerfile.debian.bookworm
+++ b/etc/docker/base-images/Dockerfile.debian.bookworm
@@ -41,4 +41,5 @@ RUN apt-get update
 
 RUN apt-get -y --no-install-recommends install -t llvm-toolchain-bookworm-15 \
     clang-15 \
-    clang-tidy-15
+    clang-tidy-15 \
+    clang-format

--- a/etc/docker/base-images/Dockerfile.debian.bullseye
+++ b/etc/docker/base-images/Dockerfile.debian.bullseye
@@ -39,7 +39,8 @@ RUN apt-get update
 
 RUN apt-get -y --no-install-recommends install -t llvm-toolchain-bullseye-15 \
     clang-15 \
-    clang-tidy-15
+    clang-tidy-15 \
+    clang-format
 
 RUN apt-get -y --no-install-recommends install -t bullseye-backports \
     cmake

--- a/etc/docker/base-images/Dockerfile.debian.bullseye
+++ b/etc/docker/base-images/Dockerfile.debian.bullseye
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-ENV HOME /root
+ENV HOME=/root
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update

--- a/etc/docker/base-images/Dockerfile.debian.sid
+++ b/etc/docker/base-images/Dockerfile.debian.sid
@@ -41,4 +41,5 @@ RUN apt-get update
 
 RUN apt-get -y --no-install-recommends install -t llvm-toolchain-15 \
     clang-15 \
-    clang-tidy-15
+    clang-tidy-15 \
+    clang-format

--- a/etc/docker/base-images/Dockerfile.ubuntu.focal
+++ b/etc/docker/base-images/Dockerfile.ubuntu.focal
@@ -42,7 +42,8 @@ RUN apt-get update
 
 RUN apt-get -y --no-install-recommends install -t llvm-toolchain-focal-15 \
     clang-15 \
-    clang-tidy-15
+    clang-tidy-15 \
+    clang-format
 
 RUN apt-get -y install cmake
 

--- a/etc/docker/base-images/Dockerfile.ubuntu.jammy
+++ b/etc/docker/base-images/Dockerfile.ubuntu.jammy
@@ -42,6 +42,7 @@ RUN apt-get update
 
 RUN apt-get -y --no-install-recommends install -t llvm-toolchain-jammy-15 \
     clang-15 \
-    clang-tidy-15
+    clang-tidy-15 \
+    clang-format
 
 RUN apt-get -y install cmake


### PR DESCRIPTION
## What changed
- consume prebuilt base image in test.yml rather than building every time
- split test.yml build + test into separate steps (so the location of errors is clearer)
- incidental: add clang-format to base image
## Follow-up work
- scheduled rebuilds of base image
## Sample run
https://github.com/viamrobotics/viam-cpp-sdk/actions/runs/11903253787