### PR TITLE
reset parent to prevent double close

### DIFF
--- a/src/viam/sdk/module/service.cpp
+++ b/src/viam/sdk/module/service.cpp
@@ -260,7 +260,7 @@ ModuleService::~ModuleService() {
 
     if (parent_) {
         try {
-            parent_->close();
+            parent_.reset();
         } catch (const std::exception& exc) {
             VIAM_SDK_LOG(error) << exc.what();
         }


### PR DESCRIPTION
cherry picked from the dial-direct PR, figured we want this in main sooner than later 