### PR TITLE
Update debian bullseye backports url

### DIFF
--- a/etc/docker/base-images/Dockerfile.debian.bullseye
+++ b/etc/docker/base-images/Dockerfile.debian.bullseye
@@ -32,7 +32,7 @@ RUN apt-get -y --no-install-recommends install \
 # Add the public key for the llvm repository
 RUN bash -c 'wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|apt-key add -'
 RUN apt-add-repository -y 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main'
-RUN apt-add-repository -y 'deb http://deb.debian.org/debian bullseye-backports main'
+RUN apt-add-repository -y 'deb https://archive.debian.org/debian bullseye-backports main'
 
 RUN apt-get update
 


### PR DESCRIPTION
## Description

The backports apt repository URL looks to no longer be valid:
```
 => CACHED [ 6/10] RUN apt-add-repository -y 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main'              0.0s
 => CACHED [ 7/10] RUN apt-add-repository -y 'deb http://deb.debian.org/debian bullseye-backports main'                       0.0s
 => ERROR [ 8/10] RUN apt-get update                                                                                          4.7s
------                                                                                                                             
 > [ 8/10] RUN apt-get update:                                                                                                     
1.366 Hit:1 http://deb.debian.org/debian bullseye InRelease                                                                        
1.366 Hit:2 http://deb.debian.org/debian-security bullseye-security InRelease                                                      
1.433 Hit:4 http://deb.debian.org/debian bullseye-updates InRelease                                                                
1.444 Ign:5 http://deb.debian.org/debian bullseye-backports InRelease                                                              
1.460 Err:6 http://deb.debian.org/debian bullseye-backports Release
1.460   404  Not Found [IP: 151.101.66.132 80]
1.608 Get:3 https://apt.llvm.org/bullseye llvm-toolchain-bullseye-15 InRelease [6836 B]
2.386 Get:7 https://apt.llvm.org/bullseye llvm-toolchain-bullseye-15/main arm64 Packages [19.5 kB]
2.493 Reading package lists...
3.553 E: The repository 'http://deb.debian.org/debian bullseye-backports Release' does not have a Release file.
------
Dockerfile.debian.bullseye:37
--------------------
  35 |     RUN apt-add-repository -y 'deb http://deb.debian.org/debian bullseye-backports main'
  36 |     # RUN apt-add-repository -y 'deb https://archive.debian.org/debian bullseye-backports main'
  37 | >>> RUN apt-get update
  38 |     
  39 |     RUN apt-get -y --no-install-recommends install -t llvm-toolchain-bullseye-15 \
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update" did not complete successfully: exit code: 100
➜  viam-cpp-sdk git:(update-beye-backports) ✗ 
```

This PR simply updates to use the `archive` subdomain

## Tests

- Manually tested build now goes through ✅ 
```
docker build -t viam-cpp-base-beye -f etc/docker/base-images/Dockerfile.debian.bullseye
...
[+] Building 112.6s (14/14) FINISHED                                                                          docker:desktop-linux 
```
- Compatible cmake version and successful sdk build ✅ 


```
$  ninja all -j 4
...
[271/271] Linking CXX executable src/viam/examples/modules/complex/test_complex_module
```
