### PR TITLE
Fix conan build failures

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -39,7 +39,7 @@ class ViamCppSdkRecipe(ConanFile):
             # From some experiments it seems that the shared-ness of these packages
             # should match that of the SDK recipe. Failure to do so can cause linker
             # errors while compiling, or static initialization errors at runtime for modules.
-            for lib in ["grpc", "protobuf", "abseil"]:
+            for lib in ["grpc", "protobuf"]:
                 self.options[lib].shared = True
 
     def requirements(self):
@@ -51,7 +51,6 @@ class ViamCppSdkRecipe(ConanFile):
         self.requires('protobuf/[>=3.17.1]')
 
         self.requires('xtensor/[>=0.24.3]')
-        self.requires('abseil/[>=20230125.3]')
 
     def build_requirements(self):
         if self.options.offline_proto_generation:
@@ -93,8 +92,6 @@ class ViamCppSdkRecipe(ConanFile):
            self.cpp_info.components[component].requires = ["grpc::grpc++"]
            if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components[component].system_libs = ["pthread"]
-
-        self.cpp_info.components["viamapi"].requires.append("abseil::absl_strings")
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["viamsdk"].system_libs.extend(["dl", "rt"])


### PR DESCRIPTION
Conan build has been broken as of https://github.com/viamrobotics/viam-cpp-sdk/actions/runs/13652553282

It seems that the release of grpc 1.69 conan package is causing a version conflict with abseil. However, as of #357 there is no longer any direct consumption of abseil in SDK/API code, so it should be fine to remove the dependency from conan entirely. 