### PR TITLE
AI update based on proto changes

### DIFF
--- a/src/viam/sdk/components/audio_out.hpp
+++ b/src/viam/sdk/components/audio_out.hpp
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <string>
+#include <vector>
+#include <memory>
 
 #include <boost/optional/optional.hpp>
 
@@ -16,6 +18,37 @@ namespace viam {
 namespace sdk {
 
 /// @defgroup AudioOut Classes related to the AudioOut component.
+
+// Forward declarations
+class AudioOutStreamWriter;
+class AudioOutStreamReader;
+
+/// @class AudioOutStreamWriter audio_out.hpp "components/audio_out.hpp"
+/// @brief An abstract base class for writing audio streams.
+class AudioOutStreamWriter {
+   public:
+    /// @brief Writes audio data to the stream.
+    /// @param audio_data The audio data to write.
+    virtual void write(std::vector<uint8_t> const& audio_data) = 0;
+
+    /// @brief Closes the audio stream.
+    virtual void close() = 0;
+
+    /// @brief Virtual destructor.
+    virtual ~AudioOutStreamWriter() = default;
+};
+
+/// @class AudioOutStreamReader audio_out.hpp "components/audio_out.hpp"
+/// @brief An abstract base class for reading audio streams.
+class AudioOutStreamReader {
+   public:
+    /// @brief Reads audio data from the stream.
+    /// @return An optional vector of bytes containing the audio data, or boost::none if no data is available.
+    virtual boost::optional<std::vector<uint8_t>> read() = 0;
+
+    /// @brief Virtual destructor.
+    virtual ~AudioOutStreamReader() = default;
+};
 
 /// @class AudioOut audio_out.hpp "components/audio_out.hpp"
 /// @brief An `AudioOut` is a device that can output audio.
@@ -74,6 +107,25 @@ class AudioOut : public Component {
     /// @param extra Any additional arguments to the method.
     /// @return The requested `GeometryConfig`s associated with the component.
     virtual std::vector<GeometryConfig> get_geometries(const ProtoStruct& extra) = 0;
+
+    /// @brief Plays an audio stream.
+    /// @param info Information about the audio stream.
+    /// @param extra Any additional arguments to the method.
+    /// @return A unique pointer to an `AudioOutStreamWriter` for writing the audio stream.
+    virtual std::unique_ptr<AudioOutStreamWriter> play_stream(audio_info info, const ProtoStruct& extra) = 0;
+
+    /// @brief Plays an audio stream from a reader.
+    /// @param reader A unique pointer to an `AudioOutStreamReader` for reading the audio stream.
+    /// @param info Information about the audio stream.
+    /// @param extra Any additional arguments to the method.
+    virtual void play_stream(std::unique_ptr<AudioOutStreamReader> reader, audio_info info, const ProtoStruct& extra) = 0;
+
+    /// @brief Plays an audio stream.
+    /// @param info Information about the audio stream.
+    /// @return A unique pointer to an `AudioOutStreamWriter` for writing the audio stream.
+    inline std::unique_ptr<AudioOutStreamWriter> play_stream(audio_info info) {
+        return play_stream(std::move(info), {});
+    }
 
     API api() const override;
 

--- a/src/viam/sdk/components/private/audio_out_client.cpp
+++ b/src/viam/sdk/components/private/audio_out_client.cpp
@@ -82,6 +82,48 @@ std::vector<GeometryConfig> AudioOutClient::get_geometries(const ProtoStruct& ex
         .invoke([](auto& response) { return from_proto(response); });
 };
 
+AudioOutClientStreamWriter::AudioOutClientStreamWriter(
+    std::unique_ptr<::grpc::ClientWriter< ::viam::component::audioout::v1::PlayStreamRequest>> writer,
+    audio_info info,
+    const ProtoStruct& extra,
+    const std::string& name)
+    : writer_(std::move(writer)) {
+    ::viam::component::audioout::v1::PlayStreamInit init_message;
+    init_message.set_name(name);
+    ::viam::common::v1::AudioInfo* proto_info = init_message.mutable_audio_info();
+    proto_info->set_codec(info.codec);
+    proto_info->set_sample_rate_hz(info.sample_rate_hz);
+    proto_info->set_num_channels(info.num_channels);
+    *init_message.mutable_extra() = to_proto(extra);
+
+    ::viam::component::audioout::v1::PlayStreamRequest init_request;
+    *init_request.mutable_init() = init_message;
+    writer_->Write(init_request);
+}
+
+void AudioOutClientStreamWriter::write(std::vector<uint8_t> const& audio_data) {
+    ::viam::component::audioout::v1::PlayStreamChunk chunk_message;
+    std::string audio_data_str(audio_data.begin(), audio_data.end());
+    chunk_message.set_audio_data(std::move(audio_data_str));
+
+    ::viam::component::audioout::v1::PlayStreamRequest chunk_request;
+    *chunk_request.mutable_audio_chunk() = chunk_message;
+    writer_->Write(chunk_request);
+}
+
+void AudioOutClientStreamWriter::close() {
+    writer_->WritesDone();
+    writer_->Finish(&response_);
+}
+
+std::unique_ptr<AudioOutStream> AudioOutClient::play_stream(audio_info info,
+                                                           const ProtoStruct& extra) {
+    ::grpc::ClientContext context;
+    ::viam::component::audioout::v1::PlayStreamResponse response;
+    auto writer = stub_->PlayStream(&context, &response);
+    return std::make_unique<AudioOutClientStreamWriter>(std::move(writer), info, extra, name());
+}
+
 }  // namespace impl
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/components/private/audio_out_client.hpp
+++ b/src/viam/sdk/components/private/audio_out_client.hpp
@@ -12,6 +12,17 @@ namespace viam {
 namespace sdk {
 namespace impl {
 
+class AudioOutClientStreamWriter : public AudioOutStreamWriter {
+   public:
+    AudioOutClientStreamWriter(std::unique_ptr<::grpc::ClientWriter< ::viam::component::audioout::v1::PlayStreamRequest>> writer, audio_info info, const ProtoStruct& extra, const std::string& name);
+    void write(std::vector<uint8_t> const& audio_data) override;
+    void close() override;
+
+   private:
+    std::unique_ptr<::grpc::ClientWriter< ::viam::component::audioout::v1::PlayStreamRequest>> writer_;
+    ::viam::component::audioout::v1::PlayStreamResponse response_;
+};
+
 /// @class AudioOutClient
 /// @brief gRPC client implementation of an `AudioOut` component.
 /// @ingroup AudioOut
@@ -36,9 +47,12 @@ class AudioOutClient : public AudioOut {
 
     std::vector<GeometryConfig> get_geometries(const ProtoStruct& extra) override;
 
+    std::unique_ptr<AudioOutStreamWriter> play_stream(audio_info info, const ProtoStruct& extra) override;
+
     using AudioOut::get_geometries;
     using AudioOut::get_properties;
     using AudioOut::play;
+    using AudioOut::play_stream;
 
    private:
     using StubType = viam::component::audioout::v1::AudioOutService::StubInterface;

--- a/src/viam/sdk/components/private/audio_out_server.cpp
+++ b/src/viam/sdk/components/private/audio_out_server.cpp
@@ -9,6 +9,21 @@ namespace viam {
 namespace sdk {
 namespace impl {
 
+// AudioOutServerStreamReader
+AudioOutServerStreamReader::AudioOutServerStreamReader(
+    ::grpc::ServerReader< ::viam::component::audioout::v1::PlayStreamRequest>* reader)
+    : reader_(reader) {}
+
+boost::optional<std::vector<uint8_t>> AudioOutServerStreamReader::read() {
+    ::viam::component::audioout::v1::PlayStreamRequest request;
+    if (reader_->Read(&request)) {
+        if (request.payload_case() == ::viam::component::audioout::v1::PlayStreamRequest::kAudioChunk) {
+            return boost::make_optional(string_to_bytes(request.audio_chunk().audio_data()));
+        }
+    }
+    return boost::none;
+}
+
 AudioOutServer::AudioOutServer(std::shared_ptr<ResourceManager> manager)
     : ResourceServer(std::move(manager)) {}
 
@@ -30,6 +45,36 @@ AudioOutServer::AudioOutServer(std::shared_ptr<ResourceManager> manager)
         }
         audio_out->play(audio_data, info, helper.getExtra());
     });
+}
+
+::grpc::Status AudioOutServer::PlayStream(
+    ::grpc::ServerContext* context,
+    ::grpc::ServerReader< ::viam::component::audioout::v1::PlayStreamRequest>* reader) {
+    return make_service_helper<AudioOut>(
+        "AudioOutServer::PlayStream", this, context, reader)(
+        [&](auto& helper, auto& audio_out) {
+            ::viam::component::audioout::v1::PlayStreamRequest request;
+            if (!reader->Read(&request)) {
+                throw std::runtime_error("failed to read first PlayStreamRequest");
+            }
+
+            if (request.payload_case() !=
+                ::viam::component::audioout::v1::PlayStreamRequest::kInit) {
+                throw std::invalid_argument(
+                    "first message must be PlayStreamInit");
+            }
+
+            const auto& init = request.init();
+            const auto& audio_info_proto = init.audio_info();
+            const auto info = audio_info{audio_info_proto.codec(),
+                                         audio_info_proto.sample_rate_hz(),
+                                         audio_info_proto.num_channels()};
+
+            std::unique_ptr<AudioOutStreamReader> reader_wrapper =
+                std::make_unique<AudioOutServerStreamReader>(reader);
+
+            audio_out->play_stream(std::move(reader_wrapper), info, helper.getExtra());
+        });
 }
 
 ::grpc::Status AudioOutServer::DoCommand(::grpc::ServerContext* context,

--- a/src/viam/sdk/components/private/audio_out_server.hpp
+++ b/src/viam/sdk/components/private/audio_out_server.hpp
@@ -29,6 +29,8 @@ class AudioOutServer : public ResourceServer,
                         const ::viam::component::audioout::v1::PlayRequest* request,
                         ::viam::component::audioout::v1::PlayResponse* response) noexcept override;
 
+    ::grpc::Status PlayStream(::grpc::ServerContext* context, ::grpc::ServerReader< ::viam::component::audioout::v1::PlayStreamRequest>* reader, ::viam::component::audioout::v1::PlayStreamResponse* response) noexcept override;
+
     ::grpc::Status DoCommand(::grpc::ServerContext* context,
                              const ::viam::common::v1::DoCommandRequest* request,
                              ::viam::common::v1::DoCommandResponse* response) noexcept override;

--- a/src/viam/sdk/tests/mocks/mock_audio_out.cpp
+++ b/src/viam/sdk/tests/mocks/mock_audio_out.cpp
@@ -12,12 +12,62 @@ namespace audioout {
 
 using namespace viam::sdk;
 
+// MockAudioOutStreamWriter
+MockAudioOutStreamWriter::MockAudioOutStreamWriter(std::weak_ptr<MockAudioOut> parent)
+    : parent_(std::move(parent)) {}
+
+void MockAudioOutStreamWriter::write(std::vector<uint8_t> const& audio_data) {
+    if (auto parent = parent_.lock()) {
+        parent->streamed_audio_chunks_.push_back(audio_data);
+    }
+}
+
+void MockAudioOutStreamWriter::close() {}
+
+// MockAudioOutStreamReader
+MockAudioOutStreamReader::MockAudioOutStreamReader(std::weak_ptr<MockAudioOut> parent)
+    : parent_(std::move(parent)), current_chunk_index_(0) {}
+
+boost::optional<std::vector<uint8_t>> MockAudioOutStreamReader::read() {
+    if (auto parent = parent_.lock()) {
+        if (current_chunk_index_ < parent->streamed_audio_chunks_.size()) {
+            return boost::make_optional(parent->streamed_audio_chunks_[current_chunk_index_++]);
+        }
+    }
+    return boost::none;
+}
+
+// MockAudioOut
 void MockAudioOut::play(std::vector<uint8_t> const& audio_data,
                         boost::optional<audio_info> info,
                         const ProtoStruct& extra) {
     last_played_audio_ = audio_data;
     last_played_audio_info_ = info;
 }
+
+std::unique_ptr<AudioOutStreamWriter> MockAudioOut::play_stream(
+    audio_info info, const sdk::ProtoStruct& extra) {
+    streamed_audio_chunks_.clear();
+    streamed_audio_info_ = info;
+    streamed_extra_ = extra;
+    return std::make_unique<MockAudioOutStreamWriter>(shared_from_this());
+}
+
+void MockAudioOut::play_stream(std::unique_ptr<AudioOutStreamReader> reader,
+                               audio_info info,
+                               const sdk::ProtoStruct& extra) {
+    streamed_audio_chunks_.clear();
+    streamed_audio_info_ = info;
+    streamed_extra_ = extra;
+    while (true) {
+        auto chunk = reader->read();
+        if (!chunk) {
+            break;
+        }
+        streamed_audio_chunks_.push_back(*chunk);
+    }
+}
+
 
 audio_properties MockAudioOut::get_properties(const ProtoStruct& extra) {
     return properties_;

--- a/src/viam/sdk/tests/mocks/mock_audio_out.hpp
+++ b/src/viam/sdk/tests/mocks/mock_audio_out.hpp
@@ -12,6 +12,10 @@ namespace audioout {
 using viam::sdk::AudioOut;
 using namespace viam::sdk;
 
+// Forward declarations
+class MockAudioOutStreamWriter;
+class MockAudioOutStreamReader;
+
 class MockAudioOut : public AudioOut {
    public:
     void play(std::vector<uint8_t> const& audio_data,
@@ -21,6 +25,10 @@ class MockAudioOut : public AudioOut {
     viam::sdk::ProtoStruct do_command(const viam::sdk::ProtoStruct& command) override;
     sdk::ProtoStruct get_status() override;
     std::vector<GeometryConfig> get_geometries(const ProtoStruct& extra) override;
+
+    // New overrides for stream play
+    std::unique_ptr<AudioOutStreamWriter> play_stream(audio_info info, const sdk::ProtoStruct& extra) override;
+    void play_stream(std::unique_ptr<AudioOutStreamReader> reader, audio_info info, const sdk::ProtoStruct& extra) override;
 
     static std::shared_ptr<MockAudioOut> get_mock_audio_out();
 
@@ -35,6 +43,31 @@ class MockAudioOut : public AudioOut {
     std::vector<GeometryConfig> geometries_;
     std::vector<uint8_t> last_played_audio_;
     boost::optional<audio_info> last_played_audio_info_;
+
+    // New public members for testing and verification
+    std::vector<std::vector<uint8_t>> streamed_audio_chunks_;
+    boost::optional<audio_info> streamed_audio_info_;
+    sdk::ProtoStruct streamed_extra_;
+};
+
+class MockAudioOutStreamWriter : public AudioOutStreamWriter {
+   public:
+    MockAudioOutStreamWriter(std::shared_ptr<MockAudioOut> parent);
+    void write(std::vector<uint8_t> const& audio_data) override;
+    void close() override;
+
+   private:
+    std::shared_ptr<MockAudioOut> parent_;
+};
+
+class MockAudioOutStreamReader : public AudioOutStreamReader {
+   public:
+    MockAudioOutStreamReader(std::shared_ptr<MockAudioOut> parent);
+    boost::optional<std::vector<uint8_t>> read() override;
+
+   private:
+    std::shared_ptr<MockAudioOut> parent_;
+    size_t current_chunk_index_;
 };
 
 audio_properties fake_properties();

--- a/src/viam/sdk/tests/test_audio_out.cpp
+++ b/src/viam/sdk/tests/test_audio_out.cpp
@@ -59,6 +59,35 @@ BOOST_AUTO_TEST_CASE(test_play_no_audio_info) {
     });
 }
 
+BOOST_AUTO_TEST_CASE(test_play_stream) {
+    std::shared_ptr<MockAudioOut> mock = MockAudioOut::get_mock_audio_out();
+    client_to_mock_pipeline<AudioOut>(mock, [mock](AudioOut& client) {
+        audio_info info;
+        info.codec = audio_codecs::PCM_16;
+        info.sample_rate_hz = 44100;
+        info.num_channels = 1;
+        ProtoStruct extra = {{"key1", ProtoValue("value1")}};
+
+        std::unique_ptr<AudioOutStreamWriter> writer = client.play_stream(info, extra);
+
+        std::vector<uint8_t> chunk1 = {1, 2, 3, 4};
+        std::vector<uint8_t> chunk2 = {5, 6, 7, 8};
+        std::vector<uint8_t> chunk3 = {9, 10, 11, 12};
+
+        writer->write(chunk1);
+        writer->write(chunk2);
+        writer->write(chunk3);
+        writer->close();
+
+        BOOST_CHECK(mock->streamed_audio_info_ == info);
+        BOOST_CHECK(mock->streamed_extra_ == extra);
+        BOOST_CHECK_EQUAL(mock->streamed_audio_chunks_.size(), 3);
+        BOOST_CHECK(mock->streamed_audio_chunks_[0] == chunk1);
+        BOOST_CHECK(mock->streamed_audio_chunks_[1] == chunk2);
+        BOOST_CHECK(mock->streamed_audio_chunks_[2] == chunk3);
+    });
+}
+
 BOOST_AUTO_TEST_CASE(test_get_properties) {
     std::shared_ptr<MockAudioOut> mock = MockAudioOut::get_mock_audio_out();
     client_to_mock_pipeline<AudioOut>(mock, [](AudioOut& client) {


### PR DESCRIPTION
This is an AI-generated PR to update the SDK based on proto changes. The AI may make mistakes so review carefully.

**Summary of Changes:**
This change introduces streaming audio playback functionality for the `AudioOut` component. It adds a new `PlayStream` RPC method, enabling clients to stream audio data chunks to the component for playback.

Key updates include:
*   Defining new gRPC methods and protobuf messages (`PlayStreamRequest`, `PlayStreamChunk`, `PlayStreamInit`).
*   Introducing abstract SDK interfaces (`AudioOutStreamWriter`, `AudioOutStreamReader`) for handling the stream.
*   Implementing client-side streaming logic to send audio data and server-side logic to receive and process it.
*   Adding mock implementations and a new test case (`test_play_stream`) to verify the functionality.