### PR TITLE
[RSDK-11703, RSDK-11602] Update C++ GetImages signature

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -441,7 +441,7 @@ that they are pre-populated.
 cmake -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON ...
 ninja all   # FAILS!
 ninja generate-dynamic-protos
-nina all    # OK!
+ninja all    # OK!
 ```
 
 ### Build Issue: Proto Mismatch

--- a/src/viam/sdk/components/camera.hpp
+++ b/src/viam/sdk/components/camera.hpp
@@ -179,7 +179,8 @@ class Camera : public Component {
     /// sources are returned.
     /// @param extra any additional arguments to the method.
     /// @return a vector of raw_images and associated response metadata.
-    virtual image_collection get_images(std::vector<std::string> filter_source_names, const ProtoStruct& extra) = 0;
+    virtual image_collection get_images(std::vector<std::string> filter_source_names,
+                                        const ProtoStruct& extra) = 0;
 
     /// @brief Get the next `point_cloud` from the camera.
     /// @param mime_type the desired mime_type of the point_cloud (does not guarantee output type).

--- a/src/viam/sdk/components/camera.hpp
+++ b/src/viam/sdk/components/camera.hpp
@@ -160,7 +160,26 @@ class Camera : public Component {
     /// @brief Get the next images from the camera as a vector of raw images with names and
     /// metadata.
     /// @return a vector of raw_images and associated response metadata.
-    virtual image_collection get_images() = 0;
+    inline image_collection get_images() {
+        return get_images({}, {});
+    }
+
+    /// @brief Get the next images from specific sources as a vector of raw images with names and
+    /// metadata.
+    /// @param filter_source_names the names of sources to receive images from. If empty, all
+    /// sources are returned.
+    /// @return a vector of raw_images and associated response metadata.
+    inline image_collection get_images(std::vector<std::string> filter_source_names) {
+        return get_images(std::move(filter_source_names), {});
+    }
+
+    /// @brief Get the next images from the camera as a vector of raw images with names and
+    /// metadata.
+    /// @param filter_source_names the names of sources to receive images from. If empty, all
+    /// sources are returned.
+    /// @param extra any additional arguments to the method.
+    /// @return a vector of raw_images and associated response metadata.
+    virtual image_collection get_images(std::vector<std::string> filter_source_names, const ProtoStruct& extra) = 0;
 
     /// @brief Get the next `point_cloud` from the camera.
     /// @param mime_type the desired mime_type of the point_cloud (does not guarantee output type).

--- a/src/viam/sdk/components/private/camera_client.cpp
+++ b/src/viam/sdk/components/private/camera_client.cpp
@@ -54,6 +54,9 @@ Camera::image_collection from_proto(const viam::component::camera::v1::GetImages
         std::string img_string = img.image();
         const std::vector<unsigned char> bytes(img_string.begin(), img_string.end());
         raw_image.bytes = bytes;
+        // TODO(RSDK-11733): This is a temporary fix to support handling both the format and mime
+        // type. We will remove this once we remove the format field from the proto.
+        // We will remove this once we remove the format field from the proto.
         if (!img.mime_type().empty()) {
             raw_image.mime_type = img.mime_type();
         } else {

--- a/src/viam/sdk/components/private/camera_client.cpp
+++ b/src/viam/sdk/components/private/camera_client.cpp
@@ -126,14 +126,16 @@ Camera::raw_image CameraClient::get_image(std::string mime_type, const ProtoStru
         .invoke([](auto& response) { return from_proto(response); });
 };
 
-Camera::image_collection CameraClient::get_images(std::vector<std::string> filter_source_names, const ProtoStruct& extra) {
-    return make_client_helper(this, *stub_, &StubType::GetImages).with(extra, [&](auto& request) {
-        for (const auto& source_name : filter_source_names) {
-            *request.add_filter_source_names() = source_name;
-        }
-    }).invoke([](auto& response) {
-        return from_proto(response);
-    });
+Camera::image_collection CameraClient::get_images(std::vector<std::string> filter_source_names,
+                                                  const ProtoStruct& extra) {
+    return make_client_helper(this, *stub_, &StubType::GetImages)
+        .with(extra,
+              [&](auto& request) {
+                  for (const auto& source_name : filter_source_names) {
+                      *request.add_filter_source_names() = source_name;
+                  }
+              })
+        .invoke([](auto& response) { return from_proto(response); });
 };
 
 Camera::point_cloud CameraClient::get_point_cloud(std::string mime_type, const ProtoStruct& extra) {

--- a/src/viam/sdk/components/private/camera_client.cpp
+++ b/src/viam/sdk/components/private/camera_client.cpp
@@ -56,7 +56,6 @@ Camera::image_collection from_proto(const viam::component::camera::v1::GetImages
         raw_image.bytes = bytes;
         // TODO(RSDK-11733): This is a temporary fix to support handling both the format and mime
         // type. We will remove this once we remove the format field from the proto.
-        // We will remove this once we remove the format field from the proto.
         if (!img.mime_type().empty()) {
             raw_image.mime_type = img.mime_type();
         } else {
@@ -134,8 +133,10 @@ Camera::image_collection CameraClient::get_images(std::vector<std::string> filte
     return make_client_helper(this, *stub_, &StubType::GetImages)
         .with(extra,
               [&](auto& request) {
-                  for (const auto& source_name : filter_source_names) {
-                      *request.add_filter_source_names() = source_name;
+                  if (!filter_source_names.empty()) {
+                      request.mutable_filter_source_names()->Add(
+                          std::make_move_iterator(filter_source_names.begin()),
+                          std::make_move_iterator(filter_source_names.end()));
                   }
               })
         .invoke([](auto& response) { return from_proto(response); });

--- a/src/viam/sdk/components/private/camera_client.cpp
+++ b/src/viam/sdk/components/private/camera_client.cpp
@@ -134,13 +134,12 @@ Camera::image_collection CameraClient::get_images(std::vector<std::string> filte
         .with(extra,
               [&](auto& request) {
                   if (!filter_source_names.empty()) {
-                    // Once gRPC version is bumped we can avoid the loop and transfer ownership
-                    // of the vector to the request.
-                    // *request.mutable_filter_source_names() = std::move(filter_source_names)
-                    request.mutable_filter_source_names()->Reserve(filter_source_names.size());
-                    for (auto& source_name : filter_source_names) {
-                        request.add_filter_source_names(std::move(source_name));
-                    }
+                      // in newer gRPC versions we would be able to call `Add` or `Assign` on an
+                      // iterator range rather than element-wise copy
+                      request.mutable_filter_source_names()->Reserve(filter_source_names.size());
+                      for (auto& source_name : filter_source_names) {
+                          request.add_filter_source_names(std::move(source_name));
+                      }
                   }
               })
         .invoke([](auto& response) { return from_proto(response); });

--- a/src/viam/sdk/components/private/camera_client.hpp
+++ b/src/viam/sdk/components/private/camera_client.hpp
@@ -26,7 +26,8 @@ class CameraClient : public Camera {
     CameraClient(std::string name, std::shared_ptr<grpc::Channel> channel);
     ProtoStruct do_command(const ProtoStruct& command) override;
     raw_image get_image(std::string mime_type, const ProtoStruct& extra) override;
-    image_collection get_images(std::vector<std::string> filter_source_names, const ProtoStruct& extra) override;
+    image_collection get_images(std::vector<std::string> filter_source_names,
+                                const ProtoStruct& extra) override;
     point_cloud get_point_cloud(std::string mime_type, const ProtoStruct& extra) override;
     properties get_properties() override;
     std::vector<GeometryConfig> get_geometries(const ProtoStruct& extra) override;

--- a/src/viam/sdk/components/private/camera_client.hpp
+++ b/src/viam/sdk/components/private/camera_client.hpp
@@ -26,7 +26,7 @@ class CameraClient : public Camera {
     CameraClient(std::string name, std::shared_ptr<grpc::Channel> channel);
     ProtoStruct do_command(const ProtoStruct& command) override;
     raw_image get_image(std::string mime_type, const ProtoStruct& extra) override;
-    image_collection get_images() override;
+    image_collection get_images(std::vector<std::string> filter_source_names, const ProtoStruct& extra) override;
     point_cloud get_point_cloud(std::string mime_type, const ProtoStruct& extra) override;
     properties get_properties() override;
     std::vector<GeometryConfig> get_geometries(const ProtoStruct& extra) override;
@@ -42,6 +42,7 @@ class CameraClient : public Camera {
     // we need to include these `using` lines.
     using Camera::get_geometries;
     using Camera::get_image;
+    using Camera::get_images;
     using Camera::get_point_cloud;
 
    protected:

--- a/src/viam/sdk/components/private/camera_server.cpp
+++ b/src/viam/sdk/components/private/camera_server.cpp
@@ -83,12 +83,14 @@ CameraServer::CameraServer(std::shared_ptr<ResourceManager> manager)
     const ::viam::component::camera::v1::GetImagesRequest* request,
     ::viam::component::camera::v1::GetImagesResponse* response) noexcept {
     return make_service_helper<Camera>(
-        "CameraServer::GetImages", this, request)([&](auto&, auto& camera) {
-        const Camera::image_collection image_coll = camera->get_images();
+        "CameraServer::GetImages", this, request)([&](auto& helper, auto& camera) {
+        const Camera::image_collection image_coll =
+            camera->get_images({request->filter_source_names().begin(), request->filter_source_names().end()}, helper.getExtra());
         for (const auto& img : image_coll.images) {
             ::viam::component::camera::v1::Image proto_image;
             const std::string img_string = bytes_to_string(img.bytes);
             proto_image.set_source_name(img.source_name);
+            proto_image.set_mime_type(img.mime_type);
             proto_image.set_format(
                 MIME_string_to_format(Camera::normalize_mime_type(img.mime_type)));
             proto_image.set_image(img_string);

--- a/src/viam/sdk/components/private/camera_server.cpp
+++ b/src/viam/sdk/components/private/camera_server.cpp
@@ -84,8 +84,9 @@ CameraServer::CameraServer(std::shared_ptr<ResourceManager> manager)
     ::viam::component::camera::v1::GetImagesResponse* response) noexcept {
     return make_service_helper<Camera>(
         "CameraServer::GetImages", this, request)([&](auto& helper, auto& camera) {
-        const Camera::image_collection image_coll =
-            camera->get_images({request->filter_source_names().begin(), request->filter_source_names().end()}, helper.getExtra());
+        const Camera::image_collection image_coll = camera->get_images(
+            {request->filter_source_names().begin(), request->filter_source_names().end()},
+            helper.getExtra());
         for (const auto& img : image_coll.images) {
             ::viam::component::camera::v1::Image proto_image;
             const std::string img_string = bytes_to_string(img.bytes);

--- a/src/viam/sdk/tests/mocks/camera_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.cpp
@@ -1,4 +1,5 @@
 #include <viam/sdk/tests/mocks/camera_mocks.hpp>
+#include <algorithm>
 
 #include <viam/sdk/common/proto_value.hpp>
 #include <viam/sdk/components/camera.hpp>
@@ -16,8 +17,20 @@ ProtoStruct MockCamera::do_command(const ProtoStruct&) {
 Camera::raw_image MockCamera::get_image(std::string, const ProtoStruct&) {
     return image_;
 }
-Camera::image_collection MockCamera::get_images() {
-    return images_;
+Camera::image_collection MockCamera::get_images(std::vector<std::string> filter_source_names, const ProtoStruct& extra) {
+    last_filter_source_names_ = std::move(filter_source_names);
+    last_extra_ = extra;
+    if (last_filter_source_names_.empty()) {
+        return images_;
+    }
+    Camera::image_collection filtered = images_;
+    filtered.images.clear();
+    for (const auto& img : images_.images) {
+        if (std::find(last_filter_source_names_.begin(), last_filter_source_names_.end(), img.source_name) != last_filter_source_names_.end()) {
+            filtered.images.push_back(img);
+        }
+    }
+    return filtered;
 }
 Camera::point_cloud MockCamera::get_point_cloud(std::string, const ProtoStruct&) {
     return pc_;
@@ -43,13 +56,13 @@ Camera::image_collection fake_raw_images() {
     std::vector<Camera::raw_image> images;
     Camera::raw_image image1;
     image1.mime_type = "image/jpeg";
-    image1.source_name = "color_sensor";
+    image1.source_name = "color";
     std::vector<unsigned char> bytes1 = {'a', 'b', 'c'};
     image1.bytes = bytes1;
     images.push_back(image1);
     Camera::raw_image image2;
     image2.mime_type = "image/vnd.viam.dep";
-    image2.source_name = "depth_sensor";
+    image2.source_name = "depth";
     std::vector<unsigned char> bytes2 = {'d', 'e', 'f'};
     image2.bytes = bytes2;
     images.push_back(image2);

--- a/src/viam/sdk/tests/mocks/camera_mocks.cpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.cpp
@@ -1,5 +1,5 @@
-#include <viam/sdk/tests/mocks/camera_mocks.hpp>
 #include <algorithm>
+#include <viam/sdk/tests/mocks/camera_mocks.hpp>
 
 #include <viam/sdk/common/proto_value.hpp>
 #include <viam/sdk/components/camera.hpp>
@@ -17,7 +17,8 @@ ProtoStruct MockCamera::do_command(const ProtoStruct&) {
 Camera::raw_image MockCamera::get_image(std::string, const ProtoStruct&) {
     return image_;
 }
-Camera::image_collection MockCamera::get_images(std::vector<std::string> filter_source_names, const ProtoStruct& extra) {
+Camera::image_collection MockCamera::get_images(std::vector<std::string> filter_source_names,
+                                                const ProtoStruct& extra) {
     last_filter_source_names_ = std::move(filter_source_names);
     last_extra_ = extra;
     if (last_filter_source_names_.empty()) {
@@ -26,7 +27,9 @@ Camera::image_collection MockCamera::get_images(std::vector<std::string> filter_
     Camera::image_collection filtered = images_;
     filtered.images.clear();
     for (const auto& img : images_.images) {
-        if (std::find(last_filter_source_names_.begin(), last_filter_source_names_.end(), img.source_name) != last_filter_source_names_.end()) {
+        if (std::find(last_filter_source_names_.begin(),
+                      last_filter_source_names_.end(),
+                      img.source_name) != last_filter_source_names_.end()) {
             filtered.images.push_back(img);
         }
     }

--- a/src/viam/sdk/tests/mocks/camera_mocks.hpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.hpp
@@ -12,15 +12,20 @@ class MockCamera : public Camera {
    public:
     ProtoStruct do_command(const ProtoStruct& command) override;
     raw_image get_image(std::string mime_type, const sdk::ProtoStruct& extra) override;
-    image_collection get_images(std::vector<std::string> filter_source_names, const sdk::ProtoStruct& extra) override;
+    image_collection get_images(std::vector<std::string> filter_source_names,
+                                const sdk::ProtoStruct& extra) override;
     point_cloud get_point_cloud(std::string mime_type, const sdk::ProtoStruct& extra) override;
     std::vector<GeometryConfig> get_geometries(const sdk::ProtoStruct& extra) override;
     properties get_properties() override;
     static std::shared_ptr<MockCamera> get_mock_camera();
     MockCamera(std::string name) : Camera(std::move(name)) {}
 
-    const std::vector<std::string>& last_filter_source_names() const { return last_filter_source_names_; }
-    const ProtoStruct& last_extra() const { return last_extra_; }
+    const std::vector<std::string>& last_filter_source_names() const {
+        return last_filter_source_names_;
+    }
+    const ProtoStruct& last_extra() const {
+        return last_extra_;
+    }
 
    private:
     Camera::intrinsic_parameters intrinsic_parameters_;

--- a/src/viam/sdk/tests/mocks/camera_mocks.hpp
+++ b/src/viam/sdk/tests/mocks/camera_mocks.hpp
@@ -12,12 +12,15 @@ class MockCamera : public Camera {
    public:
     ProtoStruct do_command(const ProtoStruct& command) override;
     raw_image get_image(std::string mime_type, const sdk::ProtoStruct& extra) override;
-    image_collection get_images() override;
+    image_collection get_images(std::vector<std::string> filter_source_names, const sdk::ProtoStruct& extra) override;
     point_cloud get_point_cloud(std::string mime_type, const sdk::ProtoStruct& extra) override;
     std::vector<GeometryConfig> get_geometries(const sdk::ProtoStruct& extra) override;
     properties get_properties() override;
     static std::shared_ptr<MockCamera> get_mock_camera();
     MockCamera(std::string name) : Camera(std::move(name)) {}
+
+    const std::vector<std::string>& last_filter_source_names() const { return last_filter_source_names_; }
+    const ProtoStruct& last_extra() const { return last_extra_; }
 
    private:
     Camera::intrinsic_parameters intrinsic_parameters_;
@@ -28,6 +31,8 @@ class MockCamera : public Camera {
     Camera::point_cloud pc_;
     ProtoStruct map_;
     std::vector<GeometryConfig> geometries_;
+    std::vector<std::string> last_filter_source_names_;
+    ProtoStruct last_extra_;
 };
 
 Camera::raw_image fake_raw_image();

--- a/src/viam/sdk/tests/test_camera.cpp
+++ b/src/viam/sdk/tests/test_camera.cpp
@@ -70,15 +70,16 @@ BOOST_AUTO_TEST_CASE(test_get_images_filtering) {
 }
 
 BOOST_AUTO_TEST_CASE(test_get_images_with_extra) {
-    auto mock = MockCamera::get_mock_camera();
-    CameraClient client("camera", std::make_shared<ClientChannel>("camera", "a", mock));
-    ProtoStruct extra;
-    extra["foo"] = ProtoValue("bar");
-    auto images = client.get_images({}, extra);
-    (void)images;  // unused variable in test body
-    const auto& last_extra = mock->last_extra();
-    BOOST_CHECK(last_extra.at("foo").is_a<std::string>());
-    BOOST_CHECK_EQUAL(last_extra.at("foo").get_unchecked<std::string>(), "bar");
+    std::shared_ptr<MockCamera> mock = MockCamera::get_mock_camera();
+    client_to_mock_pipeline<Camera>(mock, [&](Camera& client) {
+        ProtoStruct extra;
+        extra["foo"] = ProtoValue("bar");
+        auto images = client.get_images({}, extra);
+        (void)images;  // unused variable in test body
+        const auto& last_extra = mock->last_extra();
+        BOOST_CHECK(last_extra.at("foo").is_a<std::string>());
+        BOOST_CHECK_EQUAL(last_extra.at("foo").get_unchecked<std::string>(), "bar");
+    });
 }
 
 BOOST_AUTO_TEST_CASE(test_get_point_cloud) {

--- a/src/viam/sdk/tests/test_camera.cpp
+++ b/src/viam/sdk/tests/test_camera.cpp
@@ -70,16 +70,15 @@ BOOST_AUTO_TEST_CASE(test_get_images_filtering) {
 }
 
 BOOST_AUTO_TEST_CASE(test_get_images_with_extra) {
-    std::shared_ptr<MockCamera> mock = MockCamera::get_mock_camera();
-    client_to_mock_pipeline<Camera>(mock, [&](Camera& client) {
-        ProtoStruct extra;
-        extra["foo"] = ProtoValue("bar");
-        auto images = client.get_images({}, extra);
-        (void)images; // unused variable in test body
-        const auto& last_extra = mock->last_extra();
-        BOOST_CHECK(last_extra.at("foo").is_a<std::string>());
-        BOOST_CHECK_EQUAL(last_extra.at("foo").get_unchecked<std::string>(), "bar");
-    });
+    auto mock = MockCamera::get_mock_camera();
+    CameraClient client("camera", std::make_shared<ClientChannel>("camera", "a", mock));
+    ProtoStruct extra;
+    extra["foo"] = ProtoValue("bar");
+    auto images = client.get_images({}, extra);
+    (void)images;  // unused variable in test body
+    const auto& last_extra = mock->last_extra();
+    BOOST_CHECK(last_extra.at("foo").is_a<std::string>());
+    BOOST_CHECK_EQUAL(last_extra.at("foo").get_unchecked<std::string>(), "bar");
 }
 
 BOOST_AUTO_TEST_CASE(test_get_point_cloud) {


### PR DESCRIPTION
This PR is part of the SDK changes of[ the Consolidate GetImage(s) project](https://docs.google.com/document/d/1Q4UWacS76tx3ohOjS98aei2UdHU4XdyWsFldQHTQ_7s/edit?usp=sharing)

It

- Updates the GetImages signature to be in line with [the new camera.proto](https://github.com/viamrobotics/api/blob/main/proto/viam/component/camera/v1/camera.proto)
- Updates unit tests accordingly

# Manual Testing

Built a local RealSense module executable with its C++ SDK pinned to this commit https://github.com/viamrobotics/viam-cpp-sdk/pull/481/commits/d8292dfdc29fcc51ee84f09c9bdb211c778d7857

Added logging to make sure that the server is receiving extra and filter_source_names. It was

```
8/27/2025, 2:16:11 PM info Viam C++ SDK     [src/camera_realsense.cpp:439] extra keys: ["foo"]   log_ts 2025-08-27T14:16:11.789Z

8/27/2025, 2:16:11 PM info Viam C++ SDK     [src/camera_realsense.cpp:426] filter_source_names: ["color"]   log_ts 2025-08-27T14:16:11.788Z
``` 

Verified client received back metadata and loaded the image properly.

```
2025-08-27 14:16:11,704         INFO    viam.rpc.dial (dial.py:336)     Connecting to socket: /tmp/proxy-6MDrUDgt.sock
captured_at {
  seconds: 1756318571
  nanos: 669000000
}

length of images: 1
image/jpeg
```