### PR TITLE
RSDK-6574: Fix use of `time_point`

### DIFF
--- a/src/viam/sdk/common/utils.cpp
+++ b/src/viam/sdk/common/utils.cpp
@@ -40,7 +40,7 @@ time_pt timestamp_to_time_pt(const google::protobuf::Timestamp& timestamp) {
 google::protobuf::Timestamp time_pt_to_timestamp(time_pt tp) {
     const std::chrono::nanoseconds since_epoch = tp.time_since_epoch();
 
-    const auto sec_floor = std::chrono::floor<std::chrono::seconds>(since_epoch);
+    const auto sec_floor = std::chrono::duration_cast<std::chrono::seconds>(since_epoch);
     const std::chrono::nanoseconds nano_part = since_epoch - sec_floor;
 
     google::protobuf::Timestamp result;

--- a/src/viam/sdk/common/utils.hpp
+++ b/src/viam/sdk/common/utils.hpp
@@ -18,8 +18,10 @@ const std::string kService = "service";
 const std::string kRDK = "rdk";
 const std::string kBuiltin = "builtin";
 
+using time_pt = std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>;
+
 struct response_metadata {
-    std::chrono::time_point<long long, std::chrono::nanoseconds> captured_at;
+    time_pt captured_at;
 
     static response_metadata from_proto(const viam::common::v1::ResponseMetadata& proto);
     static viam::common::v1::ResponseMetadata to_proto(const response_metadata& metadata);
@@ -27,21 +29,17 @@ struct response_metadata {
 
 bool operator==(const response_metadata& lhs, const response_metadata& rhs);
 
-/// @brief convert a google::protobuf::Timestamp to
-/// std::chrono::time_point<long long, std::chrono::nanoseconds>
-std::chrono::time_point<long long, std::chrono::nanoseconds> timestamp_to_time_pt(
-    const google::protobuf::Timestamp& timestamp);
+/// @brief convert a google::protobuf::Timestamp to time_point
+time_pt timestamp_to_time_pt(const google::protobuf::Timestamp& timestamp);
 
-/// @brief convert a std::chrono::time_point<long long, std::chrono::nanoseconds> to
-/// a google::protobuf::Timestamp.
-google::protobuf::Timestamp time_pt_to_timestamp(
-    const std::chrono::time_point<long long, std::chrono::nanoseconds>& time_pt);
+/// @brief convert a time_point to a google::protobuf::Timestamp.
+google::protobuf::Timestamp time_pt_to_timestamp(time_pt);
 
 std::vector<unsigned char> string_to_bytes(std::string const& s);
 std::string bytes_to_string(std::vector<unsigned char> const& b);
 
 std::chrono::microseconds from_proto(const google::protobuf::Duration& proto);
-google::protobuf::Duration to_proto(const std::chrono::microseconds& duration);
+google::protobuf::Duration to_proto(std::chrono::microseconds duration);
 
 // the authority on a grpc::ClientContext is sometimes set to an invalid uri on mac, causing
 // `rust-utils` to fail to process gRPC requests. This class provides a convenience wrapper around a

--- a/src/viam/sdk/common/utils.hpp
+++ b/src/viam/sdk/common/utils.hpp
@@ -29,10 +29,10 @@ struct response_metadata {
 
 bool operator==(const response_metadata& lhs, const response_metadata& rhs);
 
-/// @brief convert a google::protobuf::Timestamp to time_point
+/// @brief convert a google::protobuf::Timestamp to time_pt
 time_pt timestamp_to_time_pt(const google::protobuf::Timestamp& timestamp);
 
-/// @brief convert a time_point to a google::protobuf::Timestamp.
+/// @brief convert a time_pt to a google::protobuf::Timestamp.
 google::protobuf::Timestamp time_pt_to_timestamp(time_pt);
 
 std::vector<unsigned char> string_to_bytes(std::string const& s);

--- a/src/viam/sdk/robot/client.hpp
+++ b/src/viam/sdk/robot/client.hpp
@@ -57,9 +57,7 @@ class RobotClient {
     struct status {
         boost::optional<Name> name;
         ProtoStruct status_map;
-        // TODO: RSDK-6574: revisit time_point
-        boost::optional<std::chrono::time_point<long long, std::chrono::nanoseconds>>
-            last_reconfigured;
+        boost::optional<time_pt> last_reconfigured;
         friend bool operator==(const status& lhs, const status& rhs);
     };
 
@@ -68,8 +66,7 @@ class RobotClient {
         std::string method;
         boost::optional<std::string> session_id;
         ProtoStruct arguments;
-        // TODO: RSDK-6574: revisit time_point
-        boost::optional<std::chrono::time_point<long long, std::chrono::nanoseconds>> started;
+        boost::optional<time_pt> started;
         friend bool operator==(const operation& lhs, const operation& rhs);
     };
 

--- a/src/viam/sdk/services/motion.hpp
+++ b/src/viam/sdk/services/motion.hpp
@@ -85,7 +85,7 @@ class Motion : public Service {
         plan_state state;
 
         /// @brief The time the executing plan transitioned to the state.
-        std::chrono::time_point<long long, std::chrono::nanoseconds> timestamp;
+        time_pt timestamp;
 
         /// @brief The reason for the state change. The error message if the plan failed, or the
         /// re-plan reason if re-planning was necessary.

--- a/src/viam/sdk/tests/mocks/camera_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.cpp
@@ -56,8 +56,8 @@ Camera::image_collection fake_raw_images() {
     std::chrono::seconds seconds(12345);
     std::chrono::nanoseconds nanos(0);
     collection.images = images;
-    collection.metadata.captured_at = std::chrono::time_point<long long, std::chrono::nanoseconds>(
-        std::chrono::duration_cast<std::chrono::system_clock::duration>(seconds) + nanos);
+    collection.metadata.captured_at =
+        time_pt{std::chrono::duration_cast<std::chrono::system_clock::duration>(seconds) + nanos};
     return collection;
 }
 

--- a/src/viam/sdk/tests/mocks/mock_motion.cpp
+++ b/src/viam/sdk/tests/mocks/mock_motion.cpp
@@ -135,9 +135,8 @@ pose_in_frame fake_pose() {
 }
 
 Motion::plan_status MockMotion::fake_plan_status() {
-    return {Motion::plan_state::k_succeeded,
-            std::chrono::time_point<long long, std::chrono::nanoseconds>::max(),
-            boost::optional<std::string>("reason")};
+    return {
+        Motion::plan_state::k_succeeded, time_pt::max(), boost::optional<std::string>("reason")};
 }
 
 Motion::plan_status_with_id MockMotion::fake_plan_status_with_id() {


### PR DESCRIPTION
Fixes the incorrect `std::chrono::time_point` type used throughout the SDK. I have opted to call this `viam::sdk::time_pt` so as not to create name clashes with `time_point` for anyone doing `using namespace std::chrono`. 