### PR TITLE
RSDK-9549: Make RpcSubtype model api ResourceRPCSubtype

### DIFF
--- a/src/viam/examples/modules/simple/client.cpp
+++ b/src/viam/examples/modules/simple/client.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <memory>
 #include <string>
 

--- a/src/viam/sdk/common/exception.hpp
+++ b/src/viam/sdk/common/exception.hpp
@@ -3,8 +3,10 @@
 /// @brief Defines custom exceptions for the SDK.
 #pragma once
 #include <grpcpp/support/status.h>
+
 #include <stdexcept>
 #include <string>
+#include <system_error>
 
 #include <viam/sdk/resource/resource_api.hpp>
 

--- a/src/viam/sdk/config/resource.cpp
+++ b/src/viam/sdk/config/resource.cpp
@@ -95,19 +95,19 @@ const ProtoStruct& ResourceConfig::attributes() const {
 void ResourceConfig::fix_api() {
     if (this->api_.type_namespace().empty() && this->namespace__.empty()) {
         this->namespace__ = kRDK;
-        this->api_.set_namespace(kRDK);
+        this->api_.namespace_ = kRDK;
     } else if (this->api_.type_namespace().empty()) {
-        this->api_.set_namespace(this->namespace__);
+        api_.namespace_ = namespace__;
     } else {
         this->namespace__ = this->api_.type_namespace();
     }
 
     if (this->api_.resource_type().empty()) {
-        this->api_.set_resource_type(kComponent);
+        api_.resource_type_ = kComponent;
     }
 
     if (this->api_.resource_subtype().empty()) {
-        this->api_.set_resource_subtype(this->type_);
+        api_.resource_subtype_ = this->type_;
     } else if (this->type_.empty()) {
         this->type_ = this->api_.resource_subtype();
     }

--- a/src/viam/sdk/module/handler_map.cpp
+++ b/src/viam/sdk/module/handler_map.cpp
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include <boost/log/trivial.hpp>
-#include <google/protobuf/descriptor.h>
 
 #include <viam/api/common/v1/common.pb.h>
 #include <viam/api/module/v1/module.pb.h>
@@ -62,14 +61,11 @@ HandlerMap_ from_proto<module::v1::HandlerMap>::operator()(
     for (const auto& handler : handlers) {
         const viam::common::v1::ResourceName name = handler.subtype().subtype();
         const API api(name.namespace_(), name.type(), name.subtype());
-        const google::protobuf::DescriptorPool* pool =
-            google::protobuf::DescriptorPool::generated_pool();
-        const google::protobuf::ServiceDescriptor* sd = pool->FindServiceByName(name.type());
-        const RPCSubtype handle(api, *sd);
+        const RPCSubtype handle(api);
         for (const auto& mod : handler.models()) {
             try {
                 hm.add_model(Model::from_str(mod), handle);
-            } catch (const std::exception& ex) {  // NOLINT
+            } catch (const std::exception& ex) {
                 BOOST_LOG_TRIVIAL(error) << "Error " << ex.what() << " processing model " + mod;
             }
         }

--- a/src/viam/sdk/module/handler_map.cpp
+++ b/src/viam/sdk/module/handler_map.cpp
@@ -14,37 +14,52 @@
 namespace viam {
 namespace sdk {
 
-viam::module::v1::HandlerMap HandlerMap_::to_proto() const {
-    viam::module::v1::HandlerMap proto;
-    for (const auto& h : this->handles_) {
+void HandlerMap_::add_model(Model model, const RPCSubtype& subtype) {
+    handles_[subtype].push_back(std::move(model));
+}
+
+const std::unordered_map<RPCSubtype, std::vector<Model>>& HandlerMap_::handles() const {
+    return handles_;
+}
+
+std::ostream& operator<<(std::ostream& os, const HandlerMap_& hm) {
+    for (const auto& kv : hm.handles()) {
+        os << "API: " << kv.first.api().to_string() << '\n';
+        for (const Model& model : kv.second) {
+            os << "\tModel: " << model.to_string() << '\n';
+        }
+    }
+    return os;
+}
+
+namespace proto_convert_details {
+
+void to_proto<HandlerMap_>::operator()(const HandlerMap_& self,
+                                       module::v1::HandlerMap* proto) const {
+    for (const auto& h : self.handles()) {
         viam::module::v1::HandlerDefinition hd;
         for (const auto& model : h.second) {
-            const std::string m = model.to_string();
-            *hd.mutable_models()->Add() = m;
+            *hd.mutable_models()->Add() = model.to_string();
         }
+
         viam::robot::v1::ResourceRPCSubtype rpc_subtype;
-        const Name name(h.first.api(), "", "");
-        const viam::common::v1::ResourceName resource_name = v2::to_proto(name);
-        *rpc_subtype.mutable_subtype() = resource_name;
+
+        *rpc_subtype.mutable_subtype() = v2::to_proto(Name(h.first.api(), "", ""));
         *rpc_subtype.mutable_proto_service() = h.first.proto_service_name();
         *hd.mutable_subtype() = rpc_subtype;
-        *proto.add_handlers() = hd;
+
+        *proto->add_handlers() = hd;
     }
+}
 
-    return proto;
-};
-
-HandlerMap_::HandlerMap_() {}
-
-// NOLINTNEXTLINE(readability-const-return-type)
-const HandlerMap_ HandlerMap_::from_proto(const viam::module::v1::HandlerMap& proto) {
+HandlerMap_ from_proto<module::v1::HandlerMap>::operator()(
+    const module::v1::HandlerMap* proto) const {
     HandlerMap_ hm;
 
     const google::protobuf::RepeatedPtrField<viam::module::v1::HandlerDefinition>& handlers =
-        proto.handlers();
+        proto->handlers();
 
     for (const auto& handler : handlers) {
-        std::vector<Model> models;
         const viam::common::v1::ResourceName name = handler.subtype().subtype();
         const API api(name.namespace_(), name.type(), name.subtype());
         const google::protobuf::DescriptorPool* pool =
@@ -53,31 +68,17 @@ const HandlerMap_ HandlerMap_::from_proto(const viam::module::v1::HandlerMap& pr
         const RPCSubtype handle(api, *sd);
         for (const auto& mod : handler.models()) {
             try {
-                const Model model = Model::from_str(mod);
-                models.push_back(model);
-            } catch (std::string error) {  // NOLINT
-                BOOST_LOG_TRIVIAL(error) << "Error processing model " + mod;
+                hm.add_model(Model::from_str(mod), handle);
+            } catch (const std::exception& ex) {  // NOLINT
+                BOOST_LOG_TRIVIAL(error) << "Error " << ex.what() << " processing model " + mod;
             }
         }
-        hm.handles_.emplace(handle, models);
     }
 
     return hm;
 }
 
-void HandlerMap_::add_model(Model model, const RPCSubtype& subtype) {
-    handles_[subtype].push_back(std::move(model));
-}
-
-std::ostream& operator<<(std::ostream& os, const HandlerMap_& hm) {
-    for (const auto& kv : hm.handles_) {
-        os << "API: " << kv.first.api().to_string() << '\n';
-        for (const Model& model : kv.second) {
-            os << "\tModel: " << model.to_string() << '\n';
-        }
-    }
-    return os;
-}
+}  // namespace proto_convert_details
 
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/module/handler_map.hpp
+++ b/src/viam/sdk/module/handler_map.hpp
@@ -1,24 +1,47 @@
 #pragma once
 
-#include <viam/api/module/v1/module.pb.h>
-
+#include <viam/sdk/common/proto_convert.hpp>
 #include <viam/sdk/resource/resource.hpp>
+
+namespace viam {
+namespace module {
+namespace v1 {
+
+class HandlerMap;
+
+}
+}  // namespace module
+}  // namespace viam
 
 namespace viam {
 namespace sdk {
 
 class HandlerMap_ {
    public:
-    HandlerMap_();
+    HandlerMap_() = default;
+
     void add_model(Model model, const RPCSubtype& subtype);
 
-    viam::module::v1::HandlerMap to_proto() const;
-    static const HandlerMap_ from_proto(const viam::module::v1::HandlerMap& proto);
-    friend std::ostream& operator<<(std::ostream& os, const HandlerMap_& hm);
+    const std::unordered_map<RPCSubtype, std::vector<Model>>& handles() const;
 
    private:
     std::unordered_map<RPCSubtype, std::vector<Model>> handles_;
 };
 
+std::ostream& operator<<(std::ostream& os, const HandlerMap_& hm);
+
+namespace proto_convert_details {
+
+template <>
+struct to_proto<HandlerMap_> {
+    void operator()(const HandlerMap_&, module::v1::HandlerMap*) const;
+};
+
+template <>
+struct from_proto<module::v1::HandlerMap> {
+    HandlerMap_ operator()(const module::v1::HandlerMap*) const;
+};
+
+}  // namespace proto_convert_details
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -180,7 +180,7 @@ struct ModuleService::ServiceImpl : viam::module::v1::ModuleService::Service {
                          const ::viam::module::v1::ReadyRequest* request,
                          ::viam::module::v1::ReadyResponse* response) override {
         const std::lock_guard<std::mutex> lock(parent.lock_);
-        const viam::module::v1::HandlerMap hm = parent.module_->handles().to_proto();
+        const viam::module::v1::HandlerMap hm = v2::to_proto(parent.module_->handles());
         *response->mutable_handlermap() = hm;
         parent.parent_addr_ = request->parent_address();
         response->set_ready(parent.module_->ready());

--- a/src/viam/sdk/module/service.hpp
+++ b/src/viam/sdk/module/service.hpp
@@ -8,6 +8,15 @@
 #include <viam/sdk/resource/resource.hpp>
 #include <viam/sdk/rpc/server.hpp>
 
+namespace google {
+namespace protobuf {
+
+template <typename>
+class RepeatedPtrField;
+
+}  // namespace protobuf
+}  // namespace google
+
 namespace viam {
 namespace sdk {
 
@@ -51,7 +60,7 @@ class ModuleService {
     friend ModuleService::ServiceImpl;
 
     void add_model_from_registry_inlock_(API api, Model model, const std::lock_guard<std::mutex>&);
-    Dependencies get_dependencies_(google::protobuf::RepeatedPtrField<std::string> const& proto,
+    Dependencies get_dependencies_(google::protobuf::RepeatedPtrField<std::string> const* proto,
                                    std::string const& resource_name);
     std::shared_ptr<Resource> get_parent_resource_(const Name& name);
 

--- a/src/viam/sdk/resource/resource.cpp
+++ b/src/viam/sdk/resource/resource.cpp
@@ -16,11 +16,10 @@ std::string Resource::name() const {
 }
 
 Name Resource::get_resource_name(const std::string& type) const {
-    auto api_ = api();
-    api_.set_resource_type(type);
-
     auto name_parts = long_name_to_remote_and_short(name_);
-    return {api_, name_parts.first, name_parts.second};
+    return {API(api().type_namespace(), type, api().resource_subtype()),
+            name_parts.first,
+            name_parts.second};
 }
 
 Name Resource::get_resource_name() const {

--- a/src/viam/sdk/resource/resource_api.cpp
+++ b/src/viam/sdk/resource/resource_api.cpp
@@ -165,25 +165,24 @@ std::ostream& operator<<(std::ostream& os, const Name& v) {
     return os;
 }
 
+bool operator<(const RPCSubtype& lhs, const RPCSubtype& rhs) {
+    return std::tie(lhs.api(), lhs.proto_service_name()) <
+           std::tie(rhs.api(), rhs.proto_service_name());
+}
+
 bool operator==(const RPCSubtype& lhs, const RPCSubtype& rhs) {
-    return lhs.api_.to_string() == rhs.api_.to_string() &&
-           lhs.proto_service_name_ == rhs.proto_service_name_ &&
-           lhs.descriptor_.DebugString() == rhs.descriptor_.DebugString();
+    return std::tie(lhs.api(), lhs.proto_service_name()) ==
+           std::tie(rhs.api(), rhs.proto_service_name());
 }
 
 bool operator==(const Model& lhs, const Model& rhs) {
     return lhs.to_string() == rhs.to_string();
 }
 
-RPCSubtype::RPCSubtype(API api,
-                       std::string proto_service_name,
-                       const google::protobuf::ServiceDescriptor& descriptor)
-    : descriptor_(descriptor),
-      proto_service_name_(std::move(proto_service_name)),
-      api_(std::move(api)) {}
+RPCSubtype::RPCSubtype(API api, std::string proto_service_name)
+    : api_(std::move(api)), proto_service_name_(std::move(proto_service_name)) {}
 
-RPCSubtype::RPCSubtype(API api, const google::protobuf::ServiceDescriptor& descriptor)
-    : descriptor_(descriptor), api_(std::move(api)) {}
+RPCSubtype::RPCSubtype(API api) : api_(std::move(api)) {}
 
 const std::string& RPCSubtype::proto_service_name() const {
     return proto_service_name_;

--- a/src/viam/sdk/resource/resource_api.hpp
+++ b/src/viam/sdk/resource/resource_api.hpp
@@ -2,8 +2,6 @@
 
 #include <string>
 
-#include <google/protobuf/descriptor.h>
-
 #include <viam/sdk/common/proto_convert.hpp>
 
 namespace viam {
@@ -99,23 +97,18 @@ struct from_proto<common::v1::ResourceName> {
 
 class RPCSubtype {
    public:
-    bool operator<(const RPCSubtype& rhs) const {
-        return (api_.to_string() + proto_service_name_ + descriptor_.DebugString()) <
-               (rhs.api_.to_string() + rhs.proto_service_name_ + rhs.descriptor_.DebugString());
-    };
-    const std::string& proto_service_name() const;
-    const API& api() const;
+    RPCSubtype(API api);
+    RPCSubtype(API api, std::string proto_service_name);
 
-    RPCSubtype(API api, const google::protobuf::ServiceDescriptor& descriptor);
-    RPCSubtype(API api,
-               std::string proto_service_name,
-               const google::protobuf::ServiceDescriptor& descriptor);
+    const API& api() const;
+    const std::string& proto_service_name() const;
+
     friend bool operator==(const RPCSubtype& lhs, const RPCSubtype& rhs);
+    friend bool operator<(const RPCSubtype& lhs, const RPCSubtype& rhs);
 
    private:
-    const google::protobuf::ServiceDescriptor& descriptor_;
-    std::string proto_service_name_;
     API api_;
+    std::string proto_service_name_;
 };
 
 class ModelFamily {

--- a/src/viam/sdk/resource/resource_api.hpp
+++ b/src/viam/sdk/resource/resource_api.hpp
@@ -19,45 +19,29 @@ class ResourceName;
 namespace viam {
 namespace sdk {
 
-/// @class APIType
-/// @brief Defines a resource's namespace (e.g., `RDK`) and type (e.g., component or service).
-class APIType {
-   public:
-    APIType() = default;
-    APIType(std::string namespace_, std::string resource_type);
-
-    virtual std::string to_string() const;
-
-    const std::string& type_namespace() const;
-    const std::string& resource_type() const;
-
-    void set_namespace(const std::string& type_namespace);
-    void set_resource_type(const std::string& resource_type);
-
-   private:
-    std::string namespace_;
-    std::string resource_type_;
-};
-
 /// @class API
-/// @brief Extends `APIType` to additionally define a resource's subtype (e.g., `camera`).
-// TODO: Maybe just merge these two classes or at least use composition rather than inheritance
-class API : public APIType {
+class API {
    public:
+    // Choosing to make this a friend rather than exposing public setters for everyone.
+    friend class ResourceConfig;
+
     static API from_string(std::string api);
 
     API() = default;
     API(std::string namespace_, std::string resource_type, std::string resource_subtype);
-    API(APIType type, std::string resource_subtype);
 
-    virtual std::string to_string() const override;
+    std::string to_string() const;
 
+    const std::string& type_namespace() const;
+    const std::string& resource_type() const;
     const std::string& resource_subtype() const;
-    void set_resource_subtype(const std::string& subtype);
+
     bool is_component_type();
     bool is_service_type();
+
     friend bool operator==(API const& lhs, API const& rhs);
     friend bool operator<(const API& lhs, const API& rhs);
+
     friend std::ostream& operator<<(std::ostream& os, const API& v);
 
     template <typename T>
@@ -69,6 +53,8 @@ class API : public APIType {
     }
 
    private:
+    std::string namespace_;
+    std::string resource_type_;
     std::string resource_subtype_;
 };
 

--- a/src/viam/sdk/tests/test_resource.cpp
+++ b/src/viam/sdk/tests/test_resource.cpp
@@ -26,12 +26,9 @@ using google::protobuf::Struct;
 using google::protobuf::Value;
 
 BOOST_AUTO_TEST_CASE(test_api) {
-    API api1;
-    api1.set_namespace("ns");
+    API api1("ns", "component", "st");
     BOOST_CHECK_EQUAL(api1.type_namespace(), "ns");
-    api1.set_resource_type("component");
     BOOST_CHECK_EQUAL(api1.resource_type(), "component");
-    api1.set_resource_subtype("st");
     BOOST_CHECK_EQUAL(api1.resource_subtype(), "st");
     BOOST_CHECK_EQUAL(api1.to_string(), "ns:component:st");
     BOOST_CHECK(!api1.is_service_type());


### PR DESCRIPTION
Changes the implementation of an SDK type to more closely model its corresponding API type. Note that handler_map.cpp contains what is more or less the to_proto and from_proto of RPCSubtype, so we remove the ServiceDescriptor member.

The comparison operators in this and some other classes have been optimized to not construct a concatenated string every time they're called

Also includes some drive-by changes for domino-effect missing includes, minor cleanups, etc 

Per @stuqdog we're not sure why RPCSubtype originally had a ServiceDescriptor member--it seems its only use was in using the DebugString to implement `operator<` to make RPCSubtype usable as a `map` key. I'm not sure what tests if any will exercise that this is still behaving as expected or if we know why this might have been implemented that way in the first place, cc @acmorrow for any ideas or sugestions