### PR TITLE
RSDK-9719: Simple module sensor

### DIFF
--- a/src/viam/examples/modules/simple/client.cpp
+++ b/src/viam/examples/modules/simple/client.cpp
@@ -3,9 +3,9 @@
 #include <string>
 
 #include <viam/sdk/common/proto_value.hpp>
+#include <viam/sdk/components/sensor.hpp>
 #include <viam/sdk/robot/client.hpp>
 #include <viam/sdk/rpc/dial.hpp>
-#include <viam/sdk/services/generic.hpp>
 
 using namespace viam::sdk;
 
@@ -33,18 +33,34 @@ int main() {
         std::cout << "\t" << resource << "\n";
     }
 
-    // Exercise printer methods
-    auto printer = robot->resource_by_name<GenericService>("printer1");
-    if (!printer) {
-        std::cerr << "could not get 'printer1' resource from robot\n";
+    // Exercise sensor methods
+    auto sensor = robot->resource_by_name<Sensor>("mysensor");
+    if (!sensor) {
+        std::cerr << "could not get 'mysensor' resource from robot\n";
         return EXIT_FAILURE;
     }
 
     ProtoStruct command{{"hello", "world"}};
-    ProtoStruct resp = printer->do_command(command);
+    ProtoStruct resp = sensor->do_command(command);
 
     if (command != resp) {
         std::cerr << "Got unexpected result from 'printer1'\n";
+        return EXIT_FAILURE;
+    }
+
+    ProtoStruct readings = sensor->get_readings();
+
+    auto itr = readings.find("signal");
+    if (itr == readings.end()) {
+        std::cerr << "Expected signal not found in sensor readings\n";
+        return EXIT_FAILURE;
+    }
+
+    const double* signal = itr->second.get<double>();
+    if (signal) {
+        std::cout << "\t" << itr->first << ": " << *signal << "\n";
+    } else {
+        std::cerr << "Unexpected value type for sensor reading\n";
         return EXIT_FAILURE;
     }
 

--- a/src/viam/examples/modules/simple/main.cpp
+++ b/src/viam/examples/modules/simple/main.cpp
@@ -2,11 +2,11 @@
 #include <memory>
 #include <sstream>
 
-#include <boost/log/trivial.hpp>
+#include <viam/sdk/components/sensor.hpp>
+#include <viam/sdk/config/resource.hpp>
 
 #include <viam/sdk/common/exception.hpp>
 #include <viam/sdk/common/proto_value.hpp>
-#include <viam/sdk/config/resource.hpp>
 #include <viam/sdk/module/module.hpp>
 #include <viam/sdk/module/service.hpp>
 #include <viam/sdk/registry/registry.hpp>
@@ -14,78 +14,77 @@
 #include <viam/sdk/resource/resource.hpp>
 #include <viam/sdk/rpc/dial.hpp>
 #include <viam/sdk/rpc/server.hpp>
-#include <viam/sdk/services/generic.hpp>
-#include <viam/sdk/services/service.hpp>
 
 using namespace viam::sdk;
 
-// Printer is a modular resource that can print a to_print value to STDOUT when
-// a DoCommand request is received or when reconfiguring. The to_print value
-// must be provided as an attribute in the config.
-class Printer : public GenericService, public Reconfigurable {
+class MySensor : public Sensor, public Reconfigurable {
    public:
-    void reconfigure(const Dependencies& deps, const ResourceConfig& cfg) {
-        std::cout << "Printer " << Resource::name() << " is reconfiguring" << std::endl;
-        for (auto& dep : deps) {
-            std::cout << "dependency: " << dep.first.to_string() << std::endl;
-        }
-        to_print_ = find_to_print(cfg);
-        std::cout << "Printer " << Resource::name() << " will now print " << to_print_ << std::endl;
+    MySensor(const ResourceConfig& cfg) : Sensor(cfg.name()) {
+        this->reconfigure({}, cfg);
     }
 
-    Printer(Dependencies deps, ResourceConfig cfg) : GenericService(cfg.name()) {
-        std::cout << "Creating Printer " + Resource::name() << std::endl;
-        to_print_ = find_to_print(cfg);
-        std::cout << "Printer " << Resource::name() << " will print " << to_print_ << std::endl;
+    static std::vector<std::string> validate(const ResourceConfig&);
+
+    void reconfigure(const Dependencies&, const ResourceConfig&) override;
+
+    ProtoStruct do_command(const ProtoStruct&) override;
+
+    std::vector<GeometryConfig> get_geometries(const ProtoStruct&) override {
+        throw Exception("method not supported");
     }
 
-    ProtoStruct do_command(const ProtoStruct& command) {
-        std::cout << "Received DoCommand request for Printer " << Resource::name() << std::endl;
-        std::cout << "Printer " << Resource::name() << " has printed " << to_print_ << std::endl;
-        return command;
-    }
-
-    static std::string find_to_print(ResourceConfig cfg) {
-        auto& printer_name = cfg.name();
-        auto to_print = cfg.attributes().find("to_print");
-        if (to_print == cfg.attributes().end()) {
-            std::ostringstream buffer;
-            buffer << printer_name << ": Required parameter `to_print` not found in configuration";
-            throw std::invalid_argument(buffer.str());
-        }
-        const auto* const to_print_string = to_print->second.get<std::string>();
-        if (!to_print_string || to_print_string->empty()) {
-            std::ostringstream buffer;
-            buffer << printer_name
-                   << ": Required non-empty string parameter `to_print` is either not a string "
-                      "or is an empty string";
-            throw std::invalid_argument(buffer.str());
-        }
-        return *to_print_string;
-    }
+    ProtoStruct get_readings(const ProtoStruct&) override;
 
    private:
-    std::string to_print_;
+    double multiplier_{1.0};
 };
 
+std::vector<std::string> MySensor::validate(const ResourceConfig& cfg) {
+    auto itr = cfg.attributes().find("multiplier");
+    if (itr != cfg.attributes().end()) {
+        const double* multiplier = itr->second.get<double>();
+        if (!multiplier) {
+            throw Exception("multiplier must be a number value");
+        }
+
+        if (*multiplier == 0.0) {
+            throw Exception("multiplier cannot be zero");
+        }
+    }
+
+    return {};
+}
+
+void MySensor::reconfigure(const Dependencies&, const ResourceConfig& cfg) {
+    auto itr = cfg.attributes().find("multiplier");
+    if (itr != cfg.attributes().end()) {
+        const double* multiplier = itr->second.get<double>();
+        if (multiplier) {
+            multiplier_ = *multiplier;
+        }
+    }
+}
+
+ProtoStruct MySensor::do_command(const ProtoStruct& command) {
+    for (const auto& entry : command) {
+        std::cout << "Command entry " << entry.first;
+    }
+
+    return command;
+}
+
+ProtoStruct MySensor::get_readings(const ProtoStruct&) {
+    return {{"signal", multiplier_}};
+}
+
 int main(int argc, char** argv) try {
-    API generic = API::get<GenericService>();
-    Model m("viam", "generic", "printer");
+    Model mysensor_model("viam", "sensor", "mysensor");
 
     std::shared_ptr<ModelRegistration> mr = std::make_shared<ModelRegistration>(
-        generic,
-        m,
-        [](Dependencies deps, ResourceConfig cfg) { return std::make_unique<Printer>(deps, cfg); },
-        // Custom validation can be done by specifying a validate function like
-        // this one. Validate functions can `throw` exceptions that will be
-        // returned to the parent through gRPC. Validate functions can also return
-        // a vector of strings representing the implicit dependencies of the resource.
-        [](ResourceConfig cfg) -> std::vector<std::string> {
-            // find_to_print will throw an error if the `to_print` attribute
-            // is missing, is not a string or is an empty string.
-            Printer::find_to_print(cfg);
-            return {};
-        });
+        API::get<Sensor>(),
+        mysensor_model,
+        [](Dependencies, ResourceConfig cfg) { return std::make_unique<MySensor>(cfg); },
+        &MySensor::validate);
 
     std::vector<std::shared_ptr<ModelRegistration>> mrs = {mr};
     auto my_mod = std::make_shared<ModuleService>(argc, argv, mrs);

--- a/src/viam/examples/modules/simple/main.cpp
+++ b/src/viam/examples/modules/simple/main.cpp
@@ -2,18 +2,13 @@
 #include <memory>
 #include <sstream>
 
-#include <viam/sdk/components/sensor.hpp>
-#include <viam/sdk/config/resource.hpp>
-
 #include <viam/sdk/common/exception.hpp>
 #include <viam/sdk/common/proto_value.hpp>
-#include <viam/sdk/module/module.hpp>
+#include <viam/sdk/components/sensor.hpp>
+#include <viam/sdk/config/resource.hpp>
 #include <viam/sdk/module/service.hpp>
 #include <viam/sdk/registry/registry.hpp>
 #include <viam/sdk/resource/reconfigurable.hpp>
-#include <viam/sdk/resource/resource.hpp>
-#include <viam/sdk/rpc/dial.hpp>
-#include <viam/sdk/rpc/server.hpp>
 
 using namespace viam::sdk;
 

--- a/src/viam/examples/modules/simple/main.cpp
+++ b/src/viam/examples/modules/simple/main.cpp
@@ -17,6 +17,8 @@
 
 using namespace viam::sdk;
 
+// Implements a trivial sensor component, constructed with a ResourceConfig that specifies a
+// "multiplier" value which is then returned as the only sensor reading.
 class MySensor : public Sensor, public Reconfigurable {
    public:
     MySensor(const ResourceConfig& cfg) : Sensor(cfg.name()) {


### PR DESCRIPTION
Replaces the prior "simple" module example with one that just implements a Sensor component, in line with eg Python SDK https://github.com/viamrobotics/viam-python-sdk/tree/main/examples/simple_module

