### PR TITLE
RSDK-9901 - run tests in update proto workflow

### DIFF
--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -14,6 +14,8 @@ jobs:
       image: ghcr.io/viamrobotics/canon:amd64
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
       # note (erodkin): these dependencies were cribbed from what we use to build the SDK
       # in the release job. Only very cursory effort was made to prune.
       - name: install dependencies


### PR DESCRIPTION
Sets a new token for checkout step to cause tests to run during proto update workflow.

Unlike https://github.com/viamrobotics/viam-python-sdk/pull/864, we use `GIT_ACCESS_TOKEN` instead of `REPO_READ_TOKEN`. `REPO_READ_TOKEN` does not exist in this repo's secrets, and per @abe-winter the `GIT_ACCESS_TOKEN` _may_ work as well. If it does not, we can revisit.