### PR TITLE
Read JIRA_BASE_URL from vars instead of secrets

### DIFF
--- a/.github/workflows/sync-release-to-jira.yml
+++ b/.github/workflows/sync-release-to-jira.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run Jira sync
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}
           JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
           # Pass version via env var to prevent shell injection


### PR DESCRIPTION
## Summary
- Switch `JIRA_BASE_URL` to `${{ vars.JIRA_BASE_URL }}` in the sync-release-to-jira workflow
- Matches the convention already used in `viamrobotics/rdk`

## Why
Storing the Jira instance URL as a secret caused Actions to mask it in log output, which obscured the "Release page" link printed at the end of `etc/sync_jira_release.py`. The URL isn't sensitive — it's visible to anyone viewing a Jira ticket — so a variable is the right fit.

## Follow-up required on repo settings
- Settings → Secrets and variables → Actions → **Variables** → add `JIRA_BASE_URL` (e.g. `https://viam.atlassian.net`)
- Delete the existing `JIRA_BASE_URL` **secret** so its value stops being masked in logs

## Test plan
- [ ] Re-run the "Sync Release to Jira" workflow after repo-settings update
- [ ] Confirm the "Release page" URL is rendered in full (no `***`) in the run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)