### PR TITLE
RSDK-8424 - respect ctx deadline when adding module resources

### DIFF
--- a/src/viam/examples/modules/complex/proto/buf.lock
+++ b/src/viam/examples/modules/complex/proto/buf.lock
@@ -4,5 +4,5 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 751cbe31638d43a9bfb6162cd2352e67
-    digest: shake256:87f55470d9d124e2d1dedfe0231221f4ed7efbc55bc5268917c678e2d9b9c41573a7f9a557f6d8539044524d9fc5ca8fbb7db05eb81379d168285d76b57eb8a4
+    commit: 61b203b9a9164be9a834f58c37be6f62
+    digest: shake256:e619113001d6e284ee8a92b1561e5d4ea89a47b28bf0410815cb2fa23914df8be9f1a6a98dcf069f5bc2d829a2cfb1ac614863be45cd4f8a5ad8606c5f200224

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -54,7 +54,7 @@ struct ModuleService::ServiceImpl : viam::module::v1::ModuleService::Service {
     ModuleService& parent;
 
     // TODO(RSDK-6528) - to the extent possible, switch to using `server_helper`
-    ::grpc::Status AddResource(::grpc::ServerContext*,
+    ::grpc::Status AddResource(::grpc::ServerContext* ctx,
                                const ::viam::module::v1::AddResourceRequest* request,
                                ::viam::module::v1::AddResourceResponse*) override {
         const viam::app::v1::ComponentConfig& proto = request->config();
@@ -74,7 +74,8 @@ struct ModuleService::ServiceImpl : viam::module::v1::ModuleService::Service {
             }
         };
         try {
-            parent.server_->add_resource(res);
+            auto deadline = ctx->deadline();
+            parent.server_->add_resource(res, &deadline);
         } catch (const std::exception& exc) {
             return grpc::Status(::grpc::INTERNAL, exc.what());
         }

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -74,8 +74,7 @@ struct ModuleService::ServiceImpl : viam::module::v1::ModuleService::Service {
             }
         };
         try {
-            auto deadline = ctx->deadline();
-            parent.server_->add_resource(res, &deadline);
+            parent.server_->add_resource(res, ctx->deadline());
         } catch (const std::exception& exc) {
             return grpc::Status(::grpc::INTERNAL, exc.what());
         }

--- a/src/viam/sdk/rpc/server.cpp
+++ b/src/viam/sdk/rpc/server.cpp
@@ -46,8 +46,6 @@ void Server::register_service(grpc::Service* service) {
 
 namespace {
 bool deadline_exceeded(const std::chrono::system_clock::time_point& deadline) {
-    std::cout << "deadline is " << deadline.time_since_epoch().count() << " and now is "
-              << std::chrono::system_clock::now().time_since_epoch().count() << "\n\n";
     return deadline < std::chrono::system_clock::now();  // deadline is before now
 }
 }  // namespace

--- a/src/viam/sdk/rpc/server.cpp
+++ b/src/viam/sdk/rpc/server.cpp
@@ -51,11 +51,11 @@ bool deadline_exceeded(const std::chrono::system_clock::time_point& deadline) {
 }  // namespace
 
 void Server::add_resource(std::shared_ptr<Resource> resource) {
-    add_resource(std::move(resource), nullptr);
+    add_resource(std::move(resource), boost::none);
 }
 
 void Server::add_resource(std::shared_ptr<Resource> resource,
-                          std::chrono::system_clock::time_point* deadline) {
+                          boost::optional<std::chrono::system_clock::time_point> deadline) {
     if (deadline && deadline_exceeded(*deadline)) {
         throw Exception(ErrorCondition::k_general, "Deadline expired");
     }

--- a/src/viam/sdk/rpc/server.hpp
+++ b/src/viam/sdk/rpc/server.hpp
@@ -56,7 +56,7 @@ class Server {
     /// @throws `Exception` if a matching `ResourceServer` doesn't exist in the server.
     /// @throws `Exception` if the deadline is not nil and has passed
     void add_resource(std::shared_ptr<Resource> resource,
-                      std::chrono::system_clock::time_point* deadline);
+                      boost::optional<std::chrono::system_clock::time_point> deadline);
 
     /// @brief Adds a listening port to the server.
     /// @param address The address to listen at.

--- a/src/viam/sdk/rpc/server.hpp
+++ b/src/viam/sdk/rpc/server.hpp
@@ -50,6 +50,14 @@ class Server {
     /// @throws `Exception` if a matching `ResourceServer` doesn't exist in the server.
     void add_resource(std::shared_ptr<Resource> resource);
 
+    /// @brief Adds a specific managed resource to the associated resource server
+    /// @param resource The resource to add
+    /// @param deadline Deadline after which to not add the resource
+    /// @throws `Exception` if a matching `ResourceServer` doesn't exist in the server.
+    /// @throws `Exception` if the deadline is not nil and has passed
+    void add_resource(std::shared_ptr<Resource> resource,
+                      std::chrono::system_clock::time_point* deadline);
+
     /// @brief Adds a listening port to the server.
     /// @param address The address to listen at.
     /// @param creds The server credentials; defaults to a insecure server credentials.


### PR DESCRIPTION
modeled after https://github.com/viamrobotics/viam-python-sdk/pull/904, tested similarly with a modified timeout in simple module.