### PR TITLE
Fix log timestamps to use utc_clock instead of local_clock

### DIFF
--- a/src/viam/sdk/log/logging.cpp
+++ b/src/viam/sdk/log/logging.cpp
@@ -152,7 +152,7 @@ void LogManager::init_logging() {
                                  boost::log::attributes::make_constant(module_tag{}));
 
     boost::log::core::get()->add_global_attribute("TimeStamp",
-                                                  boost::log::attributes::local_clock());
+                                                  boost::log::attributes::utc_clock());
 
     const boost::log::formatter fmt =
         boost::log::expressions::stream

--- a/src/viam/sdk/log/logging.cpp
+++ b/src/viam/sdk/log/logging.cpp
@@ -151,8 +151,7 @@ void LogManager::init_logging() {
     module_logger_.add_attribute("module_log_tag",
                                  boost::log::attributes::make_constant(module_tag{}));
 
-    boost::log::core::get()->add_global_attribute("TimeStamp",
-                                                  boost::log::attributes::utc_clock());
+    boost::log::core::get()->add_global_attribute("TimeStamp", boost::log::attributes::utc_clock());
 
     const boost::log::formatter fmt =
         boost::log::expressions::stream

--- a/src/viam/sdk/log/logging.hpp
+++ b/src/viam/sdk/log/logging.hpp
@@ -161,7 +161,7 @@ BOOST_LOG_ATTRIBUTE_KEYWORD_TYPE(attr_file, "file", boost::string_view);
 BOOST_LOG_ATTRIBUTE_KEYWORD_TYPE(attr_line, "line", unsigned int);
 BOOST_LOG_ATTRIBUTE_KEYWORD_TYPE(attr_time,
                                  "TimeStamp",
-                                 boost::log::attributes::local_clock::value_type);
+                                 boost::log::attributes::utc_clock::value_type);
 
 }  // namespace sdk
 }  // namespace viam


### PR DESCRIPTION
Log timestamps were generated using `local_clock()`, which produces local system time. The timestamp is then converted via ptime_convert() which subtracts the UTC epoch - implicitly assuming the ptime is UTC. Feeding it local time produces a timestamp offset by the machine's UTC offset

C++ SDK log_ts was consistently 4 hours behind the rdk's utc timestamps for the same event

The output is a protobuf Timestamp, which is defined as UTC by spec