### PR TITLE
Remove destructor logging

### DIFF
--- a/src/viam/sdk/log/logging.hpp
+++ b/src/viam/sdk/log/logging.hpp
@@ -150,6 +150,8 @@ BOOST_LOG_ATTRIBUTE_KEYWORD_TYPE(attr_time,
 /// @ingroup Log
 ///
 /// Use this macro to generate log messages pertaining to the SDK at large.
+/// @warning Using this macro outside of the lifetime of LogManager is UB and for this reason
+/// logging in destructors should be done with caution or avoided entirely.
 #define VIAM_SDK_LOG(level) VIAM_SDK_LOG_IMPL(::viam::sdk::LogManager::get().global_logger(), level)
 
 /// @brief Log macro for resource-level logs.
@@ -158,6 +160,8 @@ BOOST_LOG_ATTRIBUTE_KEYWORD_TYPE(attr_time,
 /// This macro can only be called from the definition of a member function of a class inheriting
 /// @ref Resource. It will log messages to the log source of that specific resource, allowing
 /// resource-level log filtering.
+/// @warning Using this macro outside of the lifetime of LogManager is UB and for this reason
+/// logging in destructors should be done with caution or avoided entirely.
 #define VIAM_RESOURCE_LOG(level) VIAM_SDK_LOG_IMPL(this->logger_, level)
 
 }  // namespace sdk

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -254,7 +254,7 @@ ModuleService::ModuleService(int argc,
 }
 
 ModuleService::~ModuleService() {
-    std::cout << "Shutting down gracefully.";
+    std::cout << "Shutting down gracefully.\n";
     server_->shutdown();
 
     if (parent_) {

--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -254,15 +254,14 @@ ModuleService::ModuleService(int argc,
 }
 
 ModuleService::~ModuleService() {
-    // TODO(RSDK-5509): Run registered cleanup functions here.
-    VIAM_SDK_LOG(info) << "Shutting down gracefully.";
+    std::cout << "Shutting down gracefully.";
     server_->shutdown();
 
     if (parent_) {
         try {
             parent_->close();
         } catch (const std::exception& exc) {
-            VIAM_SDK_LOG(error) << exc.what();
+            std::cerr << exc.what();
         }
     }
 }

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -120,9 +120,9 @@ RobotClient::~RobotClient() {
         try {
             this->close();
         } catch (const std::exception& e) {
-            std::cerr << "Received err while closing RobotClient: " << e.what();
+            std::cerr << "Received err while closing RobotClient: " << e.what() << "\n";
         } catch (...) {
-            std::cerr << "Received unknown err while closing RobotClient";
+            std::cerr << "Received unknown err while closing RobotClient\n";
         }
     }
 }

--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -120,9 +120,9 @@ RobotClient::~RobotClient() {
         try {
             this->close();
         } catch (const std::exception& e) {
-            VIAM_SDK_LOG(error) << "Received err while closing RobotClient: " << e.what();
+            std::cerr << "Received err while closing RobotClient: " << e.what();
         } catch (...) {
-            VIAM_SDK_LOG(error) << "Received unknown err while closing RobotClient";
+            std::cerr << "Received unknown err while closing RobotClient";
         }
     }
 }


### PR DESCRIPTION
So this came up while working on another PR, but it turns out logging in destructors was causing issues after all. In particular the `RobotClient` destructor may run after `Instance` (and hence `LogManager`) have already been destroyed. I encountered this when joining threads in `RobotClient::close` was throwing an exception due to joining an unjoinable thread, so that will probably need a separate hotfix, but we should merge this one soon. 