### PR TITLE
[RSDK-10385] Windows build system improvements and rust_utils workarounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,10 @@ if (NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+if(MSVC)
+  # https://discourse.cmake.org/t/set-cmake-cxx-standard-should-set-zc-cplusplus-for-msvc/1876
+  string(APPEND CMAKE_CXX_FLAGS " /Zc:__cplusplus")
+endif()
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 
@@ -255,7 +259,7 @@ if (viam_rust_utils_files)
     ${viam_rust_utils_file}
     ONLY_IF_DIFFERENT
   )
-else()
+elseif(NOT WIN32) # TODO(RSDK-10366): Currently, rust_utils is not published for windows, so don't even try downloading
   set(lvru_system_name ${CMAKE_SYSTEM_NAME})
   if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(lvru_system_name "macosx")
@@ -275,21 +279,23 @@ else()
 
 endif()
 
-add_library(viam_rust_utils SHARED IMPORTED)
+# TODO(RSDK-10366): Currently, rust_utils is not published for windows, so don't even declare the library
+if (NOT WIN32)
+  add_library(viam_rust_utils SHARED IMPORTED)
 
-target_link_directories(viam_rust_utils
-  INTERFACE
+  target_link_directories(viam_rust_utils
+    INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}>"
-)
+  )
 
-set_property(TARGET viam_rust_utils PROPERTY IMPORTED_LOCATION ${viam_rust_utils_file})
+  set_property(TARGET viam_rust_utils PROPERTY IMPORTED_LOCATION ${viam_rust_utils_file})
 
-install(
-  IMPORTED_RUNTIME_ARTIFACTS viam_rust_utils
-  LIBRARY COMPONENT viam-cpp-sdk_runtime
-)
-
+  install(
+    IMPORTED_RUNTIME_ARTIFACTS viam_rust_utils
+    LIBRARY COMPONENT viam-cpp-sdk_runtime
+  )
+endif()
 
 # Install the license file
 install(FILES

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -132,6 +132,7 @@ target_sources(viamsdk
     rpc/dial.cpp
     rpc/server.cpp
     rpc/private/viam_grpc_channel.cpp
+    rpc/private/viam_rust_utils_stubs.cpp
     services/discovery.cpp
     services/generic.cpp
     services/mlmodel.cpp
@@ -263,10 +264,15 @@ target_link_libraries(viamsdk
   PRIVATE ${VIAMCPPSDK_GRPCXX_LIBRARIES}
   PRIVATE ${VIAMCPPSDK_GRPC_LIBRARIES}
   PRIVATE ${VIAMCPPSDK_PROTOBUF_LIBRARIES}
-  PRIVATE viam_rust_utils
   PRIVATE Threads::Threads
 )
 
+# TODO(RSDK-10366): Currently, rust_utils is not published for windows, so don't link to it.
+if (NOT WIN32)
+  target_link_libraries(viamsdk
+    PRIVATE viam_rust_utils
+  )
+endif()
 
 if (APPLE)
   target_link_libraries(viamsdk PUBLIC "-framework Security")

--- a/src/viam/sdk/CMakeLists.txt
+++ b/src/viam/sdk/CMakeLists.txt
@@ -132,7 +132,6 @@ target_sources(viamsdk
     rpc/dial.cpp
     rpc/server.cpp
     rpc/private/viam_grpc_channel.cpp
-    rpc/private/viam_rust_utils_stubs.cpp
     services/discovery.cpp
     services/generic.cpp
     services/mlmodel.cpp
@@ -267,11 +266,15 @@ target_link_libraries(viamsdk
   PRIVATE Threads::Threads
 )
 
-# TODO(RSDK-10366): Currently, rust_utils is not published for windows, so don't link to it.
+# TODO(RSDK-10366): Currently, rust_utils is not published for
+# windows, so don't link to it.  Instead, link a stub implementation
+# that just calls `abort`.
 if (NOT WIN32)
   target_link_libraries(viamsdk
     PRIVATE viam_rust_utils
   )
+else()
+  target_sources(viamsdk PRIVATE rpc/private/viam_rust_utils_stubs.cpp)
 endif()
 
 if (APPLE)

--- a/src/viam/sdk/common/private/service_helper.hpp
+++ b/src/viam/sdk/common/private/service_helper.hpp
@@ -55,7 +55,6 @@ class ServiceHelper : public ServiceHelperBase {
     }
 
    private:
-
 #if __cplusplus >= 201703L
     template <typename Callable, typename... Args>
     using is_void_result = std::is_void<std::invoke_result_t<Callable, Args...>>;

--- a/src/viam/sdk/common/private/service_helper.hpp
+++ b/src/viam/sdk/common/private/service_helper.hpp
@@ -55,8 +55,14 @@ class ServiceHelper : public ServiceHelperBase {
     }
 
    private:
+
+#if __cplusplus >= 201703L
+    template <typename Callable, typename... Args>
+    using is_void_result = std::is_void<std::invoke_result_t<Callable, Args...>>;
+#else
     template <typename Callable, typename... Args>
     using is_void_result = std::is_void<std::result_of_t<Callable(Args...)>>;
+#endif
 
     // Implementation of `invoke_` for a Callable returning non-void,
     // presumably an error return, which we return as a

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -1,7 +1,11 @@
 #ifdef _WIN32
 #define NOMINMAX
+// clang-format off
+// Otherwise clang-format tries to alphabetize these headers,
+// but `winsock2.h` should definitely precede `windows.h`.
 #include <winsock2.h>
 #include <windows.h>
+// clang-format on
 #endif
 
 #include <viam/sdk/module/service.hpp>

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -1,3 +1,9 @@
+#ifdef _WIN32
+#define NOMINMAX
+#include <winsock2.h>
+#include <windows.h>
+#endif
+
 #include <viam/sdk/module/service.hpp>
 
 #include <exception>

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -13,17 +13,8 @@
 #include <viam/api/robot/v1/robot.pb.h>
 #include <viam/sdk/common/exception.hpp>
 #include <viam/sdk/rpc/private/viam_grpc_channel.hpp>
+#include <viam/sdk/rpc/private/viam_rust_utils.h>
 
-extern "C" void* init_rust_runtime();
-extern "C" int free_rust_runtime(void* ptr);
-extern "C" void free_string(const char* s);
-extern "C" char* dial(const char* uri,
-                      const char* entity,
-                      const char* type,
-                      const char* payload,
-                      bool allow_insecure,
-                      float timeout,
-                      void* ptr);
 namespace viam {
 namespace sdk {
 

--- a/src/viam/sdk/rpc/private/viam_rust_utils.h
+++ b/src/viam/sdk/rpc/private/viam_rust_utils.h
@@ -1,0 +1,21 @@
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// Prototypes for the entrypoints from viam_rust_utils
+// that we use in the SDK.
+
+void* init_rust_runtime();
+int free_rust_runtime(void* ptr);
+void free_string(const char* s);
+char* dial(const char* uri,
+           const char* entity,
+           const char* type,
+           const char* payload,
+           bool allow_insecure,
+           float timeout,
+           void* ptr);
+
+#if defined(__cplusplus)
+}  // extern "C"
+#endif

--- a/src/viam/sdk/rpc/private/viam_rust_utils_stubs.cpp
+++ b/src/viam/sdk/rpc/private/viam_rust_utils_stubs.cpp
@@ -2,9 +2,6 @@
 
 #include <cstdlib>
 
-// TODO(RSDK-10366): Currently, rust_utils is not published for windows
-// so we just implement the associated entry points as `abort`.
-#ifdef _WIN32
 void* init_rust_runtime() {
     abort();
 }
@@ -20,4 +17,3 @@ void free_string(const char*) {
 char* dial(const char*, const char*, const char*, const char*, bool, float, void*) {
     abort();
 }
-#endif

--- a/src/viam/sdk/rpc/private/viam_rust_utils_stubs.cpp
+++ b/src/viam/sdk/rpc/private/viam_rust_utils_stubs.cpp
@@ -1,0 +1,23 @@
+#include <viam/sdk/rpc/private/viam_rust_utils.h>
+
+#include <cstdlib>
+
+// TODO(RSDK-10366): Currently, rust_utils is not published for windows
+// so we just implement the associated entry points as `abort`.
+#ifdef _WIN32
+void* init_rust_runtime() {
+    abort();
+}
+
+int free_rust_runtime(void*) {
+    abort();
+}
+
+void free_string(const char*) {
+    abort();
+}
+
+char* dial(const char*, const char*, const char*, const char*, bool, float, void*) {
+    abort();
+}
+#endif


### PR DESCRIPTION
- Ensure `__cplusplus` is set right on Windows builds.
- Don't download or link to `viam_rust_utils` on Windows.
- Redirect the `viam_rust_utils` entry points to `abort` on Windows.
- Adjust `viamapi` library name on Windows and apply `/WHOLEARCHIVE`
- Use `std::invoke_result_t` instead of `result_of` in C++17, where the latter is deprecated
- Add windows headers where needed.