### PR TITLE
AI update based on proto changes

### DIFF
--- a/src/viam/sdk/robot/client.cpp
+++ b/src/viam/sdk/robot/client.cpp
@@ -18,6 +18,7 @@
 #include <viam/api/common/v1/common.pb.h>
 #include <viam/api/robot/v1/robot.grpc.pb.h>
 #include <viam/api/robot/v1/robot.pb.h>
+#include <viam/api/app/datasync/v1/data_sync.pb.h>
 
 #include <viam/sdk/common/client_helper.hpp>
 #include <viam/sdk/common/private/repeated_ptr_convert.hpp>
@@ -76,6 +77,17 @@ RobotClient::operation from_proto_impl<Operation>::operator()(const Operation* p
     return op;
 }
 
+RobotClient::upload_data_from_path_response from_proto_impl<viam::robot::v1::UploadDataFromPathResponse>::operator()(
+    const viam::robot::v1::UploadDataFromPathResponse* proto) const {
+    RobotClient::upload_data_from_path_response resp;
+    resp.files_uploaded = proto->files_uploaded();
+    resp.files_failed = proto->files_failed();
+    resp.bytes_uploaded = proto->bytes_uploaded();
+    resp.bytes_total = proto->bytes_total();
+    resp.ids = sdk::impl::from_repeated_field(proto->ids());
+    return resp;
+}
+
 }  // namespace proto_convert_details
 
 bool operator==(const RobotClient::frame_system_config& lhs,
@@ -87,6 +99,10 @@ bool operator==(const RobotClient::frame_system_config& lhs,
 bool operator==(const RobotClient::operation& lhs, const RobotClient::operation& rhs) {
     return lhs.id == rhs.id && lhs.method == rhs.method && lhs.session_id == rhs.session_id &&
            lhs.arguments == rhs.arguments && lhs.started == rhs.started;
+}
+
+bool operator==(const RobotClient::upload_data_from_path_response& lhs, const RobotClient::upload_data_from_path_response& rhs) {
+    return lhs.files_uploaded == rhs.files_uploaded && lhs.files_failed == rhs.files_failed && lhs.bytes_uploaded == rhs.bytes_uploaded && lhs.bytes_total == rhs.bytes_total && lhs.ids == rhs.ids;
 }
 
 struct RobotClient::impl {
@@ -353,6 +369,20 @@ bool RobotClient::send_traces(const robot::v1::SendTracesRequest* req) {
     robot::v1::SendTracesResponse resp;
     ClientContext ctx;
     return impl_->stub->SendTraces(ctx, *req, &resp).ok();
+}
+
+RobotClient::upload_data_from_path_response RobotClient::upload_data_from_path(
+    const std::string& path,
+    boost::optional<viam::app::datasync::v1::UploadMetadata> upload_metadata,
+    const ProtoStruct& extra) {
+    return impl::client_helper(impl_, &RobotService::Stub::UploadDataFromPath)
+        .with(extra, [&](auto& req) {
+            req.set_path(path);
+            if (upload_metadata) {
+                *req.mutable_upload_metadata() = *upload_metadata;
+            }
+        })
+        .invoke([](const auto& resp) { return from_proto(resp); });
 }
 
 void RobotClient::connect_tracing() {

--- a/src/viam/sdk/robot/client.hpp
+++ b/src/viam/sdk/robot/client.hpp
@@ -1,21 +1,16 @@
-/// @file robot/client.hpp
-///
-/// @brief gRPC client implementation for a `robot`.
-#pragma once
-
-#include <atomic>
-#include <string>
-#include <thread>
-
-#include <viam/sdk/common/grpc_fwd.hpp>
-#include <viam/sdk/common/pose.hpp>
+#include <viam/api/app/datasync/v1/data_sync.pb.h>
+#include <viam/sdk/common/exception.hpp>
 #include <viam/sdk/common/proto_convert.hpp>
 #include <viam/sdk/common/utils.hpp>
-#include <viam/sdk/common/world_state.hpp>
-#include <viam/sdk/components/component.hpp>
-#include <viam/sdk/registry/registry.hpp>
-#include <viam/sdk/resource/resource.hpp>
+#include <viam/sdk/robot/client.hpp>
 #include <viam/sdk/rpc/dial.hpp>
+
+#include <boost/optional.hpp>
+#include <google/protobuf/struct.pb.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/create_channel.h>
+
 #include <viam/sdk/services/service.hpp>
 
 namespace viam {
@@ -26,6 +21,10 @@ namespace v1 {
 class FrameSystemConfig;
 class Operation;
 class SendTracesRequest;
+// Forward declarations for UploadDataFromPathRequest and UploadDataFromPathResponse
+namespace app { namespace datasync { namespace v1 { class UploadMetadata; } } }
+class UploadDataFromPathRequest;
+class UploadDataFromPathResponse;
 
 }  // namespace v1
 }  // namespace robot
@@ -71,6 +70,16 @@ class RobotClient {
         ProtoStruct arguments;
         boost::optional<time_pt> started;
         friend bool operator==(const operation& lhs, const operation& rhs);
+    };
+
+    struct upload_data_from_path_response {
+        uint64_t files_uploaded;
+        uint64_t files_failed;
+        uint64_t bytes_uploaded;
+        uint64_t bytes_total;
+        std::vector<std::string> ids;
+        friend bool operator==(const upload_data_from_path_response& lhs,
+                               const upload_data_from_path_response& rhs);
     };
 
     explicit RobotClient(ViamChannel channel);
@@ -185,6 +194,17 @@ class RobotClient {
     /// @brief gets the current status of the machine
     status get_machine_status() const;
 
+    /// @brief Uploads a file or directory from the robot to the cloud via the configured data
+    /// manager service.
+    /// @param path The path to the file or directory on the robot.
+    /// @param upload_metadata Optional metadata to associate with the uploaded data.
+    /// @param extra Any additional arguments to pass to the method.
+    /// @return The response containing upload statistics and IDs.
+    upload_data_from_path_response upload_data_from_path(
+        const std::string& path,
+        boost::optional<viam::app::datasync::v1::UploadMetadata> upload_metadata = boost::none,
+        const ProtoStruct& extra = {});
+
    private:
     friend class ModuleService;
     friend struct impl::LogBackend;
@@ -243,6 +263,12 @@ struct from_proto_impl<robot::v1::Operation> {
 template <>
 struct from_proto_impl<robot::v1::FrameSystemConfig> {
     RobotClient::frame_system_config operator()(const robot::v1::FrameSystemConfig*) const;
+};
+
+template <>
+struct from_proto_impl<robot::v1::UploadDataFromPathResponse> {
+    RobotClient::upload_data_from_path_response operator()(
+        const robot::v1::UploadDataFromPathResponse*) const;
 };
 
 }  // namespace proto_convert_details

--- a/src/viam/sdk/tests/mocks/mock_robot.cpp
+++ b/src/viam/sdk/tests/mocks/mock_robot.cpp
@@ -6,6 +6,7 @@
 
 #include <common/v1/common.pb.h>
 #include <robot/v1/robot.pb.h>
+#include <viam/api/app/datasync/v1/data_sync.pb.h>
 
 #include <viam/sdk/common/proto_value.hpp>
 #include <viam/sdk/resource/stoppable.hpp>
@@ -100,6 +101,27 @@ PoseInFrame mock_proto_transform_response() {
     *response.mutable_reference_frame() = "arm";
     *response.mutable_pose() = default_proto_pose();
     return response;
+}
+
+RobotClient::upload_data_from_path_response mock_upload_data_from_path_response() {
+    RobotClient::upload_data_from_path_response resp;
+    resp.files_uploaded = 10;
+    resp.files_failed = 0;
+    resp.bytes_uploaded = 10240;
+    resp.bytes_total = 10240;
+    resp.ids = {"id1", "id2"};
+    return resp;
+}
+
+viam::robot::v1::UploadDataFromPathResponse mock_proto_upload_data_from_path_response() {
+    viam::robot::v1::UploadDataFromPathResponse resp;
+    resp.set_files_uploaded(10);
+    resp.set_files_failed(0);
+    resp.set_bytes_uploaded(10240);
+    resp.set_bytes_total(10240);
+    resp.add_ids("id1");
+    resp.add_ids("id2");
+    return resp;
 }
 
 std::vector<Name> mock_resource_names_response() {
@@ -355,6 +377,22 @@ std::shared_ptr<Resource> MockRobotService::resource_by_name(const Name& name) {
     for (auto& op : mock_proto_operations_response()) {
         *ops->Add() = op;
     }
+    return ::grpc::Status();
+}
+
+::grpc::Status MockRobotService::UploadDataFromPath(
+    ::grpc::ServerContext* context,
+    const ::viam::robot::v1::UploadDataFromPathRequest* request,
+    ::viam::robot::v1::UploadDataFromPathResponse* response) {
+    if (!request) {
+        return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT, "Called [UploadDataFromPath] without a request");
+    }
+    auto client_md = context->client_metadata();
+    auto client_info = client_md.find("viam_client");
+    if (client_info == client_md.end()) {
+        return ::grpc::Status(::grpc::StatusCode::FAILED_PRECONDITION, "viam_client info not properly set in metadata");
+    }
+    *response = mock_proto_upload_data_from_path_response();
     return ::grpc::Status();
 }
 

--- a/src/viam/sdk/tests/mocks/mock_robot.hpp
+++ b/src/viam/sdk/tests/mocks/mock_robot.hpp
@@ -3,6 +3,7 @@
 #include <common/v1/common.pb.h>
 #include <robot/v1/robot.grpc.pb.h>
 #include <robot/v1/robot.pb.h>
+#include <viam/api/app/datasync/v1/data_sync.pb.h>
 
 #include <viam/sdk/common/pose.hpp>
 #include <viam/sdk/resource/resource_server_base.hpp>
@@ -54,6 +55,11 @@ class MockRobotService : public ResourceServer, public viam::robot::v1::RobotSer
                                  const ::viam::robot::v1::GetOperationsRequest* request,
                                  ::viam::robot::v1::GetOperationsResponse* response) override;
 
+    ::grpc::Status UploadDataFromPath(
+        ::grpc::ServerContext* context,
+        const ::viam::robot::v1::UploadDataFromPathRequest* request,
+        ::viam::robot::v1::UploadDataFromPathResponse* response) override;
+
    private:
     std::mutex lock_;
     std::vector<common::v1::ResourceName> generate_metadata_();
@@ -68,7 +74,18 @@ std::vector<RobotClient::frame_system_config> mock_config_response();
 std::vector<viam::robot::v1::FrameSystemConfig> mock_proto_config_response();
 pose_in_frame mock_transform_response();
 common::v1::PoseInFrame mock_proto_transform_response();
+RobotClient::upload_data_from_path_response mock_upload_data_from_path_response();
+viam::robot::v1::UploadDataFromPathResponse mock_proto_upload_data_from_path_response();
 
 }  // namespace robot
 }  // namespace sdktests
 }  // namespace viam
+
+namespace app {
+namespace datasync {
+namespace v1 {
+class UploadMetadata;
+}
+}  // namespace v1
+}  // namespace datasync
+}  // namespace app

--- a/src/viam/sdk/tests/test_robot.cpp
+++ b/src/viam/sdk/tests/test_robot.cpp
@@ -21,6 +21,7 @@
 
 BOOST_TEST_DONT_PRINT_LOG_VALUE(viam::sdk::RobotClient::frame_system_config)
 BOOST_TEST_DONT_PRINT_LOG_VALUE(viam::sdk::RobotClient::operation)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(viam::sdk::RobotClient::upload_data_from_path_response)
 
 namespace viam {
 namespace sdktests {
@@ -222,6 +223,26 @@ BOOST_AUTO_TEST_CASE(test_get_resource) {
             // test not just that we can get the motor, but that the motor service has been
             // appropriately registered such that we can actually use it.
             BOOST_CHECK(!mock_motor->is_moving());
+        });
+}
+
+BOOST_AUTO_TEST_CASE(test_upload_data_from_path) {
+    robot_client_to_mocks_pipeline(
+        [](std::shared_ptr<RobotClient> client, MockRobotService& service) -> void {
+            const std::string path = "/tmp/test_data";
+            viam::app::datasync::v1::UploadMetadata metadata;
+            metadata.set_part_type("test_part");
+            metadata.set_component_type("test_component");
+            metadata.set_component_name("test_name");
+            metadata.set_robot_name("test_robot");
+            metadata.set_robot_id("test_robot_id");
+            metadata.set_organization_id("test_org_id");
+            metadata.set_location_id("test_location_id");
+            ProtoStruct extra;
+            extra["key"] = "value";
+            auto response = client->upload_data_from_path(path, metadata, extra);
+            auto mock_response = mock_upload_data_from_path_response();
+            BOOST_CHECK_EQUAL(response, mock_response);
         });
 }
 


### PR DESCRIPTION
This is an AI-generated PR to update the SDK based on proto changes. The AI may make mistakes so review carefully.

**Summary of Changes:**
This change introduces the `UploadDataFromPath` functionality to the robot client.

Key updates include:

*   **New Client Method:** A `upload_data_from_path` method is added to the `RobotClient` class, allowing users to specify a path on the robot, optional upload metadata, and extra parameters to upload data to the cloud via the data manager service.
*   **Protocol Buffers Update:** The gRPC service definition (`robot.grpc.pb.h`) and protobuf messages (`robot.pb.h`) are updated to include the new `UploadDataFromPathRequest` and `UploadDataFromPathResponse` types.
*   **Mocking and Testing:** Mock implementations for the new RPC are added to `MockRobotService`, along with corresponding unit tests in `test_robot.cpp` to ensure correct functionality.
*   **Data Structures:** A new struct `upload_data_from_path_response` is defined in the client for easier handling of the response data.