### PR TITLE
[RSDK-9624] Add discovery service

### DIFF
--- a/bin/run-clang-format.sh
+++ b/bin/run-clang-format.sh
@@ -14,4 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Check if clang-format is installed
+if ! command -v clang-format >/dev/null 2>&1; then
+    echo "Error: clang-format is not installed"
+    echo "Please install it using: brew install clang-format"
+    exit 1
+fi
+
 find ./src -not -path "./src/viam/api" -type f \( -name \*.cpp -o -name \*.hpp \) | xargs clang-format -style=file -i -fallback-style=none "$@"

--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -306,8 +306,6 @@ target_sources(viamapi
     ${PROTO_GEN_DIR}/component/encoder/v1/encoder.pb.cc
     ${PROTO_GEN_DIR}/component/gantry/v1/gantry.grpc.pb.cc
     ${PROTO_GEN_DIR}/component/gantry/v1/gantry.pb.cc
-    ${PROTO_GEN_DIR}/component/discovery/v1/discovery.grpc.pb.cc
-    ${PROTO_GEN_DIR}/component/discovery/v1/discovery.pb.cc
     ${PROTO_GEN_DIR}/component/generic/v1/generic.grpc.pb.cc
     ${PROTO_GEN_DIR}/component/generic/v1/generic.pb.cc
     ${PROTO_GEN_DIR}/component/gripper/v1/gripper.grpc.pb.cc
@@ -332,6 +330,8 @@ target_sources(viamapi
     ${PROTO_GEN_DIR}/module/v1/module.pb.cc
     ${PROTO_GEN_DIR}/robot/v1/robot.grpc.pb.cc
     ${PROTO_GEN_DIR}/robot/v1/robot.pb.cc
+    ${PROTO_GEN_DIR}/service/discovery/v1/discovery.grpc.pb.cc
+    ${PROTO_GEN_DIR}/service/discovery/v1/discovery.pb.cc
     ${PROTO_GEN_DIR}/service/generic/v1/generic.grpc.pb.cc
     ${PROTO_GEN_DIR}/service/generic/v1/generic.pb.cc
     ${PROTO_GEN_DIR}/service/mlmodel/v1/mlmodel.grpc.pb.cc
@@ -366,8 +366,6 @@ target_sources(viamapi
       ${PROTO_GEN_DIR}/../../viam/api/component/encoder/v1/encoder.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/gantry/v1/gantry.grpc.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/gantry/v1/gantry.pb.h
-      ${PROTO_GEN_DIR}/../../viam/api/component/discovery/v1/discovery.grpc.pb.h
-      ${PROTO_GEN_DIR}/../../viam/api/component/discovery/v1/discovery.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/generic/v1/generic.grpc.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/generic/v1/generic.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/gripper/v1/gripper.grpc.pb.h
@@ -393,6 +391,8 @@ target_sources(viamapi
       ${PROTO_GEN_DIR}/../../viam/api/robot/v1/robot.grpc.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/robot/v1/robot.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/tagger/v1/tagger.grpc.pb.h
+      ${PROTO_GEN_DIR}/../../viam/api/service/discovery/v1/discovery.grpc.pb.h
+      ${PROTO_GEN_DIR}/../../viam/api/service/discovery/v1/discovery.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/service/generic/v1/generic.grpc.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/service/generic/v1/generic.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/service/mlmodel/v1/mlmodel.grpc.pb.h

--- a/src/viam/api/CMakeLists.txt
+++ b/src/viam/api/CMakeLists.txt
@@ -213,6 +213,10 @@ if (VIAMCPPSDK_USE_DYNAMIC_PROTOS)
     ${PROTO_GEN_DIR}/robot/v1/robot.grpc.pb.h
     ${PROTO_GEN_DIR}/robot/v1/robot.pb.cc
     ${PROTO_GEN_DIR}/robot/v1/robot.pb.h
+    ${PROTO_GEN_DIR}/service/discovery/v1/discovery.grpc.pb.cc
+    ${PROTO_GEN_DIR}/service/discovery/v1/discovery.grpc.pb.h
+    ${PROTO_GEN_DIR}/service/discovery/v1/discovery.pb.cc
+    ${PROTO_GEN_DIR}/service/discovery/v1/discovery.pb.h
     ${PROTO_GEN_DIR}/service/generic/v1/generic.grpc.pb.cc
     ${PROTO_GEN_DIR}/service/generic/v1/generic.grpc.pb.h
     ${PROTO_GEN_DIR}/service/generic/v1/generic.pb.cc
@@ -302,6 +306,8 @@ target_sources(viamapi
     ${PROTO_GEN_DIR}/component/encoder/v1/encoder.pb.cc
     ${PROTO_GEN_DIR}/component/gantry/v1/gantry.grpc.pb.cc
     ${PROTO_GEN_DIR}/component/gantry/v1/gantry.pb.cc
+    ${PROTO_GEN_DIR}/component/discovery/v1/discovery.grpc.pb.cc
+    ${PROTO_GEN_DIR}/component/discovery/v1/discovery.pb.cc
     ${PROTO_GEN_DIR}/component/generic/v1/generic.grpc.pb.cc
     ${PROTO_GEN_DIR}/component/generic/v1/generic.pb.cc
     ${PROTO_GEN_DIR}/component/gripper/v1/gripper.grpc.pb.cc
@@ -360,6 +366,8 @@ target_sources(viamapi
       ${PROTO_GEN_DIR}/../../viam/api/component/encoder/v1/encoder.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/gantry/v1/gantry.grpc.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/gantry/v1/gantry.pb.h
+      ${PROTO_GEN_DIR}/../../viam/api/component/discovery/v1/discovery.grpc.pb.h
+      ${PROTO_GEN_DIR}/../../viam/api/component/discovery/v1/discovery.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/generic/v1/generic.grpc.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/generic/v1/generic.pb.h
       ${PROTO_GEN_DIR}/../../viam/api/component/gripper/v1/gripper.grpc.pb.h

--- a/src/viam/examples/modules/complex/proto/buf.lock
+++ b/src/viam/examples/modules/complex/proto/buf.lock
@@ -4,5 +4,5 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: e93e34f48be043dab55be31b4b47f458
-    digest: shake256:93dbe51c27606999eef918360df509485a4d272e79aaed6d0016940379a9b06d316fc5228b7b50cca94bb310f34c5fc5955ce7474f655f0d0a224c4121dda3c1
+    commit: 546238c53f7340c6a2a6099fb863bc1b
+    digest: shake256:8d75c12f391e392b24c076d05117b47aeddb090add99c70247a8f4389b906a65f61a933c68e54ed8b73a050b967b6b712ba194348b67c3ab3ee26cc2cb25852c

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -118,10 +118,13 @@ target_sources(viamsdk
     rpc/dial.cpp
     rpc/server.cpp
     rpc/private/viam_grpc_channel.cpp
+    services/discovery.cpp
     services/generic.cpp
     services/mlmodel.cpp
     services/motion.cpp
     services/navigation.cpp
+    services/private/discovery_client.cpp
+    services/private/discovery_server.cpp
     services/private/generic_client.cpp
     services/private/generic_server.cpp
     services/private/mlmodel.cpp
@@ -181,6 +184,7 @@ target_sources(viamsdk
       ../../viam/sdk/rpc/dial.hpp
       ../../viam/sdk/rpc/message_sizes.hpp
       ../../viam/sdk/rpc/server.hpp
+      ../../viam/sdk/services/discovery.hpp
       ../../viam/sdk/services/generic.hpp
       ../../viam/sdk/services/mlmodel.hpp
       ../../viam/sdk/services/motion.hpp

--- a/src/viam/sdk/config/resource.cpp
+++ b/src/viam/sdk/config/resource.cpp
@@ -8,6 +8,7 @@
 
 #include <viam/api/app/v1/robot.pb.h>
 #include <viam/api/robot/v1/robot.pb.h>
+#include <viam/api/service/discovery/v1/discovery.pb.h>
 
 #include <viam/sdk/common/exception.hpp>
 #include <viam/sdk/common/private/repeated_ptr_convert.hpp>
@@ -154,6 +155,12 @@ ResourceConfig from_proto_impl<app::v1::ComponentConfig>::operator()(
                           proto->api(),
                           Model::from_str(proto->model()),
                           proto->has_frame() ? from_proto(proto->frame()) : LinkConfig{});
+}
+
+std::vector<ResourceConfig>
+from_proto_impl<service::discovery::v1::DiscoverResourcesResponse>::operator()(
+    const service::discovery::v1::DiscoverResourcesResponse* proto) const {
+    return impl::from_repeated_field(proto->discoveries());
 }
 
 }  // namespace proto_convert_details

--- a/src/viam/sdk/config/resource.hpp
+++ b/src/viam/sdk/config/resource.hpp
@@ -17,6 +17,15 @@ class ResourceLevelServiceConfig;
 
 }  // namespace v1
 }  // namespace app
+
+namespace service {
+namespace discovery {
+namespace v1 {
+
+class DiscoverResourcesResponse;
+}
+}  // namespace discovery
+}  // namespace service
 }  // namespace viam
 
 namespace viam {
@@ -81,6 +90,12 @@ struct to_proto_impl<ResourceConfig> {
 template <>
 struct from_proto_impl<app::v1::ComponentConfig> {
     ResourceConfig operator()(const app::v1::ComponentConfig*) const;
+};
+
+template <>
+struct from_proto_impl<service::discovery::v1::DiscoverResourcesResponse> {
+    std::vector<ResourceConfig> operator()(
+        const service::discovery::v1::DiscoverResourcesResponse*) const;
 };
 
 }  // namespace proto_convert_details

--- a/src/viam/sdk/registry/registry.cpp
+++ b/src/viam/sdk/registry/registry.cpp
@@ -43,7 +43,7 @@
 #include <viam/sdk/resource/resource.hpp>
 #include <viam/sdk/resource/resource_api.hpp>
 #include <viam/sdk/services/private/discovery_client.hpp>
-#include <viam/sdk/services/private/discovery_service.hpp>
+#include <viam/sdk/services/private/discovery_server.hpp>
 #include <viam/sdk/services/private/generic_client.hpp>
 #include <viam/sdk/services/private/generic_server.hpp>
 #include <viam/sdk/services/private/mlmodel_client.hpp>

--- a/src/viam/sdk/registry/registry.cpp
+++ b/src/viam/sdk/registry/registry.cpp
@@ -42,6 +42,8 @@
 #include <viam/sdk/components/private/servo_server.hpp>
 #include <viam/sdk/resource/resource.hpp>
 #include <viam/sdk/resource/resource_api.hpp>
+#include <viam/sdk/services/private/discovery_client.hpp>
+#include <viam/sdk/services/private/discovery_service.hpp>
 #include <viam/sdk/services/private/generic_client.hpp>
 #include <viam/sdk/services/private/generic_server.hpp>
 #include <viam/sdk/services/private/mlmodel_client.hpp>
@@ -202,6 +204,7 @@ void register_resources() {
     Registry::register_resource<impl::ServoClient, impl::ServoServer>();
 
     // Register all services
+    Registry::register_resource<impl::DiscoveryClient, impl::DiscoveryServer>();
     Registry::register_resource<impl::GenericServiceClient, impl::GenericServiceServer>();
     Registry::register_resource<impl::MLModelServiceClient, impl::MLModelServiceServer>();
     Registry::register_resource<impl::MotionClient, impl::MotionServer>();

--- a/src/viam/sdk/services/discovery.cpp
+++ b/src/viam/sdk/services/discovery.cpp
@@ -11,7 +11,7 @@ API Discovery::api() const {
     return API::get<Discovery>();
 }
 
-API::traits<Discovery>::api() {
+API API::traits<Discovery>::api() {
     return {kRDK, kService, "discovery"};
 }
 

--- a/src/viam/sdk/services/discovery.cpp
+++ b/src/viam/sdk/services/discovery.cpp
@@ -1,0 +1,17 @@
+#include <viam/sdk/services/discovery.hpp>
+
+namespace viam {
+namespace sdk {
+
+API Discovery::api() const {
+    return API::get<Discovery>();
+}
+
+API::traits<Discovery>::api() {
+    return {kRDK, kService, "discovery"};
+}
+
+Discovery::Discovery(std::string name) : Service(std::move(name)) {}
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/services/discovery.cpp
+++ b/src/viam/sdk/services/discovery.cpp
@@ -1,7 +1,11 @@
 #include <viam/sdk/services/discovery.hpp>
 
+#include <viam/sdk/common/utils.hpp>
+
 namespace viam {
 namespace sdk {
+
+Discovery::Discovery(std::string name) : Service(std::move(name)) {}
 
 API Discovery::api() const {
     return API::get<Discovery>();
@@ -10,8 +14,6 @@ API Discovery::api() const {
 API::traits<Discovery>::api() {
     return {kRDK, kService, "discovery"};
 }
-
-Discovery::Discovery(std::string name) : Service(std::move(name)) {}
 
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/services/discovery.hpp
+++ b/src/viam/sdk/services/discovery.hpp
@@ -27,12 +27,16 @@ class Discovery : public Service {
    public:
     /// @brief Discover valid viam configuration of resources that are physically
     /// connected to your machine.
+    /// @ingroup Discovery
     inline std::vector<ResourceConfig> discover_resources() {
         return discover_resources({});
     }
 
     /// @brief Discover valid viam configuration of resources that are physically
     /// connected to your machine.
+    /// @param extra Any additional arguments to the method.
+    /// @return array of potential viam configurations for hardware physically
+    // connected to your viam server
     virtual std::vector<ResourceConfig> discover_resources(const ProtoStruct& extra) = 0;
 
     /// @brief Do an arbitrary command.

--- a/src/viam/sdk/services/discovery.hpp
+++ b/src/viam/sdk/services/discovery.hpp
@@ -27,7 +27,8 @@ class Discovery : public Service {
    public:
     /// @brief Discover valid viam configuration of resources that are physically
     /// connected to your machine.
-    /// @ingroup Discovery
+    /// @return array of potential viam configurations for hardware physically
+    /// connected to your viam server
     inline std::vector<ResourceConfig> discover_resources() {
         return discover_resources({});
     }

--- a/src/viam/sdk/services/discovery.hpp
+++ b/src/viam/sdk/services/discovery.hpp
@@ -6,7 +6,9 @@
 
 #include <string>
 
+#include <viam/sdk/common/utils.hpp>
 #include <viam/sdk/config/resource.hpp>
+#include <viam/sdk/services/service.hpp>
 
 namespace viam {
 namespace sdk {

--- a/src/viam/sdk/services/discovery.hpp
+++ b/src/viam/sdk/services/discovery.hpp
@@ -14,25 +14,24 @@ namespace sdk {
 /// @defgroup Discovery Classes related to the Discovery service.
 
 /// @class Discovery discovery.hpp "services/discovery.hpp"
-/// @brief A `Discovery` service is used to discover resources that are physically connected to your machine.
-/// @ingroup Discovery 
+/// @brief A `Discovery` service is used to discover resources that are physically connected to
+/// your machine.
+/// @ingroup Discovery
 ///
 /// This acts as an abstract parent class to be inherited from by any drivers representing
 /// specific discovery implementations. This class cannot be used on its own.
 
 class Discovery : public Service {
    public:
-
     /// @brief Discover valid viam configuration of resources that are physically
     /// connected to your machine.
     inline std::vector<ResourceConfig> discover_resources() {
-        return discover_resources({})
+        return discover_resources({});
     }
 
-    /// @brief Discover valid viam configuration of resources that are physically 
-    /// connected to your machine. 
-    virtual std::vector<ResourceConfig> discover_resources(
-        const ProtoStruct& extra) = 0;
+    /// @brief Discover valid viam configuration of resources that are physically
+    /// connected to your machine.
+    virtual std::vector<ResourceConfig> discover_resources(const ProtoStruct& extra) = 0;
 
     /// @brief Do an arbitrary command.
     /// @param command Freeform fields that are service-specific.
@@ -45,9 +44,8 @@ class Discovery : public Service {
     explicit Discovery(std::string name);
 };
 
-
 template <>
-struct API::traits<Navigation> {
+struct API::traits<Discovery> {
     static API api();
 };
 

--- a/src/viam/sdk/services/discovery.hpp
+++ b/src/viam/sdk/services/discovery.hpp
@@ -1,0 +1,55 @@
+/// @file services/discovery.hpp
+///
+/// @brief Defines a `Discovery` service.
+
+#pragma once
+
+#include <string>
+
+#include <viam/sdk/config/resource.hpp>
+
+namespace viam {
+namespace sdk {
+
+/// @defgroup Discovery Classes related to the Discovery service.
+
+/// @class Discovery discovery.hpp "services/discovery.hpp"
+/// @brief A `Discovery` service is used to discover resources that are physically connected to your machine.
+/// @ingroup Discovery 
+///
+/// This acts as an abstract parent class to be inherited from by any drivers representing
+/// specific discovery implementations. This class cannot be used on its own.
+
+class Discovery : public Service {
+   public:
+
+    /// @brief Discover valid viam configuration of resources that are physically
+    /// connected to your machine.
+    inline std::vector<ResourceConfig> discover_resources() {
+        return discover_resources({})
+    }
+
+    /// @brief Discover valid viam configuration of resources that are physically 
+    /// connected to your machine. 
+    virtual std::vector<ResourceConfig> discover_resources(
+        const ProtoStruct& extra) = 0;
+
+    /// @brief Do an arbitrary command.
+    /// @param command Freeform fields that are service-specific.
+    /// @return Freeform result of the command.
+    virtual ProtoStruct do_command(const ProtoStruct& command) = 0;
+
+    API api() const override;
+
+   protected:
+    explicit Discovery(std::string name);
+};
+
+
+template <>
+struct API::traits<Navigation> {
+    static API api();
+};
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/services/discovery.hpp
+++ b/src/viam/sdk/services/discovery.hpp
@@ -22,7 +22,6 @@ namespace sdk {
 ///
 /// This acts as an abstract parent class to be inherited from by any drivers representing
 /// specific discovery implementations. This class cannot be used on its own.
-
 class Discovery : public Service {
    public:
     /// @brief Discover valid viam configuration of resources that are physically

--- a/src/viam/sdk/services/private/discovery_client.cpp
+++ b/src/viam/sdk/services/private/discovery_client.cpp
@@ -1,0 +1,34 @@
+#include <viam/sdk/services/private/discovery_client.hpp> 
+
+#include <viam/api/service/discovery/v1/discovery.grpc.pb.h>
+#include <viam/api/service/discovery/v1/discovery.pb.h>
+
+#include <viam/sdk/common/client_helper.hpp>
+
+namespace viam {
+namespace sdk {
+namespace impl {
+
+DiscoveryClient::DiscoveryClient(std::string name std::shared_ptr<grpc::Channel> channel)
+        : Discovery(std::move(name)), 
+          stub_(viam::service::discovery::v1::DiscoveryService::NewStub(channel)),
+          channel_(std::move(channel)) {}
+ 
+std::vector<ResourceConfig> DiscoveryClient::discover_resources(const ProtoStruct& extra) {
+    return make_client_helper(this, *stub_, &StubType::DiscoverResources)
+        .with(extra)
+        .invoke([](auto& response) {return from_proto(response);});
+}
+
+ProtoStruct DiscoveryClient::do_command(const ProtoStruct& extra) {
+    return make_client_helper(this, *stub_, &StubType::DoCommand)
+        .with([&](auto& request) {*request.mutable_command() = to_proto(command); })
+        .invoke([](auto& response) {return from_proto(response.result());});
+}
+
+
+} // namespace impl
+
+
+} //namespace sdk
+} //namespace viam

--- a/src/viam/sdk/services/private/discovery_client.cpp
+++ b/src/viam/sdk/services/private/discovery_client.cpp
@@ -4,12 +4,16 @@
 #include <viam/api/service/discovery/v1/discovery.pb.h>
 
 #include <viam/sdk/common/client_helper.hpp>
+#include <viam/sdk/common/private/repeated_ptr_convert.hpp>
+#include <viam/sdk/common/proto_value.hpp>
+#include <viam/sdk/common/utils.hpp>
+#include <viam/sdk/services/discovery.hpp>
 
 namespace viam {
 namespace sdk {
 namespace impl {
 
-DiscoveryClient::DiscoveryClient(std::string name std::shared_ptr<grpc::Channel> channel)
+DiscoveryClient::DiscoveryClient(std::string name, std::shared_ptr<grpc::Channel> channel)
     : Discovery(std::move(name)),
       stub_(viam::service::discovery::v1::DiscoveryService::NewStub(channel)),
       channel_(std::move(channel)) {}
@@ -20,7 +24,7 @@ std::vector<ResourceConfig> DiscoveryClient::discover_resources(const ProtoStruc
         .invoke([](auto& response) { return from_proto(response); });
 }
 
-ProtoStruct DiscoveryClient::do_command(const ProtoStruct& extra) {
+ProtoStruct DiscoveryClient::do_command(const ProtoStruct& command) {
     return make_client_helper(this, *stub_, &StubType::DoCommand)
         .with([&](auto& request) { *request.mutable_command() = to_proto(command); })
         .invoke([](auto& response) { return from_proto(response.result()); });

--- a/src/viam/sdk/services/private/discovery_client.cpp
+++ b/src/viam/sdk/services/private/discovery_client.cpp
@@ -1,4 +1,4 @@
-#include <viam/sdk/services/private/discovery_client.hpp> 
+#include <viam/sdk/services/private/discovery_client.hpp>
 
 #include <viam/api/service/discovery/v1/discovery.grpc.pb.h>
 #include <viam/api/service/discovery/v1/discovery.pb.h>
@@ -10,25 +10,22 @@ namespace sdk {
 namespace impl {
 
 DiscoveryClient::DiscoveryClient(std::string name std::shared_ptr<grpc::Channel> channel)
-        : Discovery(std::move(name)), 
-          stub_(viam::service::discovery::v1::DiscoveryService::NewStub(channel)),
-          channel_(std::move(channel)) {}
- 
+    : Discovery(std::move(name)),
+      stub_(viam::service::discovery::v1::DiscoveryService::NewStub(channel)),
+      channel_(std::move(channel)) {}
+
 std::vector<ResourceConfig> DiscoveryClient::discover_resources(const ProtoStruct& extra) {
     return make_client_helper(this, *stub_, &StubType::DiscoverResources)
         .with(extra)
-        .invoke([](auto& response) {return from_proto(response);});
+        .invoke([](auto& response) { return from_proto(response); });
 }
 
 ProtoStruct DiscoveryClient::do_command(const ProtoStruct& extra) {
     return make_client_helper(this, *stub_, &StubType::DoCommand)
-        .with([&](auto& request) {*request.mutable_command() = to_proto(command); })
-        .invoke([](auto& response) {return from_proto(response.result());});
+        .with([&](auto& request) { *request.mutable_command() = to_proto(command); })
+        .invoke([](auto& response) { return from_proto(response.result()); });
 }
 
-
-} // namespace impl
-
-
-} //namespace sdk
-} //namespace viam
+}  // namespace impl
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/services/private/discovery_client.hpp
+++ b/src/viam/sdk/services/private/discovery_client.hpp
@@ -1,0 +1,39 @@
+/// @file services/private/discovery_client.hpp
+///
+/// @brief Implements a gRPC client for the `Discovery` service
+#pragma once
+
+#include <grpcpp/channel.h>
+
+#include <viam/api/service/discovery/v1/discovery.grpc.pb.h>
+
+#include <viam/sdk/services/discovery.hpp>
+
+namespace viam {
+namespace sdk {
+namespace impl {
+
+/// @class DiscoveryClient
+/// @brief gRPC client implementation of a `Discovery` service.
+/// @ingroup Discovery
+class DiscoveryClient : public Discovery {
+   public:
+    using interface_type = Discovery;
+    DiscoveryClient(std::string name, std::shared_ptr<grpc::Channel> channel);
+
+    std::vector<ResourceConfig> discover_resources(const ProtoStruct& extra) override;
+    ProtoStruct do_command(const ProtoStruct& command) override;
+
+    // Using declarations to introduce convenience overloads of interface which do not need to be
+    // passed the ProtoStruct parameter.
+    using Discovery::discover_resources;
+
+   private:
+    using StubType = viam::service::discovery::v1::DiscoveryService::StubInterface;
+    std::unique_ptr<StubType> stub_;
+    std::shared_ptr<grpc::Channel> channel_;
+};
+
+} // namespace impl
+} // namespace sdk
+} // namespace viam

--- a/src/viam/sdk/services/private/discovery_client.hpp
+++ b/src/viam/sdk/services/private/discovery_client.hpp
@@ -24,10 +24,6 @@ class DiscoveryClient : public Discovery {
     std::vector<ResourceConfig> discover_resources(const ProtoStruct& extra) override;
     ProtoStruct do_command(const ProtoStruct& command) override;
 
-    // Using declarations to introduce convenience overloads of interface which do not need to be
-    // passed the ProtoStruct parameter.
-    using Discovery::discover_resources;
-
    private:
     using StubType = viam::service::discovery::v1::DiscoveryService::StubInterface;
     std::unique_ptr<StubType> stub_;

--- a/src/viam/sdk/services/private/discovery_client.hpp
+++ b/src/viam/sdk/services/private/discovery_client.hpp
@@ -34,6 +34,6 @@ class DiscoveryClient : public Discovery {
     std::shared_ptr<grpc::Channel> channel_;
 };
 
-} // namespace impl
-} // namespace sdk
-} // namespace viam
+}  // namespace impl
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/services/private/discovery_server.cpp
+++ b/src/viam/sdk/services/private/discovery_server.cpp
@@ -1,0 +1,38 @@
+#include <viam/sdk/services/private/discovery_client.hpp>
+
+#include <viam/sdk/common/service_helper.hpp>
+
+namespace viam {
+namespace sdk {
+namespace impl {
+
+DiscoveryServer::DiscoveryServer(std::shared_ptr<ResourceManager> manager)
+    : ResourceServer(std::move(manager)) {}
+
+::grpc::Status DiscoveryServer::DiscoverResources(
+    ::grpc::ServerContext*,
+    const ::viam::service::discovery::v1::DiscoverResourcesRequest* request,
+    ::viam::service::discovery::v1::DiscoverResourcesResponse* response) noexcept {
+    return make_service_helper<Discovery>(
+        "DiscoveryServer::DiscoverResources", this, request)([&](auto& helper, auto& discovery) {
+        const std::vector<ResourceConfig> resources = discovery->discover_resources(helper.getExtra());
+        for (const auto& resource : resources) {
+            *response->mutable_resources()->Add() = to_proto(resource);
+        }
+    });
+}
+
+::grpc::Status DiscoveryServer::DoCommand(
+    ::grpc::ServerContext*,
+    const ::viam::service::discovery::v1::DoCommandRequest* request,
+    ::viam::service::discovery::v1::DoCommandResponse* response) noexcept {
+    return make_service_helper<Discovery>(
+        "DiscoveryServer::DoCommand", this, request)([&](auto& helper, auto& discovery) {
+        const ProtoStruct result = discovery->do_command(from_proto(request->command()));
+        *response->mutable_result() = to_proto(result);
+    });
+} 
+
+} // namespace impl
+} // namespace sdk
+} // namespace viam

--- a/src/viam/sdk/services/private/discovery_server.cpp
+++ b/src/viam/sdk/services/private/discovery_server.cpp
@@ -21,7 +21,7 @@ using namespace service::discovery::v1;
         const std::vector<ResourceConfig> resources =
             discovery->discover_resources(helper.getExtra());
         for (const auto& resource : resources) {
-            *response->mutable_resources()->Add() = to_proto(resource);
+            *response->mutable_discoveries()->Add() = to_proto(resource);
         }
     });
 }
@@ -31,7 +31,7 @@ using namespace service::discovery::v1;
     const ::viam::common::v1::DoCommandRequest* request,
     ::viam::common::v1::DoCommandResponse* response) noexcept {
     return make_service_helper<Discovery>(
-        "DiscoveryServer::DoCommand", this, request)([&](auto& helper, auto& discovery) {
+        "DiscoveryServer::DoCommand", this, request)([&](auto&, auto& discovery) {
         const ProtoStruct result = discovery->do_command(from_proto(request->command()));
         *response->mutable_result() = to_proto(result);
     });

--- a/src/viam/sdk/services/private/discovery_server.cpp
+++ b/src/viam/sdk/services/private/discovery_server.cpp
@@ -1,13 +1,16 @@
 #include <viam/sdk/services/private/discovery_client.hpp>
 
-#include <viam/sdk/common/service_helper.hpp>
+#include <viam/sdk/common/private/repeated_ptr_convert.hpp>
+#include <viam/sdk/common/private/service_helper.hpp>
+#include <viam/sdk/common/proto_value.hpp>
+#include <viam/sdk/common/utils.hpp>
+#include <viam/sdk/services/private/discovery_server.hpp>
 
 namespace viam {
 namespace sdk {
 namespace impl {
 
-DiscoveryServer::DiscoveryServer(std::shared_ptr<ResourceManager> manager)
-    : ResourceServer(std::move(manager)) {}
+using namespace service::discovery::v1;
 
 ::grpc::Status DiscoveryServer::DiscoverResources(
     ::grpc::ServerContext*,
@@ -25,8 +28,8 @@ DiscoveryServer::DiscoveryServer(std::shared_ptr<ResourceManager> manager)
 
 ::grpc::Status DiscoveryServer::DoCommand(
     ::grpc::ServerContext*,
-    const ::viam::service::discovery::v1::DoCommandRequest* request,
-    ::viam::service::discovery::v1::DoCommandResponse* response) noexcept {
+    const ::viam::common::v1::DoCommandRequest* request,
+    ::viam::common::v1::DoCommandResponse* response) noexcept {
     return make_service_helper<Discovery>(
         "DiscoveryServer::DoCommand", this, request)([&](auto& helper, auto& discovery) {
         const ProtoStruct result = discovery->do_command(from_proto(request->command()));

--- a/src/viam/sdk/services/private/discovery_server.cpp
+++ b/src/viam/sdk/services/private/discovery_server.cpp
@@ -15,7 +15,8 @@ DiscoveryServer::DiscoveryServer(std::shared_ptr<ResourceManager> manager)
     ::viam::service::discovery::v1::DiscoverResourcesResponse* response) noexcept {
     return make_service_helper<Discovery>(
         "DiscoveryServer::DiscoverResources", this, request)([&](auto& helper, auto& discovery) {
-        const std::vector<ResourceConfig> resources = discovery->discover_resources(helper.getExtra());
+        const std::vector<ResourceConfig> resources =
+            discovery->discover_resources(helper.getExtra());
         for (const auto& resource : resources) {
             *response->mutable_resources()->Add() = to_proto(resource);
         }
@@ -31,8 +32,8 @@ DiscoveryServer::DiscoveryServer(std::shared_ptr<ResourceManager> manager)
         const ProtoStruct result = discovery->do_command(from_proto(request->command()));
         *response->mutable_result() = to_proto(result);
     });
-} 
+}
 
-} // namespace impl
-} // namespace sdk
-} // namespace viam
+}  // namespace impl
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/services/private/discovery_server.hpp
+++ b/src/viam/sdk/services/private/discovery_server.hpp
@@ -23,8 +23,8 @@ class DiscoveryServer : public ResourceServer,
    public:
     using interface_type = Discovery;
     using service_type = service::discovery::v1::DiscoveryService;
-
-    explicit DiscoveryServer(std::shared_ptr<ResourceManager> manager);
+    explicit DiscoveryServer(std::shared_ptr<ResourceManager> manager)
+        : ResourceServer(std::move(manager)) {}
 
     ::grpc::Status DiscoverResources(
         ::grpc::ServerContext* context,

--- a/src/viam/sdk/services/private/discovery_server.hpp
+++ b/src/viam/sdk/services/private/discovery_server.hpp
@@ -1,0 +1,42 @@
+/// @file services/private/discovery_server.hpp
+/// 
+/// @brief Implements a gRPC server for the `Discovery` service
+#pragma once
+
+#include <viam/api/service/discovery/v1/discovery.grpc.pb.h>
+#include <viam/api/service/discovery/v1/discovery.pb.h>
+
+#include <viam/sdk/services/discovery.hpp>
+#include <viam/sdk/resource/resource_manager.hpp>
+#include <viam/sdk/resource/resource_server_base.hpp>
+
+namespace viam {
+namespace sdk {
+namespace impl {
+
+/// @class DiscoveryServer
+/// @brief gRPC server implementation of a `Discovery` service.
+/// @ingroup Discovery
+
+class ArmServer : public ResourceServer, public viam::service::discovery::v1::DiscoveryService::Service {
+    public:
+    using interface_type = Discovery;
+    using service_type = service::discovery::v1::DiscoveryService;
+    
+    explicit DiscoveryServer(std::shared_ptr<ResourceManager> manager);
+
+    ::grpc::Status DiscoverResources(
+        ::grpc::ServerContext* context,
+        const ::viam::service::discovery::v1::DiscoverResourcesRequest* request,
+        ::viam::service::discovery::v1::DiscoverResourcesResponse* response) noexcept override;
+
+    ::grpc::Status DoCommand(
+        ::grpc::ServerContext* context,
+        const ::viam::service::discovery::v1::DoCommandRequest* request,
+        ::viam::service::discovery::v1::DoCommandResponse* response) noexcept override;
+
+};
+
+}  // namespace impl
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/services/private/discovery_server.hpp
+++ b/src/viam/sdk/services/private/discovery_server.hpp
@@ -17,7 +17,6 @@ namespace impl {
 /// @class DiscoveryServer
 /// @brief gRPC server implementation of a `Discovery` service.
 /// @ingroup Discovery
-
 class DiscoveryServer : public ResourceServer,
                         public viam::service::discovery::v1::DiscoveryService::Service {
    public:

--- a/src/viam/sdk/services/private/discovery_server.hpp
+++ b/src/viam/sdk/services/private/discovery_server.hpp
@@ -30,11 +30,9 @@ class DiscoveryServer : public ResourceServer,
         ::grpc::ServerContext* context,
         const ::viam::service::discovery::v1::DiscoverResourcesRequest* request,
         ::viam::service::discovery::v1::DiscoverResourcesResponse* response) noexcept override;
-
-    ::grpc::Status DoCommand(
-        ::grpc::ServerContext* context,
-        const ::viam::service::discovery::v1::DoCommandRequest* request,
-        ::viam::service::discovery::v1::DoCommandResponse* response) noexcept override;
+    ::grpc::Status DoCommand(::grpc::ServerContext* context,
+                             const ::viam::common::v1::DoCommandRequest* request,
+                             ::viam::common::v1::DoCommandResponse* response) noexcept override;
 };
 
 }  // namespace impl

--- a/src/viam/sdk/services/private/discovery_server.hpp
+++ b/src/viam/sdk/services/private/discovery_server.hpp
@@ -1,14 +1,14 @@
 /// @file services/private/discovery_server.hpp
-/// 
+///
 /// @brief Implements a gRPC server for the `Discovery` service
 #pragma once
 
 #include <viam/api/service/discovery/v1/discovery.grpc.pb.h>
 #include <viam/api/service/discovery/v1/discovery.pb.h>
 
-#include <viam/sdk/services/discovery.hpp>
 #include <viam/sdk/resource/resource_manager.hpp>
 #include <viam/sdk/resource/resource_server_base.hpp>
+#include <viam/sdk/services/discovery.hpp>
 
 namespace viam {
 namespace sdk {
@@ -18,11 +18,12 @@ namespace impl {
 /// @brief gRPC server implementation of a `Discovery` service.
 /// @ingroup Discovery
 
-class ArmServer : public ResourceServer, public viam::service::discovery::v1::DiscoveryService::Service {
-    public:
+class DiscoveryServer : public ResourceServer,
+                        public viam::service::discovery::v1::DiscoveryService::Service {
+   public:
     using interface_type = Discovery;
     using service_type = service::discovery::v1::DiscoveryService;
-    
+
     explicit DiscoveryServer(std::shared_ptr<ResourceManager> manager);
 
     ::grpc::Status DiscoverResources(
@@ -34,7 +35,6 @@ class ArmServer : public ResourceServer, public viam::service::discovery::v1::Di
         ::grpc::ServerContext* context,
         const ::viam::service::discovery::v1::DoCommandRequest* request,
         ::viam::service::discovery::v1::DoCommandResponse* response) noexcept override;
-
 };
 
 }  // namespace impl

--- a/src/viam/sdk/tests/CMakeLists.txt
+++ b/src/viam/sdk/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(viamsdk_test
     mocks/mock_motor.cpp
     mocks/mock_motion.cpp
     mocks/mock_movement_sensor.cpp
+    mocks/mock_discovery.cpp
     mocks/mock_navigation.cpp
     mocks/mock_pose_tracker.cpp
     mocks/mock_power_sensor.cpp
@@ -56,6 +57,7 @@ viamcppsdk_add_boost_test(test_board.cpp)
 viamcppsdk_add_boost_test(test_camera.cpp)
 viamcppsdk_add_boost_test(test_common.cpp)
 viamcppsdk_add_boost_test(test_encoder.cpp)
+viamcppsdk_add_boost_test(test_discovery.cpp)
 viamcppsdk_add_boost_test(test_gantry.cpp)
 viamcppsdk_add_boost_test(test_gripper.cpp)
 viamcppsdk_add_boost_test(test_generics.cpp)

--- a/src/viam/sdk/tests/mocks/mock_discovery.cpp
+++ b/src/viam/sdk/tests/mocks/mock_discovery.cpp
@@ -7,16 +7,14 @@ namespace viam {
 namespace sdktests {
 namespace discovery {
 
-std::shared_ptr<MockDiscovery> MockDiscovery::get_mock_discovery() {
-    return std::make_shared<MockDiscovery>("mock_discovery");
-}
+MockDiscovery::MockDiscovery(std::string name) : Discovery(std::move(name)) {}
 
 std::vector<sdk::ResourceConfig> MockDiscovery::discover_resources(const sdk::ProtoStruct&) {
-    return fake_resources();
+    return fake_discovered_resources();
 }
 
-sdk::ProtoStruct MockDiscovery::do_command(const sdk::ProtoStruct& command) {
-    return (peek_command = command);
+ProtoStruct MockDiscovery::do_command(const sdk::ProtoStruct& command) {
+    return ProtoStruct{};
 }
 
 }  // namespace discovery

--- a/src/viam/sdk/tests/mocks/mock_discovery.cpp
+++ b/src/viam/sdk/tests/mocks/mock_discovery.cpp
@@ -14,7 +14,7 @@ std::vector<sdk::ResourceConfig> MockDiscovery::discover_resources(const sdk::Pr
 }
 
 ProtoStruct MockDiscovery::do_command(const sdk::ProtoStruct& command) {
-    return ProtoStruct{};
+    return fake_map();
 }
 
 }  // namespace discovery

--- a/src/viam/sdk/tests/mocks/mock_discovery.cpp
+++ b/src/viam/sdk/tests/mocks/mock_discovery.cpp
@@ -1,0 +1,25 @@
+#include <viam/sdk/tests/mocks/mock_discovery.hpp>
+
+#include "mock_discovery.hpp"
+#include <viam/sdk/tests/test_utils.hpp>
+
+namespace viam {
+namespace sdktests {
+namespace discovery {
+
+std::shared_ptr<MockDiscovery> MockDiscovery::get_mock_discovery() {
+    return std::make_shared<MockDiscovery>("mock_discovery");
+}
+
+std::vector<sdk::ResourceConfig> MockDiscovery::discover_resources(const sdk::ProtoStruct&) {
+    return fake_resources();
+}
+
+sdk::ProtoStruct MockDiscovery::do_command(const sdk::ProtoStruct& command) {
+    return (peek_command = command);
+}
+
+
+} // namespace discovery
+} // namespace sdktests
+} // namespace viam

--- a/src/viam/sdk/tests/mocks/mock_discovery.cpp
+++ b/src/viam/sdk/tests/mocks/mock_discovery.cpp
@@ -19,7 +19,6 @@ sdk::ProtoStruct MockDiscovery::do_command(const sdk::ProtoStruct& command) {
     return (peek_command = command);
 }
 
-
-} // namespace discovery
-} // namespace sdktests
-} // namespace viam
+}  // namespace discovery
+}  // namespace sdktests
+}  // namespace viam

--- a/src/viam/sdk/tests/mocks/mock_discovery.hpp
+++ b/src/viam/sdk/tests/mocks/mock_discovery.hpp
@@ -19,7 +19,6 @@ class MockDiscovery : public sdk::Discovery {
     sdk::ProtoStruct peek_command;
 };
 
-} // namespace discovery
-} // namespace sdktests
-} // namespace viam 
-
+}  // namespace discovery
+}  // namespace sdktests
+}  // namespace viam

--- a/src/viam/sdk/tests/mocks/mock_discovery.hpp
+++ b/src/viam/sdk/tests/mocks/mock_discovery.hpp
@@ -8,15 +8,10 @@ namespace discovery {
 
 class MockDiscovery : public sdk::Discovery {
    public:
-    MockDiscovery(std::string name) : Discovery(std::move(name)) {}
+    MockDiscovery(std::string);
 
-    static std::shared_ptr<MockDiscovery> get_mock_discovery();
-
-    std::vector<ResourceConfig> discover_resources(const sdk::ProtoStruct&) override;
+    std::vector<sdk::ResourceConfig> discover_resources(const sdk::ProtoStruct&) override;
     sdk::ProtoStruct do_command(const sdk::ProtoStruct& command) override;
-
-    bool peek_stop_called;
-    sdk::ProtoStruct peek_command;
 };
 
 }  // namespace discovery

--- a/src/viam/sdk/tests/mocks/mock_discovery.hpp
+++ b/src/viam/sdk/tests/mocks/mock_discovery.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <viam/sdk/services/discovery.hpp>
+
+namespace viam {
+namespace sdktests {
+namespace discovery {
+
+class MockDiscovery : public sdk::Discovery {
+   public:
+    MockDiscovery(std::string name) : Discovery(std::move(name)) {}
+
+    static std::shared_ptr<MockDiscovery> get_mock_discovery();
+
+    std::vector<ResourceConfig> discover_resources(const sdk::ProtoStruct&) override;
+    sdk::ProtoStruct do_command(const sdk::ProtoStruct& command) override;
+
+    bool peek_stop_called;
+    sdk::ProtoStruct peek_command;
+};
+
+} // namespace discovery
+} // namespace sdktests
+} // namespace viam 
+

--- a/src/viam/sdk/tests/test_discovery.cpp
+++ b/src/viam/sdk/tests/test_discovery.cpp
@@ -27,8 +27,12 @@ BOOST_AUTO_TEST_CASE(test_discover_resources) {
 BOOST_AUTO_TEST_CASE(test_do_command) {
     auto mock = std::make_shared<MockDiscovery>("mock_discovery");
     client_to_mock_pipeline<Discovery>(mock, [&](Discovery& client) {
-        const auto ret = client.do_command({});
-        BOOST_CHECK_EQUAL(ret.size(), 0);
+        ProtoStruct expected = fake_map();
+
+        ProtoStruct command = fake_map();
+        ProtoStruct result_map = client.do_command(command);
+
+        BOOST_CHECK(result_map.at("test") == expected.at("test"));
     });
 }
 

--- a/src/viam/sdk/tests/test_discovery.cpp
+++ b/src/viam/sdk/tests/test_discovery.cpp
@@ -29,12 +29,12 @@ BOOST_AUTO_TEST_CASE(mock_get_api) {
 BOOST_AUTO_TEST_CASE(test_discover_resources) {
     std::shared_ptr<MockDiscovery> mock = MockDiscovery::get_mock_discovery();
     client_to_mock_pipeline<Discovery>(mock, [](Discovery& client) {
-        const auto & resources = client.discover_resources();
+        const auto& resources = client.discover_resources();
         BOOST_CHECK_EQUAL(resource, fake_discovered_resources());
     });
 }
 
-BOOST_AUTO_TEST_CASE(test_do_command)  {
+BOOST_AUTO_TEST_CASE(test_do_command) {
     std::shared_ptr<MockDiscovery> mock = MockDiscovery::get_mock_discovery();
     client_to_mock_pipeline<Discovery>(mock, [](Discovery& client) {
         ProtoStruct expected = fake_map();
@@ -46,5 +46,5 @@ BOOST_AUTO_TEST_CASE(test_do_command)  {
     });
 }
 
-} // namespace sdktests
-} // namespace viam
+}  // namespace sdktests
+}  // namespace viam

--- a/src/viam/sdk/tests/test_discovery.cpp
+++ b/src/viam/sdk/tests/test_discovery.cpp
@@ -1,0 +1,50 @@
+#define BOOST_TEST_MODULE test module test_discovery
+#include <viam/sdk/components/discovery.hpp>
+
+#include <boost/optional/optional_io.hpp>
+#include <boost/qvm/all.hpp>
+#include <boost/test/included/unit_test.hpp>
+
+#include <viam/sdk/tests/mocks/mock_discovery.hpp>
+#include <viam/sdk/tests/test_utils.hpp>
+
+BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<viam::sdk::ResourceConfig>)
+
+namespace viam {
+namespace sdktests {
+
+using namespace viam::sdk;
+
+BOOST_AUTO_TEST_SUITE(test_discovery)
+
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    const MockDiscovery discovery("mock_discovery");
+    auto api = discovery.api();
+    auto static_api = API::get<Discovery>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "discovery");
+}
+
+BOOST_AUTO_TEST_CASE(test_discover_resources) {
+    std::shared_ptr<MockDiscovery> mock = MockDiscovery::get_mock_discovery();
+    client_to_mock_pipeline<Discovery>(mock, [](Discovery& client) {
+        const auto & resources = client.discover_resources();
+        BOOST_CHECK_EQUAL(resource, fake_discovered_resources());
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_do_command)  {
+    std::shared_ptr<MockDiscovery> mock = MockDiscovery::get_mock_discovery();
+    client_to_mock_pipeline<Discovery>(mock, [](Discovery& client) {
+        ProtoStruct expected = fake_map();
+
+        ProtoStruct command = fake_map();
+        ProtoStruc result_map = client.do_command(command);
+
+        BOOST_CHECK(result.map.at("test") == expected.map.at("test"));
+    });
+}
+
+} // namespace sdktests
+} // namespace viam

--- a/src/viam/sdk/tests/test_discovery.cpp
+++ b/src/viam/sdk/tests/test_discovery.cpp
@@ -1,5 +1,5 @@
 #define BOOST_TEST_MODULE test module test_discovery
-#include <viam/sdk/components/discovery.hpp>
+#include <viam/sdk/services/discovery.hpp>
 
 #include <boost/optional/optional_io.hpp>
 #include <boost/qvm/all.hpp>
@@ -12,39 +12,26 @@ BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<viam::sdk::ResourceConfig>)
 
 namespace viam {
 namespace sdktests {
+namespace discovery {
 
 using namespace viam::sdk;
 
-BOOST_AUTO_TEST_SUITE(test_discovery)
-
-BOOST_AUTO_TEST_CASE(mock_get_api) {
-    const MockDiscovery discovery("mock_discovery");
-    auto api = discovery.api();
-    auto static_api = API::get<Discovery>();
-
-    BOOST_CHECK_EQUAL(api, static_api);
-    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "discovery");
-}
-
 BOOST_AUTO_TEST_CASE(test_discover_resources) {
-    std::shared_ptr<MockDiscovery> mock = MockDiscovery::get_mock_discovery();
+    auto mock = std::make_shared<MockDiscovery>("mock_discovery");
     client_to_mock_pipeline<Discovery>(mock, [](Discovery& client) {
         const auto& resources = client.discover_resources();
-        BOOST_CHECK_EQUAL(resource, fake_discovered_resources());
+        BOOST_CHECK_EQUAL(resources.size(), 3);
     });
 }
 
 BOOST_AUTO_TEST_CASE(test_do_command) {
-    std::shared_ptr<MockDiscovery> mock = MockDiscovery::get_mock_discovery();
-    client_to_mock_pipeline<Discovery>(mock, [](Discovery& client) {
-        ProtoStruct expected = fake_map();
-
-        ProtoStruct command = fake_map();
-        ProtoStruc result_map = client.do_command(command);
-
-        BOOST_CHECK(result.map.at("test") == expected.map.at("test"));
+    auto mock = std::make_shared<MockDiscovery>("mock_discovery");
+    client_to_mock_pipeline<Discovery>(mock, [&](Discovery& client) {
+        const auto ret = client.do_command({});
+        BOOST_CHECK_EQUAL(ret.size(), 0);
     });
 }
 
+}  // namespace discovery
 }  // namespace sdktests
 }  // namespace viam

--- a/src/viam/sdk/tests/test_utils.cpp
+++ b/src/viam/sdk/tests/test_utils.cpp
@@ -27,31 +27,37 @@ std::vector<GeometryConfig> fake_geometries() {
 }
 
 std::vector<ResourceConfig> fake_discovered_resources() {
+    pose p{1, 2, 3};
+    orientation_vector o{0, 0, 0, 1};
+    translation t{1, 2, 3};
+
+    LinkConfig link(t, o, GeometryConfig(p, sphere{1}, "sphere"), "world");
+
+
     return {
         ResourceConfig("camera",
                        "mycam",
                        "rdk",
                        {{"width", 640}, {"height", 480}, {"format", "mjpeg"}},
                        "rdk:component:camera",
-                       "rdk:builtin:webcam"),
-        ResourceConfig("motor",
-                       "arm_motor",
-                       "rand",
-                       {
-                           {"pins", {{"pwm", 18}, {"dir", 23}}},
-                           {"max_rpm", 100},
-                           {"encoder_steps", 200},
-                       },
-                       "rdk:component:motor",
-                       "rand:cool:motor"),
+                       Model("rdk", "camera", "mycam"),
+                       link),
         ResourceConfig("sensor",
                        "temp_sensor",
                        "viam",
                        {{"type", "temperature"}, {"unit", "celsius"}, {"poll_rate", 1000}},
                        "rdk:component:sensor",
-                       "viam:temp:sensor1"),
-    };
-}
+                       Model("viam", "temp", "my_temp_sensor"),
+                       link),
+        ResourceConfig("motor",
+                       "arm_motor",
+                       "rand",
+                       {{"max_rpm", 100}, {"encoder_steps", 200}},
+                       "rdk:component:motor",
+                       Model("rand", "cool", "my_motor"),
+                       link),
+                    };
+};
 
 TestServer::TestServer(std::shared_ptr<Server> sdk_server) : sdk_server_(std::move(sdk_server)) {}
 

--- a/src/viam/sdk/tests/test_utils.cpp
+++ b/src/viam/sdk/tests/test_utils.cpp
@@ -26,6 +26,26 @@ std::vector<GeometryConfig> fake_geometries() {
             GeometryConfig(p, capsule{2, 4}, "capsule")};
 }
 
+std::vector<ResourceConfig> fake_discovered_resources() {
+    return {
+        ResourceConfig("camera", "mycam", "rdk", {
+            {"width", 640},
+            {"height", 480},
+            {"format", "mjpeg"}
+        }, "rdk:component:camera", "rdk:builtin:webcam"),
+        ResourceConfig("motor", "arm_motor", "rand", {
+            {"pins", {{"pwm", 18}, {"dir", 23}}},
+            {"max_rpm", 100},
+            {"encoder_steps", 200},
+        }, "rdk:component:motor", "rand:cool:motor" ),
+        ResourceConfig("sensor", "temp_sensor", "viam", {
+            {"type", "temperature"},
+            {"unit", "celsius"},
+            {"poll_rate", 1000}
+        }, "rdk:component:sensor", "viam:temp:sensor1"),
+    };
+}
+
 TestServer::TestServer(std::shared_ptr<Server> sdk_server) : sdk_server_(std::move(sdk_server)) {}
 
 TestServer::~TestServer() = default;

--- a/src/viam/sdk/tests/test_utils.cpp
+++ b/src/viam/sdk/tests/test_utils.cpp
@@ -28,21 +28,28 @@ std::vector<GeometryConfig> fake_geometries() {
 
 std::vector<ResourceConfig> fake_discovered_resources() {
     return {
-        ResourceConfig("camera", "mycam", "rdk", {
-            {"width", 640},
-            {"height", 480},
-            {"format", "mjpeg"}
-        }, "rdk:component:camera", "rdk:builtin:webcam"),
-        ResourceConfig("motor", "arm_motor", "rand", {
-            {"pins", {{"pwm", 18}, {"dir", 23}}},
-            {"max_rpm", 100},
-            {"encoder_steps", 200},
-        }, "rdk:component:motor", "rand:cool:motor" ),
-        ResourceConfig("sensor", "temp_sensor", "viam", {
-            {"type", "temperature"},
-            {"unit", "celsius"},
-            {"poll_rate", 1000}
-        }, "rdk:component:sensor", "viam:temp:sensor1"),
+        ResourceConfig("camera",
+                       "mycam",
+                       "rdk",
+                       {{"width", 640}, {"height", 480}, {"format", "mjpeg"}},
+                       "rdk:component:camera",
+                       "rdk:builtin:webcam"),
+        ResourceConfig("motor",
+                       "arm_motor",
+                       "rand",
+                       {
+                           {"pins", {{"pwm", 18}, {"dir", 23}}},
+                           {"max_rpm", 100},
+                           {"encoder_steps", 200},
+                       },
+                       "rdk:component:motor",
+                       "rand:cool:motor"),
+        ResourceConfig("sensor",
+                       "temp_sensor",
+                       "viam",
+                       {{"type", "temperature"}, {"unit", "celsius"}, {"poll_rate", 1000}},
+                       "rdk:component:sensor",
+                       "viam:temp:sensor1"),
     };
 }
 

--- a/src/viam/sdk/tests/test_utils.cpp
+++ b/src/viam/sdk/tests/test_utils.cpp
@@ -33,7 +33,6 @@ std::vector<ResourceConfig> fake_discovered_resources() {
 
     LinkConfig link(t, o, GeometryConfig(p, sphere{1}, "sphere"), "world");
 
-
     return {
         ResourceConfig("camera",
                        "mycam",
@@ -56,7 +55,7 @@ std::vector<ResourceConfig> fake_discovered_resources() {
                        "rdk:component:motor",
                        Model("rand", "cool", "my_motor"),
                        link),
-                    };
+    };
 };
 
 TestServer::TestServer(std::shared_ptr<Server> sdk_server) : sdk_server_(std::move(sdk_server)) {}

--- a/src/viam/sdk/tests/test_utils.hpp
+++ b/src/viam/sdk/tests/test_utils.hpp
@@ -14,6 +14,7 @@ using namespace viam::sdk;
 
 ProtoStruct fake_map();
 std::vector<GeometryConfig> fake_geometries();
+std::vector<ResourceConfig> fake_discovered_resources();
 
 // TestServer is a wrapper around viam::sdk::Server that is a friend of the
 // class and can therefore access its private fields.


### PR DESCRIPTION
This PR adds the Discovery Service wrapper to the C++ SDK.

I mainly followed the pattern in #323.

I followed the `arm.get_geometries` method pattern to return an array of a `ResourceConfig` from `discovery.discover_resources`, which is intended to return a valid config with meaningful attributes for physically connected devices to viam-server. 