### PR TITLE
AI update based on proto changes

### DIFF
--- a/src/viam/sdk/app/data_client.cpp
+++ b/src/viam/sdk/app/data_client.cpp
@@ -9,6 +9,7 @@
 
 #include <viam/sdk/common/client_helper.hpp>
 #include <viam/sdk/common/utils.hpp>
+#include <viam/sdk/app/data_client_proto_conversions.hpp>
 
 namespace viam {
 namespace sdk {
@@ -97,6 +98,90 @@ std::vector<DataClient::BSONBytes> DataClient::tabular_data_by_mql(
 std::vector<DataClient::BSONBytes> DataClient::tabular_data_by_mql(
     const std::string& org_id, const std::vector<DataClient::BSONBytes>& mql_binary) {
     return tabular_data_by_mql(org_id, mql_binary, tabular_data_by_mql_opts{});
+}
+
+std::string DataClient::create_sequence(const std::string& org_id, const CreateSequenceOptions& opts) {
+    return pimpl_->client_helper(&DataService::Stub::CreateSequence)
+        .with([&](app::data::v1::CreateSequenceRequest& req) {
+            req.set_organization_id(org_id);
+            for (const auto& resource : opts.resources) {
+                *req.add_resources() = to_proto(resource);
+            }
+            for (const auto& tag : opts.sequence_tags) {
+                req.add_sequence_tags(tag);
+            }
+            if (opts.start_time.has_value()) {
+                *req.mutable_start_time() = to_proto(*opts.start_time);
+            }
+            if (opts.end_time.has_value()) {
+                *req.mutable_end_time() = to_proto(*opts.end_time);
+            }
+        })
+        .invoke([](const app::data::v1::CreateSequenceResponse& resp) { return resp.id(); });
+}
+
+Sequence DataClient::get_sequence(const GetSequenceOptions& opts) {
+    return pimpl_->client_helper(&DataService::Stub::GetSequence)
+        .with([&](app::data::v1::GetSequenceRequest& req) { req.set_id(opts.id); })
+        .invoke([](const app::data::v1::GetSequenceResponse& resp) { return from_proto(resp.sequence()); });
+}
+
+void DataClient::update_sequence(const UpdateSequenceOptions& opts) {
+    pimpl_->client_helper(&DataService::Stub::UpdateSequence)
+        .with([&](app::data::v1::UpdateSequenceRequest& req) {
+            req.set_id(opts.id);
+            if (opts.resources.has_value()) {
+                for (const auto& resource : *opts.resources) {
+                    *req.add_resources() = to_proto(resource);
+                }
+            }
+            if (opts.sequence_tags.has_value()) {
+                for (const auto& tag : *opts.sequence_tags) {
+                    req.add_sequence_tags(tag);
+                }
+            }
+            if (opts.start_time.has_value()) {
+                *req.mutable_start_time() = to_proto(*opts.start_time);
+            }
+            if (opts.end_time.has_value()) {
+                *req.mutable_end_time() = to_proto(*opts.end_time);
+            }
+            if (opts.field_mask_paths.has_value()) {
+                *req.mutable_field_mask() = to_proto(*opts.field_mask_paths);
+            }
+        })
+        .invoke([](const app::data::v1::UpdateSequenceResponse& resp) {});
+}
+
+void DataClient::delete_sequence(const DeleteSequenceOptions& opts) {
+    pimpl_->client_helper(&DataService::Stub::DeleteSequence)
+        .with([&](app::data::v1::DeleteSequenceRequest& req) { req.set_id(opts.id); })
+        .invoke([](const app::data::v1::DeleteSequenceResponse& resp) {});
+}
+
+std::pair<std::vector<Sequence>, std::string> DataClient::list_sequences(
+    const std::string& org_id, const ListSequencesOptions& opts) {
+    return pimpl_->client_helper(&DataService::Stub::ListSequences)
+        .with([&](app::data::v1::ListSequencesRequest& req) {
+            req.set_organization_id(org_id);
+            if (opts.page_token.has_value()) {
+                req.set_page_token(*opts.page_token);
+            }
+            if (opts.page_size.has_value()) {
+                req.set_page_size(*opts.page_size);
+            }
+        })
+        .invoke([](const app::data::v1::ListSequencesResponse& resp) {
+            std::vector<Sequence> sequences;
+            for (const auto& sequence_proto : resp.sequences()) {
+                sequences.push_back(from_proto(sequence_proto));
+            }
+            return std::make_pair(sequences, resp.next_page_token());
+        });
+}
+
+std::pair<std::vector<Sequence>, std::string> DataClient::list_sequences(const std::string& org_id) {
+    return list_sequences(org_id, ListSequencesOptions{});
 }
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/app/data_client.hpp
+++ b/src/viam/sdk/app/data_client.hpp
@@ -9,6 +9,7 @@
 #include <boost/optional.hpp>
 
 #include <viam/sdk/app/viam_client.hpp>
+#include <viam/sdk/app/data_client_proto_conversions.hpp>
 
 namespace viam {
 namespace sdk {
@@ -27,6 +28,40 @@ class DataClient {
 
         /// @brief Used to specify a saved query to run.
         boost::optional<std::string> query_prefix;
+    };
+
+    /// @brief Options for creating a sequence.
+    struct CreateSequenceOptions {
+        std::vector<SequenceResourceFilter> resources;
+        std::vector<std::string> sequence_tags;
+        boost::optional<time_pt> start_time;
+        boost::optional<time_pt> end_time;
+    };
+
+    /// @brief Options for retrieving a sequence.
+    struct GetSequenceOptions {
+        std::string id;
+    };
+
+    /// @brief Options for updating a sequence.
+    struct UpdateSequenceOptions {
+        std::string id;
+        boost::optional<std::vector<SequenceResourceFilter>> resources;
+        boost::optional<std::vector<std::string>> sequence_tags;
+        boost::optional<time_pt> start_time;
+        boost::optional<time_pt> end_time;
+        boost::optional<std::vector<std::string>> field_mask_paths;
+    };
+
+    /// @brief Options for deleting a sequence.
+    struct DeleteSequenceOptions {
+        std::string id;
+    };
+
+    /// @brief Options for listing sequences.
+    struct ListSequencesOptions {
+        boost::optional<std::string> page_token;
+        boost::optional<uint32_t> page_size;
     };
 
     using BSONBytes = std::vector<uint8_t>;
@@ -54,6 +89,35 @@ class DataClient {
     /// @brief Convenience overload with default options.
     std::vector<BSONBytes> tabular_data_by_mql(const std::string& org_id,
                                                const std::vector<BSONBytes>& mql_binary);
+
+    /// @brief Create a new sequence.
+    /// @param org_id The organization ID.
+    /// @param opts Options for creating the sequence.
+    /// @return The ID of the created sequence.
+    std::string create_sequence(const std::string& org_id, const CreateSequenceOptions& opts);
+
+    /// @brief Retrieve a sequence by ID.
+    /// @param opts Options for retrieving the sequence.
+    /// @return The retrieved sequence.
+    Sequence get_sequence(const GetSequenceOptions& opts);
+
+    /// @brief Update the mutable fields of a sequence.
+    /// @param opts Options for updating the sequence.
+    void update_sequence(const UpdateSequenceOptions& opts);
+
+    /// @brief Delete a sequence by ID.
+    /// @param opts Options for deleting the sequence.
+    void delete_sequence(const DeleteSequenceOptions& opts);
+
+    /// @brief List sequences for a given organization.
+    /// @param org_id The organization ID.
+    /// @param opts Options for listing sequences.
+    /// @return A pair containing a vector of sequences and the next page token.
+    std::pair<std::vector<Sequence>, std::string> list_sequences(
+        const std::string& org_id, const ListSequencesOptions& opts);
+
+    /// @brief Convenience overload for listing sequences with default options.
+    std::pair<std::vector<Sequence>, std::string> list_sequences(const std::string& org_id);
 
    private:
     DataClient(const ViamChannel& channel);

--- a/src/viam/sdk/app/data_client_proto_conversions.cpp
+++ b/src/viam/sdk/app/data_client_proto_conversions.cpp
@@ -1,0 +1,93 @@
+#include <viam/sdk/app/data_client_proto_conversions.hpp>
+
+namespace viam {
+namespace sdk {
+
+// Equality for SequenceResourceFilter
+bool operator==(const SequenceResourceFilter& lhs, const SequenceResourceFilter& rhs) {
+    return lhs.part_id == rhs.part_id && lhs.resource_name == rhs.resource_name &&
+           lhs.method_name == rhs.method_name;
+}
+
+// Equality for Sequence
+bool operator==(const Sequence& lhs, const Sequence& rhs) {
+    return lhs.id == rhs.id && lhs.organization_id == rhs.organization_id &&
+           lhs.sequence_tags == rhs.sequence_tags && lhs.created_at == rhs.created_at &&
+           lhs.updated_at == rhs.updated_at && lhs.start_time == rhs.start_time &&
+           lhs.end_time == rhs.end_time && lhs.resources == rhs.resources;
+}
+
+namespace proto_convert_details {
+
+// Conversions for SequenceResourceFilter
+void to_proto_impl<SequenceResourceFilter>::operator()(
+    const SequenceResourceFilter& sdk_type, viam::app::data::v1::SequenceResourceFilter* proto_type) const {
+    proto_type->set_part_id(sdk_type.part_id);
+    proto_type->set_resource_name(sdk_type.resource_name);
+    proto_type->set_method_name(sdk_type.method_name);
+}
+
+SequenceResourceFilter from_proto_impl<viam::app::data::v1::SequenceResourceFilter>::operator()(
+    const viam::app::data::v1::SequenceResourceFilter* proto_type) const {
+    SequenceResourceFilter sdk_type;
+    sdk_type.part_id = proto_type->part_id();
+    sdk_type.resource_name = proto_type->resource_name();
+    sdk_type.method_name = proto_type->method_name();
+    return sdk_type;
+}
+
+// Conversions for Sequence
+void to_proto_impl<Sequence>::operator()(const Sequence& sdk_type, viam::app::data::v1::Sequence* proto_type) const {
+    proto_type->set_id(sdk_type.id);
+    proto_type->set_organization_id(sdk_type.organization_id);
+    for (const auto& tag : sdk_type.sequence_tags) {
+        proto_type->add_sequence_tags(tag);
+    }
+    *proto_type->mutable_created_at() = to_proto(sdk_type.created_at);
+    *proto_type->mutable_updated_at() = to_proto(sdk_type.updated_at);
+    *proto_type->mutable_start_time() = to_proto(sdk_type.start_time);
+    *proto_type->mutable_end_time() = to_proto(sdk_type.end_time);
+    for (const auto& resource : sdk_type.resources) {
+        *proto_type->add_resources() = to_proto(resource);
+    }
+}
+
+Sequence from_proto_impl<viam::app::data::v1::Sequence>::operator()(
+    const viam::app::data::v1::Sequence* proto_type) const {
+    Sequence sdk_type;
+    sdk_type.id = proto_type->id();
+    sdk_type.organization_id = proto_type->organization_id();
+    for (const auto& tag : proto_type->sequence_tags()) {
+        sdk_type.sequence_tags.push_back(tag);
+    }
+    sdk_type.created_at = from_proto(proto_type->created_at());
+    sdk_type.updated_at = from_proto(proto_type->updated_at());
+    sdk_type.start_time = from_proto(proto_type->start_time());
+    sdk_type.end_time = from_proto(proto_type->end_time());
+    for (const auto& resource : proto_type->resources()) {
+        sdk_type.resources.push_back(from_proto(resource));
+    }
+    return sdk_type;
+}
+
+// Conversions for google::protobuf::FieldMask
+void to_proto_impl<std::vector<std::string>>::operator()(
+    const std::vector<std::string>& sdk_type, google::protobuf::FieldMask* proto_type) const {
+    for (const auto& path : sdk_type) {
+        proto_type->add_paths(path);
+    }
+}
+
+std::vector<std::string> from_proto_impl<google::protobuf::FieldMask>::operator()(
+    const google::protobuf::FieldMask* proto_type) const {
+    std::vector<std::string> sdk_type;
+    for (const auto& path : proto_type->paths()) {
+        sdk_type.push_back(path);
+    }
+    return sdk_type;
+}
+
+}  // namespace proto_convert_details
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/app/data_client_proto_conversions.hpp
+++ b/src/viam/sdk/app/data_client_proto_conversions.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <boost/optional.hpp>
+
+#include <viam/api/app/data/v1/data.grpc.pb.h>
+#include <viam/api/app/data/v1/data.pb.h>
+#include <viam/api/google/protobuf/field_mask.pb.h>
+#include <viam/api/google/protobuf/timestamp.pb.h>
+
+#include <viam/sdk/common/proto_convert.hpp>
+#include <viam/sdk/common/utils.hpp>
+
+namespace viam {
+namespace sdk {
+
+// SDK struct for SequenceResourceFilter
+struct SequenceResourceFilter {
+    std::string part_id;
+    std::string resource_name;
+    std::string method_name;
+
+    friend bool operator==(const SequenceResourceFilter& lhs, const SequenceResourceFilter& rhs);
+};
+
+// SDK struct for Sequence
+struct Sequence {
+    std::string id;
+    std::string organization_id;
+    std::vector<std::string> sequence_tags;
+    time_pt created_at;
+    time_pt updated_at;
+    time_pt start_time;
+    time_pt end_time;
+    std::vector<SequenceResourceFilter> resources;
+
+    friend bool operator==(const Sequence& lhs, const Sequence& rhs);
+};
+
+namespace proto_convert_details {
+
+// Conversions for SequenceResourceFilter
+template <>
+struct to_proto_impl<SequenceResourceFilter> {
+    void operator()(const SequenceResourceFilter&, viam::app::data::v1::SequenceResourceFilter*) const;
+};
+
+template <>
+struct from_proto_impl<viam::app::data::v1::SequenceResourceFilter> {
+    SequenceResourceFilter operator()(const viam::app::data::v1::SequenceResourceFilter*) const;
+};
+
+// Conversions for Sequence
+template <>
+struct to_proto_impl<Sequence> {
+    void operator()(const Sequence&, viam::app::data::v1::Sequence*) const;
+};
+
+template <>
+struct from_proto_impl<viam::app::data::v1::Sequence> {
+    Sequence operator()(const viam::app::data::v1::Sequence*) const;
+};
+
+// Conversions for google::protobuf::FieldMask
+template <>
+struct to_proto_impl<std::vector<std::string>> {
+    void operator()(const std::vector<std::string>&, google::protobuf::FieldMask*) const;
+};
+
+template <>
+struct from_proto_impl<google::protobuf::FieldMask> {
+    std::vector<std::string> operator()(const google::protobuf::FieldMask*) const;
+};
+
+}  // namespace proto_convert_details
+
+}  // namespace sdk
+}  // namespace viam


### PR DESCRIPTION
This is an AI-generated PR to update the SDK based on proto changes. The AI may make mistakes so review carefully.

**Summary of Changes:**
This change introduces support for managing sequences within the Viam App Data API.

Key updates include:

*   **New Sequence Management API:** Added gRPC methods for creating, retrieving, updating, deleting, and listing sequences.
*   **SDK Integration:**
    *   Introduced new SDK structs (`SequenceResourceFilter`, `Sequence`) and corresponding proto conversion utilities.
    *   Added new methods to the `DataClient` (`create_sequence`, `get_sequence`, `update_sequence`, `delete_sequence`, `list_sequences`) to expose this functionality.
    *   Defined new `Options` structs to manage parameters for these sequence operations.