### PR TITLE
Camera::properties: serialize mime_types in GetProperties response

### DIFF
--- a/src/viam/sdk/components/camera.cpp
+++ b/src/viam/sdk/components/camera.cpp
@@ -173,7 +173,9 @@ bool operator==(const Camera::properties& lhs, const Camera::properties& rhs) {
     return lhs.supports_pcd == rhs.supports_pcd &&
            lhs.intrinsic_parameters == rhs.intrinsic_parameters &&
            lhs.distortion_parameters == rhs.distortion_parameters &&
-           lhs.frame_rate == rhs.frame_rate;
+           lhs.extrinsic_parameters == rhs.extrinsic_parameters &&
+           lhs.frame_rate == rhs.frame_rate &&
+           lhs.mime_types == rhs.mime_types;
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/components/camera.cpp
+++ b/src/viam/sdk/components/camera.cpp
@@ -174,8 +174,7 @@ bool operator==(const Camera::properties& lhs, const Camera::properties& rhs) {
            lhs.intrinsic_parameters == rhs.intrinsic_parameters &&
            lhs.distortion_parameters == rhs.distortion_parameters &&
            lhs.extrinsic_parameters == rhs.extrinsic_parameters &&
-           lhs.frame_rate == rhs.frame_rate &&
-           lhs.mime_types == rhs.mime_types;
+           lhs.frame_rate == rhs.frame_rate && lhs.mime_types == rhs.mime_types;
 }
 
 }  // namespace sdk

--- a/src/viam/sdk/components/private/camera_server.cpp
+++ b/src/viam/sdk/components/private/camera_server.cpp
@@ -120,6 +120,9 @@ CameraServer::CameraServer(std::shared_ptr<ResourceManager> manager)
         *response->mutable_extrinsic_parameters() = to_proto(properties.extrinsic_parameters);
         response->set_supports_pcd(properties.supports_pcd);
         response->set_frame_rate(properties.frame_rate);
+        for (const auto& mt : properties.mime_types) {
+            response->add_mime_types(mt);
+        }
     });
 }
 

--- a/src/viam/sdk/tests/test_camera.cpp
+++ b/src/viam/sdk/tests/test_camera.cpp
@@ -89,6 +89,7 @@ BOOST_AUTO_TEST_CASE(test_get_properties) {
         Camera::properties expected = fake_properties();
 
         BOOST_CHECK(expected == props);
+        BOOST_CHECK(expected.mime_types == props.mime_types);
     });
 }
 


### PR DESCRIPTION
CameraServer::GetProperties now serializes mime_types, which was previously silently dropped and masked by operator==(Camera::properties) omitting the field