### PR TITLE
RSDK-11289: Fix logic in replace_one

### DIFF
--- a/src/viam/sdk/resource/resource_manager.cpp
+++ b/src/viam/sdk/resource/resource_manager.cpp
@@ -150,6 +150,18 @@ void ResourceManager::replace_one(const Name& name, std::shared_ptr<Resource> re
     }
 }
 
+void ResourceManager::replace_one(const Name& name,
+                                  std::function<std::shared_ptr<Resource>()> create_resource) {
+    const std::lock_guard<std::mutex> lock(lock_);
+    try {
+        do_remove(name);
+        do_add(name, create_resource());
+    } catch (std::exception& exc) {
+        VIAM_SDK_LOG(error) << "failed to replace resource " << name.to_string() << ": "
+                            << exc.what();
+    }
+}
+
 const std::unordered_map<std::string, std::shared_ptr<Resource>>& ResourceManager::resources()
     const {
     return resources_;

--- a/src/viam/sdk/resource/resource_manager.cpp
+++ b/src/viam/sdk/resource/resource_manager.cpp
@@ -139,17 +139,6 @@ void ResourceManager::remove(const Name& name) {
     }
 }
 
-void ResourceManager::replace_one(const Name& name, std::shared_ptr<Resource> resource) {
-    const std::lock_guard<std::mutex> lock(lock_);
-    try {
-        do_remove(name);
-        do_add(name, std::move(resource));
-    } catch (std::exception& exc) {
-        VIAM_SDK_LOG(error) << "failed to replace resource " << name.to_string() << ": "
-                            << exc.what();
-    }
-}
-
 void ResourceManager::replace_one(
     const Name& name, const std::function<std::shared_ptr<Resource>()>& create_resource) {
     const std::lock_guard<std::mutex> lock(lock_);

--- a/src/viam/sdk/resource/resource_manager.cpp
+++ b/src/viam/sdk/resource/resource_manager.cpp
@@ -150,8 +150,8 @@ void ResourceManager::replace_one(const Name& name, std::shared_ptr<Resource> re
     }
 }
 
-void ResourceManager::replace_one(const Name& name,
-                                  std::function<std::shared_ptr<Resource>()> create_resource) {
+void ResourceManager::replace_one(
+    const Name& name, const std::function<std::shared_ptr<Resource>()>& create_resource) {
     const std::lock_guard<std::mutex> lock(lock_);
     try {
         do_remove(name);

--- a/src/viam/sdk/resource/resource_manager.hpp
+++ b/src/viam/sdk/resource/resource_manager.hpp
@@ -58,7 +58,14 @@ class ResourceManager {
     /// @brief Replaces an existing resource. No-op if the named resource does not exist.
     /// @param name The name of the resource to replace.
     /// @param resource The new resource that is replacing the existing one.
+    [[deprecated("Use the callback overload as it destroys before constructing")]]
     void replace_one(const Name& name, std::shared_ptr<Resource> resource);
+
+    /// @brief Replaces an existing resource. No-op if the named resource does not exist.
+    /// @param name The name of the resource to replace.
+    /// @param create_resource Callback to construct the new resource that is replacing the existing
+    /// one.
+    void replace_one(const Name& name, std::function<std::shared_ptr<Resource>()> create_resource);
 
     /// @brief Returns a reference to the existing resources within the manager.
     const std::unordered_map<std::string, std::shared_ptr<Resource>>& resources() const;

--- a/src/viam/sdk/resource/resource_manager.hpp
+++ b/src/viam/sdk/resource/resource_manager.hpp
@@ -65,7 +65,8 @@ class ResourceManager {
     /// @param name The name of the resource to replace.
     /// @param create_resource Callback to construct the new resource that is replacing the existing
     /// one.
-    void replace_one(const Name& name, std::function<std::shared_ptr<Resource>()> create_resource);
+    void replace_one(const Name& name,
+                     const std::function<std::shared_ptr<Resource>()>& create_resource);
 
     /// @brief Returns a reference to the existing resources within the manager.
     const std::unordered_map<std::string, std::shared_ptr<Resource>>& resources() const;

--- a/src/viam/sdk/resource/resource_manager.hpp
+++ b/src/viam/sdk/resource/resource_manager.hpp
@@ -57,12 +57,6 @@ class ResourceManager {
 
     /// @brief Replaces an existing resource. No-op if the named resource does not exist.
     /// @param name The name of the resource to replace.
-    /// @param resource The new resource that is replacing the existing one.
-    [[deprecated("Use the callback overload as it destroys before constructing")]] void replace_one(
-        const Name& name, std::shared_ptr<Resource> resource);
-
-    /// @brief Replaces an existing resource. No-op if the named resource does not exist.
-    /// @param name The name of the resource to replace.
     /// @param create_resource Callback to construct the new resource that is replacing the existing
     /// one.
     void replace_one(const Name& name,

--- a/src/viam/sdk/resource/resource_manager.hpp
+++ b/src/viam/sdk/resource/resource_manager.hpp
@@ -58,8 +58,8 @@ class ResourceManager {
     /// @brief Replaces an existing resource. No-op if the named resource does not exist.
     /// @param name The name of the resource to replace.
     /// @param resource The new resource that is replacing the existing one.
-    [[deprecated("Use the callback overload as it destroys before constructing")]]
-    void replace_one(const Name& name, std::shared_ptr<Resource> resource);
+    [[deprecated("Use the callback overload as it destroys before constructing")]] void replace_one(
+        const Name& name, std::shared_ptr<Resource> resource);
 
     /// @brief Replaces an existing resource. No-op if the named resource does not exist.
     /// @param name The name of the resource to replace.

--- a/src/viam/sdk/spatialmath/orientation.cpp
+++ b/src/viam/sdk/spatialmath/orientation.cpp
@@ -51,7 +51,6 @@ void to_proto_impl<Orientation>::operator()(const Orientation& self,
             aa.set_z(a.z);
             aa.set_theta(a.theta);
             *orientation.mutable_axis_angles() = std::move(aa);
-            orientation.set_has_axis_angles();
         }
 
         void operator()(const orientation_vector& ov) {
@@ -61,7 +60,6 @@ void to_proto_impl<Orientation>::operator()(const Orientation& self,
             ovec.set_z(ov.z);
             ovec.set_theta(ov.theta);
             *orientation.mutable_vector_radians() = std::move(ovec);
-            orientation.set_has_vector_radians();
         }
 
         void operator()(const orientation_vector_degrees& ovd) {
@@ -71,7 +69,6 @@ void to_proto_impl<Orientation>::operator()(const Orientation& self,
             ovec.set_z(ovd.z);
             ovec.set_theta(ovd.theta);
             *orientation.mutable_vector_degrees() = std::move(ovec);
-            orientation.set_has_vector_degrees();
         }
 
         void operator()(const euler_angles& ea) {
@@ -80,7 +77,6 @@ void to_proto_impl<Orientation>::operator()(const Orientation& self,
             euler.set_roll(ea.roll);
             euler.set_yaw(ea.yaw);
             *orientation.mutable_euler_angles() = std::move(euler);
-            orientation.set_has_euler_angles();
         }
 
         void operator()(const quaternion& q) {
@@ -90,7 +86,6 @@ void to_proto_impl<Orientation>::operator()(const Orientation& self,
             quat.set_y(q.y);
             quat.set_z(q.z);
             *orientation.mutable_quaternion() = std::move(quat);
-            orientation.set_has_quaternion();
         }
 
         app::v1::Orientation& orientation;


### PR DESCRIPTION
third time's the charm? this should finally fix the  _`always-rebuild`_ logic in `ReconfigureResource`, making sure that the old resource is destructed before the new one is created. this was causing issues with realsense and would cause issues for any other unique or global resource which has sole ownership of a device, socket, etc.

this adds an overload of `replace_one` which takes a construction callback, bringing the logic closer to that of eg python
https://github.com/viamrobotics/viam-python-sdk/blob/main/src/viam/module/module.py#L253

i marked the old one as deprecated for now but we may just want to remove it entirely 

cc @hexbabe @acmorrow 