### PR TITLE
Fix sigabrt in module integration tests

### DIFF
--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -255,14 +255,14 @@ ModuleService::ModuleService(int argc,
 
 ModuleService::~ModuleService() {
     // TODO(RSDK-5509): Run registered cleanup functions here.
-    std::cerr << "Shutting down gracefully.\n";
+    VIAM_SDK_LOG(info) << "Shutting down gracefully.";
     server_->shutdown();
 
     if (parent_) {
         try {
             parent_->close();
         } catch (const std::exception& exc) {
-            std::cerr << exc.what();
+            VIAM_SDK_LOG(error) << exc.what();
         }
     }
 }

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -255,14 +255,14 @@ ModuleService::ModuleService(int argc,
 
 ModuleService::~ModuleService() {
     // TODO(RSDK-5509): Run registered cleanup functions here.
-    VIAM_SDK_LOG(info) << "Shutting down gracefully.";
+    std::cerr << "Shutting down gracefully.\n";
     server_->shutdown();
 
     if (parent_) {
         try {
             parent_->close();
         } catch (const std::exception& exc) {
-            VIAM_SDK_LOG(error) << exc.what();
+            std::cerr << exc.what();
         }
     }
 }

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -131,7 +131,7 @@ void RobotClient::close() {
     should_refresh_.store(false);
     threads_.clear();
     stop_all();
-    viam_channel_->close();
+    viam_channel_.close();
 }
 
 bool is_error_response(const grpc::Status& response) {
@@ -209,7 +209,7 @@ void RobotClient::refresh() {
         if (rs) {
             try {
                 const std::shared_ptr<Resource> rpc_client =
-                    rs->create_rpc_client(name.name(), channel_);
+                    rs->create_rpc_client(name.name(), viam_channel_.channel());
                 const Name name_({name.namespace_(), name.type(), name.subtype()}, "", name.name());
                 new_resources.emplace(name_, rpc_client);
             } catch (const std::exception& exc) {
@@ -248,11 +248,10 @@ void RobotClient::refresh_every() {
     }
 };
 
-RobotClient::RobotClient(std::shared_ptr<ViamChannel> channel)
-    : channel_(channel->channel()),
-      viam_channel_(std::move(channel)),
+RobotClient::RobotClient(ViamChannel channel)
+    : viam_channel_(std::move(channel)),
       should_close_channel_(false),
-      impl_(std::make_unique<impl>(RobotService::NewStub(channel_))) {}
+      impl_(std::make_unique<impl>(RobotService::NewStub(viam_channel_.channel()))) {}
 
 std::vector<Name> RobotClient::resource_names() const {
     const std::lock_guard<std::mutex> lock(lock_);
@@ -284,9 +283,9 @@ void RobotClient::log(const std::string& name,
     }
 }
 
-std::shared_ptr<RobotClient> RobotClient::with_channel(std::shared_ptr<ViamChannel> channel,
+std::shared_ptr<RobotClient> RobotClient::with_channel(ViamChannel channel,
                                                        const Options& options) {
-    std::shared_ptr<RobotClient> robot = std::make_shared<RobotClient>(std::move(channel));
+    auto robot = std::make_shared<RobotClient>(std::move(channel));
     robot->refresh_interval_ = options.refresh_interval();
     robot->should_refresh_ = (robot->refresh_interval_ > 0);
     if (robot->should_refresh_) {
@@ -305,8 +304,8 @@ std::shared_ptr<RobotClient> RobotClient::with_channel(std::shared_ptr<ViamChann
 std::shared_ptr<RobotClient> RobotClient::at_address(const std::string& address,
                                                      const Options& options) {
     const char* uri = address.c_str();
-    auto channel = ViamChannel::dial_initial(uri, options.dial_options());
-    std::shared_ptr<RobotClient> robot = RobotClient::with_channel(channel, options);
+    std::shared_ptr<RobotClient> robot =
+        RobotClient::with_channel(ViamChannel::dial_initial(uri, options.dial_options()), options);
     robot->should_close_channel_ = true;
 
     return robot;
@@ -315,10 +314,9 @@ std::shared_ptr<RobotClient> RobotClient::at_address(const std::string& address,
 std::shared_ptr<RobotClient> RobotClient::at_local_socket(const std::string& address,
                                                           const Options& options) {
     const std::string addr = "unix://" + address;
-    const std::shared_ptr<grpc::Channel> channel =
-        sdk::impl::create_viam_channel(addr, grpc::InsecureChannelCredentials());
-    std::shared_ptr<RobotClient> robot =
-        RobotClient::with_channel(std::make_shared<ViamChannel>(channel), options);
+    std::shared_ptr<RobotClient> robot = RobotClient::with_channel(
+        ViamChannel(sdk::impl::create_viam_channel(addr, grpc::InsecureChannelCredentials())),
+        options);
     robot->should_close_channel_ = true;
 
     return robot;

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -305,7 +305,7 @@ std::shared_ptr<RobotClient> RobotClient::with_channel(ViamChannel channel,
 std::shared_ptr<RobotClient> RobotClient::at_address(const std::string& address,
                                                      const Options& options) {
     const char* uri = address.c_str();
-    std::shared_ptr<RobotClient> robot =
+    auto robot =
         RobotClient::with_channel(ViamChannel::dial_initial(uri, options.dial_options()), options);
     robot->should_close_channel_ = true;
 

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -120,9 +120,9 @@ RobotClient::~RobotClient() {
         try {
             this->close();
         } catch (const std::exception& e) {
-            VIAM_SDK_LOG(error) << "Received err while closing RobotClient: " << e.what() << "\n";
+            VIAM_SDK_LOG(error) << "Received err while closing RobotClient: " << e.what();
         } catch (...) {
-            VIAM_SDK_LOG(error) << "Received unknown err while closing RobotClient\n";
+            VIAM_SDK_LOG(error) << "Received unknown err while closing RobotClient";
         }
     }
 }

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -315,11 +315,10 @@ std::shared_ptr<RobotClient> RobotClient::at_address(const std::string& address,
 std::shared_ptr<RobotClient> RobotClient::at_local_socket(const std::string& address,
                                                           const Options& options) {
     const std::string addr = "unix://" + address;
-    const char* uri = addr.c_str();
     const std::shared_ptr<grpc::Channel> channel =
-        sdk::impl::create_viam_channel(uri, grpc::InsecureChannelCredentials());
-    auto viam_channel = std::make_shared<ViamChannel>(channel, address.c_str(), nullptr);
-    std::shared_ptr<RobotClient> robot = RobotClient::with_channel(viam_channel, options);
+        sdk::impl::create_viam_channel(addr, grpc::InsecureChannelCredentials());
+    std::shared_ptr<RobotClient> robot =
+        RobotClient::with_channel(std::make_shared<ViamChannel>(channel), options);
     robot->should_close_channel_ = true;
 
     return robot;

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -290,11 +290,11 @@ std::shared_ptr<RobotClient> RobotClient::with_channel(std::shared_ptr<ViamChann
     robot->refresh_interval_ = options.refresh_interval();
     robot->should_refresh_ = (robot->refresh_interval_ > 0);
     if (robot->should_refresh_) {
-        auto t = std::make_unique<std::thread>(&RobotClient::refresh_every, robot);
+        auto t = std::thread(&RobotClient::refresh_every, robot);
         // TODO(RSDK-1743): this was leaking, confirm that adding thread catching in
         // close/destructor lets us shutdown gracefully. See also address sanitizer,
         // UB sanitizer
-        t->detach();
+        t.detach();
         robot->threads_.push_back(std::move(t));
     };
 

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -314,7 +314,7 @@ std::shared_ptr<RobotClient> RobotClient::at_address(const std::string& address,
 std::shared_ptr<RobotClient> RobotClient::at_local_socket(const std::string& address,
                                                           const Options& options) {
     const std::string addr = "unix://" + address;
-    std::shared_ptr<RobotClient> robot = RobotClient::with_channel(
+    auto robot = RobotClient::with_channel(
         ViamChannel(sdk::impl::create_viam_channel(addr, grpc::InsecureChannelCredentials())),
         options);
     robot->should_close_channel_ = true;

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -120,9 +120,9 @@ RobotClient::~RobotClient() {
         try {
             this->close();
         } catch (const std::exception& e) {
-            std::cerr << "Received err while closing RobotClient: " << e.what() << "\n";
+            VIAM_SDK_LOG(error) << "Received err while closing RobotClient: " << e.what() << "\n";
         } catch (...) {
-            std::cerr << "Received unknown err while closing RobotClient\n";
+            VIAM_SDK_LOG(error) << "Received unknown err while closing RobotClient\n";
         }
     }
 }

--- a/src/viam/sdk/robot/client.hpp
+++ b/src/viam/sdk/robot/client.hpp
@@ -64,7 +64,10 @@ class RobotClient {
         friend bool operator==(const operation& lhs, const operation& rhs);
     };
 
+    explicit RobotClient(ViamChannel channel);
+
     ~RobotClient();
+
     void refresh();
     void close();
 
@@ -88,8 +91,6 @@ class RobotClient {
     /// Connects directly to a pre-existing channel. A robot created this way must be
     /// `close()`d manually.
     static std::shared_ptr<RobotClient> with_channel(ViamChannel channel, const Options& options);
-
-    RobotClient(ViamChannel channel);
 
     std::vector<Name> resource_names() const;
 

--- a/src/viam/sdk/robot/client.hpp
+++ b/src/viam/sdk/robot/client.hpp
@@ -165,7 +165,7 @@ class RobotClient {
 
     void refresh_every();
 
-    std::vector<std::unique_ptr<std::thread>> threads_;
+    std::vector<std::thread> threads_;
 
     std::atomic<bool> should_refresh_;
     unsigned int refresh_interval_;

--- a/src/viam/sdk/robot/client.hpp
+++ b/src/viam/sdk/robot/client.hpp
@@ -165,7 +165,7 @@ class RobotClient {
 
     void refresh_every();
 
-    std::vector<std::shared_ptr<std::thread>> threads_;
+    std::vector<std::unique_ptr<std::thread>> threads_;
 
     std::atomic<bool> should_refresh_;
     unsigned int refresh_interval_;

--- a/src/viam/sdk/robot/client.hpp
+++ b/src/viam/sdk/robot/client.hpp
@@ -87,10 +87,9 @@ class RobotClient {
     /// @param options Options for connecting and refreshing.
     /// Connects directly to a pre-existing channel. A robot created this way must be
     /// `close()`d manually.
-    static std::shared_ptr<RobotClient> with_channel(std::shared_ptr<ViamChannel> channel,
-                                                     const Options& options);
+    static std::shared_ptr<RobotClient> with_channel(ViamChannel channel, const Options& options);
 
-    RobotClient(std::shared_ptr<ViamChannel> channel);
+    RobotClient(ViamChannel channel);
 
     std::vector<Name> resource_names() const;
 
@@ -170,8 +169,7 @@ class RobotClient {
     std::atomic<bool> should_refresh_;
     unsigned int refresh_interval_;
 
-    std::shared_ptr<GrpcChannel> channel_;
-    std::shared_ptr<ViamChannel> viam_channel_;
+    ViamChannel viam_channel_;
     bool should_close_channel_;
 
     struct impl;

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -21,6 +21,17 @@ namespace sdk {
 ViamChannel::RustDialData::RustDialData(const char* path_, void* runtime)
     : path(path_), rust_runtime(runtime) {}
 
+ViamChannel::RustDialData::RustDialData(RustDialData&& other) noexcept
+    : path(std::exchange(other.path, nullptr)),
+      rust_runtime(std::exchange(other.rust_runtime, nullptr)) {}
+
+ViamChannel::RustDialData& ViamChannel::RustDialData::operator=(RustDialData&& other) noexcept {
+    path = std::exchange(other.path, nullptr);
+    rust_runtime = std::exchange(other.rust_runtime, nullptr);
+
+    return *this;
+}
+
 ViamChannel::RustDialData::~RustDialData() {
     free_string(path);
     free_rust_runtime(rust_runtime);

--- a/src/viam/sdk/rpc/dial.cpp
+++ b/src/viam/sdk/rpc/dial.cpp
@@ -179,8 +179,6 @@ std::shared_ptr<ViamChannel> ViamChannel::dial(const char* uri,
     address += socket_path;
     const std::shared_ptr<grpc::Channel> channel =
         sdk::impl::create_viam_channel(address, grpc::InsecureChannelCredentials());
-    const std::unique_ptr<viam::robot::v1::RobotService::Stub> st =
-        viam::robot::v1::RobotService::NewStub(channel);
     return std::make_shared<ViamChannel>(channel, socket_path, ptr);
 }
 

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -13,10 +13,14 @@ namespace sdk {
 
 class DialOptions;
 class ViamChannel {
+    ViamChannel(std::shared_ptr<GrpcChannel> channel, const char* path, void* runtime);
+
    public:
     explicit ViamChannel(std::shared_ptr<GrpcChannel> channel);
 
-    ViamChannel(std::shared_ptr<GrpcChannel> channel, const char* path, void* runtime);
+    ViamChannel(ViamChannel&&) noexcept;
+
+    ViamChannel& operator=(ViamChannel&&) noexcept;
 
     ~ViamChannel();
 
@@ -26,8 +30,7 @@ class ViamChannel {
     /// In general, use of this method is discouraged. `RobotClient::at_address(...)` is the
     /// preferred method to connect to a robot, and creates the channel itself.
     /// @throws Exception if it is unable to establish a connection to the provided URI
-    static std::shared_ptr<ViamChannel> dial(const char* uri,
-                                             const boost::optional<DialOptions>& options);
+    static ViamChannel dial(const char* uri, const boost::optional<DialOptions>& options);
 
     // @brief Dials to a robot at the given URI address, using the provided dial options (or default
     // options is none are provided). Additionally specifies that this dial is an initial connection
@@ -36,8 +39,7 @@ class ViamChannel {
     /// preferred method to connect to a robot, and creates the channel itself.
     /// @throws Exception if it is unable to establish a connection to the provided URI within
     /// the given number of initial connection attempts
-    static std::shared_ptr<ViamChannel> dial_initial(const char* uri,
-                                                     const boost::optional<DialOptions>& options);
+    static ViamChannel dial_initial(const char* uri, const boost::optional<DialOptions>& options);
 
     const std::shared_ptr<GrpcChannel>& channel() const;
 

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -14,8 +14,11 @@ namespace sdk {
 class DialOptions;
 class ViamChannel {
    public:
-    void close();
+    explicit ViamChannel(std::shared_ptr<GrpcChannel> channel);
+
     ViamChannel(std::shared_ptr<GrpcChannel> channel, const char* path, void* runtime);
+
+    ~ViamChannel();
 
     /// @brief Connects to a robot at the given URI address, using the provided dial options (or
     /// default options is none are provided). Ignores initial connection options specifying
@@ -38,11 +41,20 @@ class ViamChannel {
 
     const std::shared_ptr<GrpcChannel>& channel() const;
 
+    void close();
+
    private:
+    struct RustDialData {
+        RustDialData(const char* path_, void* runtime);
+        ~RustDialData();
+
+        const char* path;
+        void* rust_runtime;
+    };
+
     std::shared_ptr<GrpcChannel> channel_;
-    const char* path_;
-    bool closed_;
-    void* rust_runtime_;
+
+    boost::optional<RustDialData> rust_data_;
 };
 
 class Credentials {

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -44,24 +44,11 @@ class ViamChannel {
     void close();
 
    private:
-    struct RustDialData {
-        RustDialData(const char* path_, void* runtime);
-
-        RustDialData(const RustDialData&) = delete;
-        RustDialData(RustDialData&&) noexcept;
-
-        RustDialData& operator=(const RustDialData&) = delete;
-        RustDialData& operator=(RustDialData&&) noexcept;
-
-        ~RustDialData();
-
-        const char* path;
-        void* rust_runtime;
-    };
+    struct impl;
 
     std::shared_ptr<GrpcChannel> channel_;
 
-    boost::optional<RustDialData> rust_data_;
+    std::unique_ptr<impl> pimpl_;
 };
 
 class Credentials {

--- a/src/viam/sdk/rpc/dial.hpp
+++ b/src/viam/sdk/rpc/dial.hpp
@@ -46,6 +46,13 @@ class ViamChannel {
    private:
     struct RustDialData {
         RustDialData(const char* path_, void* runtime);
+
+        RustDialData(const RustDialData&) = delete;
+        RustDialData(RustDialData&&) noexcept;
+
+        RustDialData& operator=(const RustDialData&) = delete;
+        RustDialData& operator=(RustDialData&&) noexcept;
+
         ~RustDialData();
 
         const char* path;

--- a/src/viam/sdk/tests/test_robot.cpp
+++ b/src/viam/sdk/tests/test_robot.cpp
@@ -50,8 +50,7 @@ void robot_client_to_mocks_pipeline(F&& test_case) {
     // in-process gRPC channel.
     auto test_server = TestServer(server);
     auto grpc_channel = test_server.grpc_in_process_channel();
-    auto viam_channel = std::make_shared<ViamChannel>(grpc_channel);
-    auto client = RobotClient::with_channel(viam_channel, Options(0, boost::none));
+    auto client = RobotClient::with_channel(ViamChannel(grpc_channel), Options(0, boost::none));
 
     // Run the passed-in test case on the created stack and give access to the
     // created RobotClient and MockRobotService.

--- a/src/viam/sdk/tests/test_robot.cpp
+++ b/src/viam/sdk/tests/test_robot.cpp
@@ -50,7 +50,7 @@ void robot_client_to_mocks_pipeline(F&& test_case) {
     // in-process gRPC channel.
     auto test_server = TestServer(server);
     auto grpc_channel = test_server.grpc_in_process_channel();
-    auto viam_channel = std::make_shared<ViamChannel>(grpc_channel, "", nullptr);
+    auto viam_channel = std::make_shared<ViamChannel>(grpc_channel);
     auto client = RobotClient::with_channel(viam_channel, Options(0, boost::none));
 
     // Run the passed-in test case on the created stack and give access to the


### PR DESCRIPTION
There was a sigabrt in recent module integration tests that revealed some UB where we sometimes accidentally double-free the memory managed by a `std::string`. Zero clue as to why logging brought this up but it is indeed something we'd want to fix anyway.

Contains some drive-by changes as well