### PR TITLE
pin cmake for conan jammy

### DIFF
--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -120,7 +120,7 @@ jobs:
           sudo echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
 
           apt-get update
-          apt-get -y install cmake
+          apt-get -y install cmake=3.25.2-0kitware1ubuntu22.04.1 cmake-data=3.25.2-0kitware1ubuntu22.04.1
 
           pip install conan
 

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - conanfile.py
       - test_package/conanfile.py
+      - .github/workflows/conan.yml
 
 jobs:
   prepare:


### PR DESCRIPTION
cmake 4.0 is causing a similar build failure as in the release build