### PR TITLE
AI update based on proto changes

### DIFF
--- a/src/viam/sdk/app/data_client.cpp
+++ b/src/viam/sdk/app/data_client.cpp
@@ -9,6 +9,8 @@
 
 #include <viam/sdk/common/client_helper.hpp>
 #include <viam/sdk/common/utils.hpp>
+#include <viam/sdk/common/private/repeated_ptr_convert.hpp>
+#include <viam/sdk/app/data_client_types.hpp>
 
 namespace viam {
 namespace sdk {
@@ -97,6 +99,57 @@ std::vector<DataClient::BSONBytes> DataClient::tabular_data_by_mql(
 std::vector<DataClient::BSONBytes> DataClient::tabular_data_by_mql(
     const std::string& org_id, const std::vector<DataClient::BSONBytes>& mql_binary) {
     return tabular_data_by_mql(org_id, mql_binary, tabular_data_by_mql_opts{});
+}
+
+// NEW: AddSequencesToDataset
+void DataClient::add_sequences_to_dataset(const std::string& dataset_id,
+                                          const std::vector<std::string>& sequence_ids) {
+    return pimpl_->client_helper(&DataService::Stub::AddSequencesToDataset)
+        .with([&](app::data::v1::AddSequencesToDatasetRequest& req) {
+            req.set_dataset_id(dataset_id);
+            *req.mutable_sequence_ids() = sdk::impl::to_repeated_field(sequence_ids);
+        })
+        .invoke();
+}
+
+// NEW: RemoveSequencesFromDataset
+void DataClient::remove_sequences_from_dataset(const std::string& dataset_id,
+                                               const std::vector<std::string>& sequence_ids) {
+    return pimpl_->client_helper(&DataService::Stub::RemoveSequencesFromDataset)
+        .with([&](app::data::v1::RemoveSequencesFromDatasetRequest& req) {
+            req.set_dataset_id(dataset_id);
+            *req.mutable_sequence_ids() = sdk::impl::to_repeated_field(sequence_ids);
+        })
+        .invoke();
+}
+
+// NEW: SequencesByDatasetID
+std::pair<std::vector<Sequence>, boost::optional<std::string>> DataClient::sequences_by_dataset_id(
+    const std::string& dataset_id, const sequences_by_dataset_id_options& opts) {
+    return pimpl_->client_helper(&DataService::Stub::SequencesByDatasetID)
+        .with([&](app::data::v1::SequencesByDatasetIDRequest& req) {
+            req.set_dataset_id(dataset_id);
+            if (opts.page_size != 0) {
+                req.set_page_size(opts.page_size);
+            }
+            if (opts.page_token.has_value()) {
+                req.set_page_token(*opts.page_token);
+            }
+        })
+        .invoke([](const app::data::v1::SequencesByDatasetIDResponse& resp) {
+            std::vector<Sequence> sequences = sdk::impl::from_repeated_field(resp.sequences());
+            boost::optional<std::string> next_page_token;
+            if (!resp.next_page_token().empty()) {
+                next_page_token = resp.next_page_token();
+            }
+            return std::make_pair(sequences, next_page_token);
+        });
+}
+
+// NEW: Convenience overload for SequencesByDatasetID with default options.
+std::pair<std::vector<Sequence>, boost::optional<std::string>> DataClient::sequences_by_dataset_id(
+    const std::string& dataset_id) {
+    return sequences_by_dataset_id(dataset_id, sequences_by_dataset_id_options{});
 }
 }  // namespace sdk
 }  // namespace viam

--- a/src/viam/sdk/app/data_client.hpp
+++ b/src/viam/sdk/app/data_client.hpp
@@ -9,6 +9,7 @@
 #include <boost/optional.hpp>
 
 #include <viam/sdk/app/viam_client.hpp>
+#include <viam/sdk/app/data_client_types.hpp>
 
 namespace viam {
 namespace sdk {
@@ -27,6 +28,15 @@ class DataClient {
 
         /// @brief Used to specify a saved query to run.
         boost::optional<std::string> query_prefix;
+    };
+
+    // NEW: Options for SequencesByDatasetID
+    /// @brief Options which are passed to a sequences_by_dataset_id request.
+    struct sequences_by_dataset_id_options {
+        /// @brief The number of sequences to return per page.
+        uint32_t page_size = 0;
+        /// @brief The token for the next page of results.
+        boost::optional<std::string> page_token;
     };
 
     using BSONBytes = std::vector<uint8_t>;
@@ -54,6 +64,33 @@ class DataClient {
     /// @brief Convenience overload with default options.
     std::vector<BSONBytes> tabular_data_by_mql(const std::string& org_id,
                                                const std::vector<BSONBytes>& mql_binary);
+
+    // NEW: AddSequencesToDataset
+    /// @brief Adds the sequences with the given IDs to the dataset.
+    /// @param dataset_id The ID of the dataset to add sequences to.
+    /// @param sequence_ids The IDs of the sequences to add.
+    void add_sequences_to_dataset(const std::string& dataset_id,
+                                  const std::vector<std::string>& sequence_ids);
+
+    // NEW: RemoveSequencesFromDataset
+    /// @brief Removes the sequences with the given IDs from the dataset.
+    /// @param dataset_id The ID of the dataset to remove sequences from.
+    /// @param sequence_ids The IDs of the sequences to remove.
+    void remove_sequences_from_dataset(const std::string& dataset_id,
+                                       const std::vector<std::string>& sequence_ids);
+
+    // NEW: SequencesByDatasetID
+    /// @brief Lists sequences that belong to the given dataset.
+    /// @param dataset_id The ID of the dataset to list sequences for.
+    /// @param opts Options for pagination.
+    /// @return A pair containing a vector of sequences and the next page token.
+    std::pair<std::vector<Sequence>, boost::optional<std::string>> sequences_by_dataset_id(
+        const std::string& dataset_id, const sequences_by_dataset_id_options& opts);
+
+    // NEW: Convenience overload for SequencesByDatasetID with default options.
+    /// @brief Convenience overload for SequencesByDatasetID with default options.
+    std::pair<std::vector<Sequence>, boost::optional<std::string>> sequences_by_dataset_id(
+        const std::string& dataset_id);
 
    private:
     DataClient(const ViamChannel& channel);

--- a/src/viam/sdk/app/data_client_types.cpp
+++ b/src/viam/sdk/app/data_client_types.cpp
@@ -1,0 +1,121 @@
+#include <viam/sdk/app/data_client_types.hpp>
+
+#include <viam/api/app/data/v1/data.pb.h>
+
+#include <viam/sdk/common/private/repeated_ptr_convert.hpp>
+#include <viam/sdk/common/utils.hpp>
+
+namespace viam {
+namespace sdk {
+
+// SequenceResourceFilter
+bool operator==(const SequenceResourceFilter& lhs, const SequenceResourceFilter& rhs) {
+    return lhs.resource_type == rhs.resource_type && lhs.resource_id == rhs.resource_id &&
+           lhs.robot_name == rhs.robot_name && lhs.part_name == rhs.part_name;
+}
+
+std::ostream& operator<<(std::ostream& os, const SequenceResourceFilter& v) {
+    return os << "SequenceResourceFilter[resource_type=" << v.resource_type
+              << ", resource_id=" << v.resource_id << ", robot_name=" << v.robot_name
+              << ", part_name=" << v.part_name << "]";
+}
+
+namespace proto_convert_details {
+
+void to_proto_impl<SequenceResourceFilter>::operator()(const SequenceResourceFilter& sdk_type,
+                                                   viam::app::data::v1::SequenceResourceFilter* proto_type) const {
+    proto_type->set_resource_type(sdk_type.resource_type);
+    proto_type->set_resource_id(sdk_type.resource_id);
+    proto_type->set_robot_name(sdk_type.robot_name);
+    proto_type->set_part_name(sdk_type.part_name);
+}
+
+SequenceResourceFilter from_proto_impl<viam::app::data::v1::SequenceResourceFilter>::operator()(
+    const viam::app::data::v1::SequenceResourceFilter* proto_type) const {
+    SequenceResourceFilter sdk_type;
+    sdk_type.resource_type = proto_type->resource_type();
+    sdk_type.resource_id = proto_type->resource_id();
+    sdk_type.robot_name = proto_type->robot_name();
+    sdk_type.part_name = proto_type->part_name();
+    return sdk_type;
+}
+
+// Sequence
+void to_proto_impl<Sequence>::operator()(const Sequence& sdk_type,
+                                         viam::app::data::v1::Sequence* proto_type) const {
+    proto_type->set_id(sdk_type.id);
+    *proto_type->mutable_sequence_tags() = sdk::impl::to_repeated_field(sdk_type.sequence_tags);
+    *proto_type->mutable_created_at() = to_proto(sdk_type.created_at);
+    *proto_type->mutable_last_modified() = to_proto(sdk_type.last_modified);
+    *proto_type->mutable_start_time() = to_proto(sdk_type.start_time);
+    *proto_type->mutable_end_time() = to_proto(sdk_type.end_time);
+    *proto_type->mutable_resources() = sdk::impl::to_repeated_field(sdk_type.resources);
+    proto_type->set_part_id(sdk_type.part_id);
+    *proto_type->mutable_dataset_ids() = sdk::impl::to_repeated_field(sdk_type.dataset_ids);
+}
+
+Sequence from_proto_impl<viam::app::data::v1::Sequence>::operator()(
+    const viam::app::data::v1::Sequence* proto_type) const {
+    Sequence sdk_type;
+    sdk_type.id = proto_type->id();
+    sdk_type.sequence_tags = sdk::impl::from_repeated_field(proto_type->sequence_tags());
+    sdk_type.created_at = from_proto(proto_type->created_at());
+    sdk_type.last_modified = from_proto(proto_type->last_modified());
+    sdk_type.start_time = from_proto(proto_type->start_time());
+    sdk_type.end_time = from_proto(proto_type->end_time());
+    sdk_type.resources = sdk::impl::from_repeated_field(proto_type->resources());
+    sdk_type.part_id = proto_type->part_id();
+    sdk_type.dataset_ids = sdk::impl::from_repeated_field(proto_type->dataset_ids());
+    return sdk_type;
+}
+
+}  // namespace proto_convert_details
+
+bool operator==(const Sequence& lhs, const Sequence& rhs) {
+    return lhs.id == rhs.id && lhs.sequence_tags == rhs.sequence_tags &&
+           lhs.created_at == rhs.created_at && lhs.last_modified == rhs.last_modified &&
+           lhs.start_time == rhs.start_time && lhs.end_time == rhs.end_time &&
+           lhs.resources == rhs.resources && lhs.part_id == rhs.part_id &&
+           lhs.dataset_ids == rhs.dataset_ids;
+}
+
+std::ostream& operator<<(std::ostream& os, const Sequence& v) {
+    os << "Sequence[id=" << v.id << ", sequence_tags=[";
+    for (size_t i = 0; i < v.sequence_tags.size(); ++i) {
+        os << v.sequence_tags[i];
+        if (i < v.sequence_tags.size() - 1) {
+            os << ", ";
+        }
+    }
+    os << "], created_at=" << std::chrono::duration_cast<std::chrono::milliseconds>(
+                                   v.created_at.time_since_epoch())
+                                   .count()
+       << "ms, last_modified="
+       << std::chrono::duration_cast<std::chrono::milliseconds>(v.last_modified.time_since_epoch())
+              .count()
+       << "ms, start_time="
+       << std::chrono::duration_cast<std::chrono::milliseconds>(v.start_time.time_since_epoch())
+              .count()
+       << "ms, end_time="
+       << std::chrono::duration_cast<std::chrono::milliseconds>(v.end_time.time_since_epoch())
+              .count()
+       << "ms, resources=[";
+    for (size_t i = 0; i < v.resources.size(); ++i) {
+        os << v.resources[i];
+        if (i < v.resources.size() - 1) {
+            os << ", ";
+        }
+    }
+    os << "], part_id=" << v.part_id << ", dataset_ids=[";
+    for (size_t i = 0; i < v.dataset_ids.size(); ++i) {
+        os << v.dataset_ids[i];
+        if (i < v.dataset_ids.size() - 1) {
+            os << ", ";
+        }
+    }
+    os << "]] ";
+    return os;
+}
+
+}  // namespace sdk
+}  // namespace viam

--- a/src/viam/sdk/app/data_client_types.hpp
+++ b/src/viam/sdk/app/data_client_types.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include <boost/optional.hpp>
+
+#include <viam/sdk/common/proto_convert.hpp>
+
+namespace viam {
+namespace sdk {
+
+/// @struct SequenceResourceFilter
+/// @brief Represents a filter for sequence resources.
+struct SequenceResourceFilter {
+    std::string resource_type;
+    std::string resource_id;
+    std::string robot_name;
+    std::string part_name;
+
+    friend bool operator==(const SequenceResourceFilter& lhs, const SequenceResourceFilter& rhs);
+    friend std::ostream& operator<<(std::ostream& os, const SequenceResourceFilter& v);
+};
+
+/// @struct Sequence
+/// @brief Represents a sequence of data.
+struct Sequence {
+    std::string id;
+    std::vector<std::string> sequence_tags;
+    std::chrono::system_clock::time_point created_at;
+    std::chrono::system_clock::time_point last_modified;
+    std::chrono::system_clock::time_point start_time;
+    std::chrono::system_clock::time_point end_time;
+    std::vector<SequenceResourceFilter> resources;
+    std::string part_id;
+    std::vector<std::string> dataset_ids;
+
+    friend bool operator==(const Sequence& lhs, const Sequence& rhs);
+    friend std::ostream& operator<<(std::ostream& os, const Sequence& v);
+};
+
+namespace proto_convert_details {
+
+template <>
+struct to_proto_impl<SequenceResourceFilter> {
+    void operator()(const SequenceResourceFilter&,
+                    viam::app::data::v1::SequenceResourceFilter*) const;
+};
+
+template <>
+struct from_proto_impl<viam::app::data::v1::SequenceResourceFilter> {
+    SequenceResourceFilter operator()(const viam::app::data::v1::SequenceResourceFilter*) const;
+};
+
+template <>
+struct to_proto_impl<Sequence> {
+    void operator()(const Sequence&, viam::app::data::v1::Sequence*) const;
+};
+
+template <>
+struct from_proto_impl<viam::app::data::v1::Sequence> {
+    Sequence operator()(const viam::app::data::v1::Sequence*) const;
+};
+
+}  // namespace proto_convert_details
+
+}  // namespace sdk
+}  // namespace viam


### PR DESCRIPTION
This is an AI-generated PR to update the SDK based on proto changes. The AI may make mistakes so review carefully.

**Summary of Changes:**
This change introduces sequence management functionality to the Viam App DataClient.

Key updates include:
*   **New Methods:** Added `add_sequences_to_dataset`, `remove_sequences_from_dataset`, and `sequences_by_dataset_id` methods to the `DataClient`.
*   **Data Types:** Introduced new SDK types (`Sequence`, `SequenceResourceFilter`) to represent sequence data and associated filters.
*   **Functionality:** Enables users to programmatically add, remove, and retrieve sequences linked to a specific dataset, including support for pagination when listing sequences.