### PR TITLE
Updating buildjet runners to use github actions

### DIFF
--- a/.github/workflows/conan-publish.yml
+++ b/.github/workflows/conan-publish.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [buildjet-8vcpu-ubuntu-2204, buildjet-8vcpu-ubuntu-2204-arm]
+        runner: [ubuntu-large, github-linux-arm64-8core]
         image: [ubuntu:22.04, debian:bookworm]
     runs-on: ${{ matrix.runner }}
     container:
@@ -186,7 +186,7 @@ jobs:
         path: conan.lock
 
     - name: Upload additional deps
-      if: inputs.upload_deps && !(matrix.runner == 'buildjet-8vcpu-ubuntu-2204' && matrix.image == 'ubuntu:22.04')
+      if: inputs.upload_deps && !(matrix.runner == 'ubuntu-large' && matrix.image == 'ubuntu:22.04')
       run: |
         . ./conan_venv/bin/activate
 

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -90,11 +90,11 @@ jobs:
           - target: aarch64-ubuntu-jammy-gnu
             platform: linux_aarch64-ubuntu-jammy
             image: ubuntu:22.04
-            runs_on: buildjet-8vcpu-ubuntu-2204-arm
+            runs_on: github-linux-arm64-8core
           - target: x86_64-ubuntu-jammy-gnu
             platform: linux_x86_64-ubuntu-jammy
             image: ubuntu:22.04
-            runs_on: buildjet-8vcpu-ubuntu-2204
+            runs_on: ubuntu-large
 
     steps:
       - name: Checkout Code
@@ -150,19 +150,19 @@ jobs:
           - target: aarch64-debian-bullseye
             platform: linux_aarch64-debian-bullseye
             image: debian:bullseye
-            runs_on: buildjet-8vcpu-ubuntu-2204-arm
+            runs_on: github-linux-arm64-8core
           - target: x86_64-debian-bullseye
             platform: linux_x86_64-debian-bullseye
             image: debian:bullseye
-            runs_on: buildjet-8vcpu-ubuntu-2204
+            runs_on: ubuntu-large
           - target: aarch64-debian-bookworm
             platform: linux_aarch64-debian-bookworm
             image: debian:bookworm
-            runs_on: buildjet-8vcpu-ubuntu-2204-arm
+            runs_on: github-linux-arm64-8core
           - target: x86_64-debian-bookworm
             platform: linux_x86_64-debian-bookworm
             image: debian:bookworm
-            runs_on: buildjet-8vcpu-ubuntu-2204
+            runs_on: ubuntu-large
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,11 +149,11 @@ jobs:
           - target: aarch64-ubuntu-jammy-gnu
             platform: linux_aarch64-ubuntu-jammy
             image: ubuntu:22.04
-            runs_on: buildjet-8vcpu-ubuntu-2204-arm
+            runs_on: github-linux-arm64-8core
           - target: x86_64-ubuntu-jammy-gnu
             platform: linux_x86_64-ubuntu-jammy
             image: ubuntu:22.04
-            runs_on: buildjet-8vcpu-ubuntu-2204
+            runs_on: ubuntu-large
 
     steps:
       - name: Checkout Code
@@ -232,11 +232,11 @@ jobs:
           - target: aarch64-debian-bookworm
             platform: linux_aarch64-debian-bookworm
             image: debian:bookworm
-            runs_on: buildjet-8vcpu-ubuntu-2204-arm
+            runs_on: github-linux-arm64-8core
           - target: x86_64-debian-bookworm
             platform: linux_x86_64-debian-bookworm
             image: debian:bookworm
-            runs_on: buildjet-8vcpu-ubuntu-2204
+            runs_on: ubuntu-large
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Buildjet runners have been failing in CI. This PR updates CI to use github action runners.