### PR TITLE
[RSDK-7426] Make it more obvious how to run the tests for the C++ SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ to change without warning. In particular, using Boost.Log macros such as
 fail to output log messages.
 
 ## Running Tests
-Tests for the SDK are located in `src/viam/sdk/tests`. The CMakeLists.txt file in that directory defines how to build them. When the SDK is built, the test executables are placed in the test folder within your specified build directory (e.g., `build`, if you followed the instructions in [`BUILDING.md`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md)). To run the entire test suite at once, navigate to the `tests` folder in your build directory and run:
+Tests for the SDK are located in `src/viam/sdk/tests`. The CMakeLists.txt file in that directory defines how to build them. When the SDK is built, the test executables are placed in the test folder within your specified build directory (e.g., `build`, if you followed the instructions in [`BUILDING.md`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md)). The test executable files can be run individually. To run the entire test suite at once, navigate to the `tests` folder in your build directory and run:
 ```
 ctest
 ```

--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ Tests for the SDK are located in `src/viam/sdk/tests`. The CMakeLists.txt file i
 ```
 ctest
 ```
+Or to avoid navigating all the way to the folder you can specify the test directory, for example:
+```
+ctest --test-dir build/src/viam/sdk/tests/
+```
+Additionally, for more useful ctest options explore:
+```
+ctest --help
+```
 
 ## License
 Copyright 2022 Viam Inc.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ to change without warning. In particular, using Boost.Log macros such as
 `BOOST_LOG_TRIVIAL` or `BOOST_LOG_SEV` is undefined behavior which will likely
 fail to output log messages.
 
+## Running Tests
+Tests for the SDK are located in `src/viam/sdk/tests`. The CMakeLists.txt file in that directory defines how to build them. When the SDK is built, the test executables are placed in the test folder within your specified build directory (e.g., `build`, if you followed the instructions in [`BUILDING.md`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md)). To run the entire test suite at once, navigate to the `tests` folder in your build directory and run:
+```
+ctest
+```
+
 ## License
 Copyright 2022 Viam Inc.
 


### PR DESCRIPTION
Added a section to the README to make the location of the tests and how to run the tests more clear.