### PR TITLE
Add armhf to the docker matrix

### DIFF
--- a/.github/workflows/docker-base-images.yml
+++ b/.github/workflows/docker-base-images.yml
@@ -62,12 +62,15 @@ jobs:
       fail-fast: false
       matrix:
         cell: ${{ fromJson(needs.matrix.outputs.cells) }}
-        arch: [amd64, arm64]
+        arch: [amd64, arm64, armhf]
         include:
           - arch: amd64
             runner: ubuntu-24.04
           - arch: arm64
             runner: ubuntu-24.04-arm
+          - arch: armhf
+            runner: ubuntu-24.04-arm
+
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -24,7 +24,7 @@ target "base" {
   target     = "base"
 
   // Full matrix; slice to a native arch with --set '*.platform=linux/<arch>'.
-  platforms = ["linux/amd64", "linux/arm64"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/armhf"]
 }
 
 target "system" {

--- a/etc/docker/scripts/install-llvm.sh
+++ b/etc/docker/scripts/install-llvm.sh
@@ -24,7 +24,7 @@ rm -rf /var/lib/apt/lists/*
 if [[ -n "${clang_candidate}" ]]; then
     # Distro ships it directly.
     apt_install "${LLVM_PKGS[@]}"
-else
+elif [[ $(dpkg --print-architecture) != "armhf" ]]; then
     # apt.llvm.org suite name: llvm-toolchain-<codename>-<version>, except
     # Debian sid which drops the codename segment (llvm-toolchain-<version>).
     if [[ "${DISTRO_CODENAME}" == "sid" ]]; then


### PR DESCRIPTION
There is no armhf LLVM on the apt repos for it, so if we hit the fallback, just don't install there. Probably short-lived if we stop trying to pin the LLVM version to 19.