### PR TITLE
[RSDK-10385] Misc conan improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # ignore doxygen output
 /etc/docs/api/*
+
+# Conan user presets should be ignored
+CMakeUserPresets.json

--- a/conanfile.py
+++ b/conanfile.py
@@ -49,8 +49,7 @@ class ViamCppSdkRecipe(ConanFile):
         # maintained conan packages.
         self.requires('grpc/[>=1.48.4]')
         self.requires('protobuf/[>=3.17.1]')
-
-        self.requires('xtensor/[>=0.24.3]')
+        self.requires('xtensor/[>=0.24.3]', transitive_headers=True)
 
     def build_requirements(self):
         if self.options.offline_proto_generation:
@@ -126,7 +125,6 @@ class ViamCppSdkRecipe(ConanFile):
             "grpc::grpc++_reflection",
             "protobuf::libprotobuf",
             "xtensor::xtensor",
-
             "viamapi",
         ])
 


### PR DESCRIPTION
- The presets shouldn't get checked in, so, gitignore them
- We use xtensor publicly, so the dependency should have transitive headers.